### PR TITLE
Recompile organization pages when articles, memberships, or org info are updated

### DIFF
--- a/app/liquid_tags/feed_tag.rb
+++ b/app/liquid_tags/feed_tag.rb
@@ -52,7 +52,7 @@ class FeedTag < LiquidTagBase
 
   def parse_org(value)
     @org_slug = value
-    @organization = Organization.find_by(slug: @org_slug)
+    @organization = Organization.find_by_slug_or_legacy(@org_slug)
     raise StandardError, I18n.t("liquid_tags.feed_tag.invalid_org", slug: @org_slug) unless @organization
   end
 

--- a/app/liquid_tags/forem_tag.rb
+++ b/app/liquid_tags/forem_tag.rb
@@ -39,7 +39,7 @@ module ForemTag
 
   def self.user_or_org(match)
     return UserTag if User.find_by(username: match[:name], registered: true)
-    return OrganizationTag if Organization.find_by(slug: match[:name])
+    return OrganizationTag if Organization.find_by_slug_or_legacy(match[:name])
   end
 
   def self.podcast_or_link(match)

--- a/app/liquid_tags/link_tag.rb
+++ b/app/liquid_tags/link_tag.rb
@@ -47,7 +47,7 @@ class LinkTag < LiquidTagBase
   end
 
   def find_article_by_org(hash)
-    org = Organization.find_by(slug: hash[:username])
+    org = Organization.find_by_slug_or_legacy(hash[:username])
     return unless org
 
     org.articles.where(slug: hash[:slug])&.first

--- a/app/liquid_tags/org_posts_tag.rb
+++ b/app/liquid_tags/org_posts_tag.rb
@@ -12,7 +12,7 @@ class OrgPostsTag < LiquidTagBase
     super
     tokens = input.strip.split
     @org_slug = tokens.first
-    @organization = Organization.find_by(slug: @org_slug)
+    @organization = Organization.find_by_slug_or_legacy(@org_slug)
     raise StandardError, I18n.t("liquid_tags.org_posts_tag.invalid_slug") unless @organization
 
     parse_options(tokens.drop(1))

--- a/app/liquid_tags/org_team_tag.rb
+++ b/app/liquid_tags/org_team_tag.rb
@@ -12,7 +12,7 @@ class OrgTeamTag < LiquidTagBase
     super
     tokens = input.strip.split
     @org_slug = tokens.first
-    @organization = Organization.find_by(slug: @org_slug)
+    @organization = Organization.find_by_slug_or_legacy(@org_slug)
     raise StandardError, I18n.t("liquid_tags.org_team_tag.invalid_slug") unless @organization
 
     parse_options(tokens.drop(1))

--- a/app/liquid_tags/organization_tag.rb
+++ b/app/liquid_tags/organization_tag.rb
@@ -24,7 +24,7 @@ class OrganizationTag < LiquidTagBase
   end
 
   def parse_slug_to_organization(org_slug)
-    organization = Organization.find_by(slug: org_slug)
+    organization = Organization.find_by_slug_or_legacy(org_slug)
     raise StandardError, I18n.t("liquid_tags.organization_tag.invalid_slug") if organization.nil?
 
     organization

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1724,6 +1724,12 @@ class Article < ApplicationRecord
   end
 
   def recompile_organization_pages
+    was_published = destroyed? ? published? : published_before_last_save
+    is_published = published?
+    # `{% org_posts %}` only renders published articles, so skip recompilation when
+    # the article is (and was) unpublished.
+    return unless is_published || was_published || saved_change_to_published?
+
     org_ids_to_recompile = []
     if destroyed?
       org_ids_to_recompile << organization_id

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -339,6 +339,8 @@ class Article < ApplicationRecord
 
   after_update_commit :regenerate_summary_if_content_changed
 
+  after_commit :recompile_organization_pages, on: %i[create update destroy]
+
   # The trigger `update_reading_list_document` is used to keep the `articles.reading_list_document` column updated.
   #
   # Its body is inserted in a PostgreSQL trigger function and that joins the columns values
@@ -1719,6 +1721,22 @@ class Article < ApplicationRecord
     return if published_at.blank?
 
     self.published_at = nil if published_at > 5.years.from_now
+  end
+
+  def recompile_organization_pages
+    org_ids_to_recompile = []
+    if destroyed?
+      org_ids_to_recompile << organization_id
+    elsif saved_change_to_organization_id?
+      org_ids_to_recompile << organization_id_before_last_save
+      org_ids_to_recompile << organization_id
+    else
+      org_ids_to_recompile << organization_id
+    end
+
+    org_ids_to_recompile.compact.uniq.each do |org_id|
+      Organizations::RecompilePagesWorker.perform_async(org_id)
+    end
   end
 
   private

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1741,6 +1741,8 @@ class Article < ApplicationRecord
     end
 
     org_ids_to_recompile.compact.uniq.each do |org_id|
+      next unless FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[org_id])
+
       Organizations::RecompilePagesWorker.perform_async(org_id)
     end
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -43,6 +43,7 @@ class Organization < ApplicationRecord
   after_save :generate_social_images
 
   after_update_commit :conditionally_update_articles
+  after_update_commit :recompile_pages, if: -> { saved_change_to_name? || saved_change_to_slug? || saved_change_to_summary? }
   after_save_commit :manage_fastly_tls_subscription
   after_destroy_commit :bust_cache
 
@@ -384,5 +385,9 @@ class Organization < ApplicationRecord
 
   def bust_cache
     Organizations::BustCacheWorker.perform_async(id, slug)
+  end
+
+  def recompile_pages
+    Organizations::RecompilePagesWorker.perform_async(id)
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -120,6 +120,10 @@ class Organization < ApplicationRecord
     I18n.t("models.organization.reserved_word")
   end
 
+  def self.find_by_slug_or_legacy(slug)
+    find_by(slug: slug) || find_by(old_slug: slug) || find_by(old_old_slug: slug)
+  end
+
   def check_for_slug_change
     return unless slug_changed?
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -392,6 +392,8 @@ class Organization < ApplicationRecord
   end
 
   def recompile_pages
+    return unless FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[self])
+
     Organizations::RecompilePagesWorker.perform_async(id)
   end
 end

--- a/app/models/organization_membership.rb
+++ b/app/models/organization_membership.rb
@@ -47,10 +47,10 @@ class OrganizationMembership < ApplicationRecord
   end
 
   def recompile_organization_pages
+    return unless FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[organization_id])
+
     Organizations::RecompilePagesWorker.perform_async(organization_id)
   end
-
-  private
 
   def bust_cache
     BustCachePathWorker.perform_async(organization.path.to_s)

--- a/app/models/organization_membership.rb
+++ b/app/models/organization_membership.rb
@@ -18,6 +18,7 @@ class OrganizationMembership < ApplicationRecord
   after_destroy :update_user_organization_info_updated_at
 
   after_commit :bust_cache
+  after_commit :recompile_organization_pages
 
   scope :admin, -> { where(type_of_user: "admin") }
   scope :member, -> { where(type_of_user: %w[admin member]) }
@@ -43,6 +44,10 @@ class OrganizationMembership < ApplicationRecord
   #       :organization_memberships dependent: :delete_all`
   def update_user_organization_info_updated_at
     user.touch(:organization_info_updated_at)
+  end
+
+  def recompile_organization_pages
+    Organizations::RecompilePagesWorker.perform_async(organization_id)
   end
 
   private

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -91,6 +91,12 @@ class Page < ApplicationRecord
     save!
   end
 
+  # Force evaluation of markdown and save changes if any
+  def recompile!
+    evaluate_markdown
+    save!
+  end
+
   private
 
   def evaluate_markdown

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -91,9 +91,8 @@ class Page < ApplicationRecord
     save!
   end
 
-  # Force evaluation of markdown and save changes if any
+  # Force evaluation of markdown (via before_save) and persist any resulting changes
   def recompile!
-    evaluate_markdown
     save!
   end
 

--- a/app/workers/organizations/recompile_pages_worker.rb
+++ b/app/workers/organizations/recompile_pages_worker.rb
@@ -16,6 +16,7 @@ module Organizations
           Rails.logger.error(
             "Organizations::RecompilePagesWorker failed to recompile page #{page.id} for org #{organization.id}: #{e.class} - #{e.message}",
           )
+          Rails.logger.error(e.backtrace.join("\n")) if e.backtrace
         end
       end
     end

--- a/app/workers/organizations/recompile_pages_worker.rb
+++ b/app/workers/organizations/recompile_pages_worker.rb
@@ -1,0 +1,15 @@
+module Organizations
+  class RecompilePagesWorker
+    include Sidekiq::Job
+
+    sidekiq_options queue: :default, retry: 3, lock: :until_executing, on_conflict: :replace
+
+    def perform(organization_id)
+      organization = Organization.find_by(id: organization_id)
+      return unless organization
+      return unless FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[organization])
+
+      organization.pages.find_each(&:recompile!)
+    end
+  end
+end

--- a/app/workers/organizations/recompile_pages_worker.rb
+++ b/app/workers/organizations/recompile_pages_worker.rb
@@ -9,7 +9,15 @@ module Organizations
       return unless organization
       return unless FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[organization])
 
-      organization.pages.find_each(&:recompile!)
+      organization.pages.find_each do |page|
+        begin
+          page.recompile!
+        rescue StandardError => e
+          Rails.logger.error(
+            "Organizations::RecompilePagesWorker failed to recompile page #{page.id} for org #{organization.id}: #{e.class} - #{e.message}",
+          )
+        end
+      end
     end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -3921,4 +3921,35 @@ RSpec.describe Article do
       expect(GenerateArticleEmbeddingWorker).not_to have_received(:perform_async)
     end
   end
+
+  describe "recompiling organization pages" do
+    let(:organization) { create(:organization) }
+    let(:user) { create(:user) }
+
+    before do
+      allow(Organizations::RecompilePagesWorker).to receive(:perform_async)
+    end
+
+    it "enqueues recompilation on create when organization is present" do
+      create(:article, organization: organization, user: user)
+      expect(Organizations::RecompilePagesWorker).to have_received(:perform_async).with(organization.id)
+    end
+
+    it "does not enqueue recompilation on create when organization is nil" do
+      create(:article, organization: nil, user: user)
+      expect(Organizations::RecompilePagesWorker).not_to have_received(:perform_async)
+    end
+
+    it "enqueues recompilation on update when organization changes" do
+      article = create(:article, organization: nil, user: user)
+      article.update!(organization: organization)
+      expect(Organizations::RecompilePagesWorker).to have_received(:perform_async).with(organization.id)
+    end
+
+    it "enqueues recompilation on destroy when organization is present" do
+      article = create(:article, organization: organization, user: user)
+      article.destroy!
+      expect(Organizations::RecompilePagesWorker).to have_received(:perform_async).with(organization.id).twice
+    end
+  end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -3930,26 +3930,42 @@ RSpec.describe Article do
       allow(Organizations::RecompilePagesWorker).to receive(:perform_async)
     end
 
-    it "enqueues recompilation on create when organization is present" do
-      create(:article, organization: organization, user: user)
+    it "enqueues recompilation on create when organization is present and published is true" do
+      create(:article, organization: organization, user: user, published: true)
       expect(Organizations::RecompilePagesWorker).to have_received(:perform_async).with(organization.id)
     end
 
     it "does not enqueue recompilation on create when organization is nil" do
-      create(:article, organization: nil, user: user)
+      create(:article, organization: nil, user: user, published: true)
       expect(Organizations::RecompilePagesWorker).not_to have_received(:perform_async)
     end
 
-    it "enqueues recompilation on update when organization changes" do
-      article = create(:article, organization: nil, user: user)
+    it "enqueues recompilation on update when organization changes on a published article" do
+      article = create(:article, organization: nil, user: user, published: true)
       article.update!(organization: organization)
       expect(Organizations::RecompilePagesWorker).to have_received(:perform_async).with(organization.id)
     end
 
-    it "enqueues recompilation on destroy when organization is present" do
-      article = create(:article, organization: organization, user: user)
+    it "enqueues recompilation on destroy when organization is present and article is published" do
+      article = create(:article, organization: organization, user: user, published: true)
       article.destroy!
       expect(Organizations::RecompilePagesWorker).to have_received(:perform_async).with(organization.id).twice
+    end
+
+    it "does not enqueue recompilation for draft articles on create or update" do
+      article = create(:unpublished_article, organization: organization, user: user)
+      expect(Organizations::RecompilePagesWorker).not_to have_received(:perform_async)
+
+      article.update!(title: "New Draft Title")
+      expect(Organizations::RecompilePagesWorker).not_to have_received(:perform_async)
+    end
+
+    it "enqueues recompilation when a draft article is published" do
+      article = create(:unpublished_article, organization: organization, user: user)
+      expect(Organizations::RecompilePagesWorker).not_to have_received(:perform_async)
+
+      article.update!(published: true)
+      expect(Organizations::RecompilePagesWorker).to have_received(:perform_async).with(organization.id)
     end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -3928,6 +3928,8 @@ RSpec.describe Article do
 
     before do
       allow(Organizations::RecompilePagesWorker).to receive(:perform_async)
+      allow(FeatureFlag).to receive(:enabled?).and_call_original
+      allow(FeatureFlag).to receive(:enabled?).with(:org_readme, anything).and_return(true)
     end
 
     it "enqueues recompilation on create when organization is present and published is true" do

--- a/spec/models/organization_membership_spec.rb
+++ b/spec/models/organization_membership_spec.rb
@@ -91,4 +91,30 @@ RSpec.describe OrganizationMembership do
       expect(membership.invitation_token).to eq(existing_token)
     end
   end
+
+  describe "recompiling organization pages" do
+    let(:organization) { create(:organization) }
+    let(:user) { create(:user) }
+
+    before do
+      allow(Organizations::RecompilePagesWorker).to receive(:perform_async)
+    end
+
+    it "enqueues recompilation on create" do
+      create(:organization_membership, organization: organization, user: user)
+      expect(Organizations::RecompilePagesWorker).to have_received(:perform_async).with(organization.id)
+    end
+
+    it "enqueues recompilation on update" do
+      membership = create(:organization_membership, organization: organization, user: user, type_of_user: "pending")
+      membership.update!(type_of_user: "member")
+      expect(Organizations::RecompilePagesWorker).to have_received(:perform_async).with(organization.id).twice
+    end
+
+    it "enqueues recompilation on destroy" do
+      membership = create(:organization_membership, organization: organization, user: user)
+      membership.destroy!
+      expect(Organizations::RecompilePagesWorker).to have_received(:perform_async).with(organization.id).twice
+    end
+  end
 end

--- a/spec/models/organization_membership_spec.rb
+++ b/spec/models/organization_membership_spec.rb
@@ -98,6 +98,8 @@ RSpec.describe OrganizationMembership do
 
     before do
       allow(Organizations::RecompilePagesWorker).to receive(:perform_async)
+      allow(FeatureFlag).to receive(:enabled?).and_call_original
+      allow(FeatureFlag).to receive(:enabled?).with(:org_readme, anything).and_return(true)
     end
 
     it "enqueues recompilation on create" do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -552,6 +552,8 @@ RSpec.describe Organization do
 
     before do
       allow(Organizations::RecompilePagesWorker).to receive(:perform_async)
+      allow(FeatureFlag).to receive(:enabled?).and_call_original
+      allow(FeatureFlag).to receive(:enabled?).with(:org_readme, anything).and_return(true)
     end
 
     it "enqueues recompilation when name changes" do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -546,4 +546,32 @@ RSpec.describe Organization do
       expect(organization.active_users.pluck(:id)).not_to include(user3.id)
     end
   end
+
+  describe "recompiling organization pages on update" do
+    let(:organization) { create(:organization) }
+
+    before do
+      allow(Organizations::RecompilePagesWorker).to receive(:perform_async)
+    end
+
+    it "enqueues recompilation when name changes" do
+      organization.update!(name: "New Name")
+      expect(Organizations::RecompilePagesWorker).to have_received(:perform_async).with(organization.id)
+    end
+
+    it "enqueues recompilation when slug changes" do
+      organization.update!(slug: "new-slug")
+      expect(Organizations::RecompilePagesWorker).to have_received(:perform_async).with(organization.id)
+    end
+
+    it "enqueues recompilation when summary changes" do
+      organization.update!(summary: "New Summary")
+      expect(Organizations::RecompilePagesWorker).to have_received(:perform_async).with(organization.id)
+    end
+
+    it "does not enqueue recompilation when other attributes change" do
+      organization.update!(company_size: "50")
+      expect(Organizations::RecompilePagesWorker).not_to have_received(:perform_async)
+    end
+  end
 end

--- a/spec/workers/organizations/recompile_pages_worker_spec.rb
+++ b/spec/workers/organizations/recompile_pages_worker_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe Organizations::RecompilePagesWorker do
+  describe "#perform" do
+    let(:organization) { create(:organization) }
+    let!(:page) do
+      create(:page, organization: organization, body_markdown: "# Title\n{% org_posts #{organization.slug} %}",
+                    title: "Readme", description: "desc", slug: "#{organization.slug}/readme")
+    end
+
+    before do
+      FeatureFlag.add(:org_readme)
+    end
+
+    context "when :org_readme feature is disabled" do
+      before do
+        FeatureFlag.disable(:org_readme, FeatureFlag::Actor[organization])
+      end
+
+      it "does not recompile the organization pages" do
+        allow_any_instance_of(Page).to receive(:recompile!)
+        described_class.new.perform(organization.id)
+        expect_any_instance_of(Page).not_to receive(:recompile!)
+      end
+    end
+
+    context "when :org_readme feature is enabled" do
+      before do
+        FeatureFlag.enable(:org_readme, FeatureFlag::Actor[organization])
+      end
+
+      it "recompiles the organization pages" do
+        expect_any_instance_of(Page).to receive(:recompile!).and_call_original
+        described_class.new.perform(organization.id)
+      end
+
+      it "updates processed_html during recompilation" do
+        # Setup initial content that renders without articles
+        expect(page.processed_html).not_to include("An Amazing Article")
+
+        # Create a published article
+        create(:article, organization: organization, published: true, title: "An Amazing Article")
+
+        described_class.new.perform(organization.id)
+        expect(page.reload.processed_html).to include("An Amazing Article")
+      end
+    end
+  end
+end

--- a/spec/workers/organizations/recompile_pages_worker_spec.rb
+++ b/spec/workers/organizations/recompile_pages_worker_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
-RSpec.describe Organizations::RecompilePagesWorker do
+RSpec.describe Organizations::RecompilePagesWorker, type: :worker do
+  include_examples "#enqueues_on_correct_queue", "default", 1
+
   describe "#perform" do
     let(:organization) { create(:organization) }
     let!(:page) do
@@ -18,9 +20,8 @@ RSpec.describe Organizations::RecompilePagesWorker do
       end
 
       it "does not recompile the organization pages" do
-        allow_any_instance_of(Page).to receive(:recompile!)
-        described_class.new.perform(organization.id)
         expect_any_instance_of(Page).not_to receive(:recompile!)
+        described_class.new.perform(organization.id)
       end
     end
 

--- a/spec/workers/organizations/recompile_pages_worker_spec.rb
+++ b/spec/workers/organizations/recompile_pages_worker_spec.rb
@@ -45,6 +45,43 @@ RSpec.describe Organizations::RecompilePagesWorker, type: :worker do
         described_class.new.perform(organization.id)
         expect(page.reload.processed_html).to include("An Amazing Article")
       end
+
+      it "does not raise an error and logs it if a page compilation fails" do
+        bad_page = create(:page, organization: organization, body_markdown: "# Bad Page",
+                                 title: "Bad Page", description: "desc", slug: "#{organization.slug}/bad")
+
+        allow_any_instance_of(Page).to receive(:recompile!) do |instance|
+          if instance.id == bad_page.id
+            raise StandardError, "Something went wrong"
+          else
+            instance.save!
+          end
+        end
+
+        allow(Rails.logger).to receive(:error)
+        expect { described_class.new.perform(organization.id) }.not_to raise_error
+        expect(Rails.logger).to have_received(:error).with(/failed to recompile page #{bad_page.id}/)
+      end
+
+      it "recompiles successfully when the page uses a legacy slug" do
+        old_slug = organization.slug
+        new_slug = "brand-new-slug"
+
+        # Simulate slug change which stores old_slug
+        organization.update!(slug: new_slug)
+        expect(organization.reload.old_slug).to eq(old_slug)
+
+        # Create page using the legacy slug in the tag
+        legacy_page = create(:page, organization: organization, body_markdown: "{% org_posts #{old_slug} %}",
+                                    title: "Legacy", description: "desc", slug: "#{new_slug}/legacy")
+
+        # Create published article under new slug
+        create(:article, organization: organization, published: true, title: "An Amazing Article")
+
+        # Recompile should find the org by old_slug, render org posts tag, and include the article!
+        described_class.new.perform(organization.id)
+        expect(legacy_page.reload.processed_html).to include("An Amazing Article")
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds automatic page/markdown recompilation for organizations under the `:org_readme` feature flag whenever organization articles, memberships, or info are updated.

See the implementation plan and walkthrough artifacts for details.