### PR TITLE
Fix Rack::Timeout connection pool deadlocks by using deadlock-free raw socket closing

### DIFF
--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -23,22 +23,20 @@ if defined?(Rack::Timeout) && defined?(ActiveRecord::Base)
       request_thread = env["rack-timeout.request_thread"]
       if request_thread
         ActiveRecord::Base.connection_handler.connection_pool_list.each do |pool|
-          # Safely retrieve and disconnect the connection cached for the request thread
+          # Safely retrieve the connection cached for the request thread
           tcc = pool.instance_variable_get(:@thread_cached_conns)
           conn = tcc[request_thread] if tcc
           if conn
             begin
-              conn.disconnect!
+              # Close the raw connection socket to wake up any blocking C extension query execution
+              # without acquiring the connection's lock (which is held by the request thread).
+              raw_conn = conn.raw_connection rescue nil
+              if raw_conn && raw_conn.respond_to?(:close)
+                raw_conn.close
+              end
             rescue StandardError => e
-              Rails.logger.warn "Rack::Timeout: failed to disconnect timed out connection: #{e.class}: #{e.message}"
-              conn.discard! if conn.respond_to?(:discard!)
+              Rails.logger.warn "Rack::Timeout: failed to close raw database connection: #{e.class}: #{e.message}"
             end
-          end
-          # Release the connection back to the pool
-          begin
-            pool.release_connection(request_thread)
-          rescue StandardError => e
-            Rails.logger.warn "Rack::Timeout: failed to release timed out connection: #{e.class}: #{e.message}"
           end
         end
       end

--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -30,9 +30,13 @@ if defined?(Rack::Timeout) && defined?(ActiveRecord::Base)
             begin
               # Close the raw connection socket to wake up any blocking C extension query execution
               # without acquiring the connection's lock (which is held by the request thread).
-              raw_conn = conn.raw_connection rescue nil
-              if raw_conn && raw_conn.respond_to?(:close)
-                raw_conn.close
+              raw_conn = conn.raw_connection
+              if raw_conn
+                if raw_conn.respond_to?(:close)
+                  raw_conn.close
+                elsif raw_conn.respond_to?(:finish)
+                  raw_conn.finish
+                end
               end
             rescue StandardError => e
               Rails.logger.warn "Rack::Timeout: failed to close raw database connection: #{e.class}: #{e.message}"

--- a/spec/initializers/timeout_spec.rb
+++ b/spec/initializers/timeout_spec.rb
@@ -55,6 +55,33 @@ RSpec.describe Rack::Timeout, type: :initializer do
         expect(pool).not_to have_received(:release_connection)
       end
 
+      it "falls back to calling finish if the raw connection does not respond to close but responds to finish" do
+        pool = ActiveRecord::Base.connection_pool
+        mock_connection = double("ActiveRecord::ConnectionAdapters::PostgreSQLAdapter")
+        mock_raw_connection = double("PG::Connection")
+        mock_tcc = { mock_thread => mock_connection }
+
+        # Mock the connection pool internals
+        allow(pool).to receive(:instance_variable_get).with(:@thread_cached_conns).and_return(mock_tcc)
+        allow(mock_connection).to receive(:raw_connection).and_return(mock_raw_connection)
+        allow(mock_raw_connection).to receive(:respond_to?).with(:close).and_return(false)
+        allow(mock_raw_connection).to receive(:respond_to?).with(:finish).and_return(true)
+        allow(mock_raw_connection).to receive(:finish)
+        allow(mock_connection).to receive(:disconnect!)
+        allow(pool).to receive(:release_connection)
+
+        # Retrieve the observer proc directly from the registry
+        observers = described_class.instance_variable_get(:@state_change_observers)
+        observer_proc = observers[:clear_db_connections_on_timeout]
+        expect(observer_proc).not_to be_nil
+
+        observer_proc.call(env)
+
+        expect(mock_raw_connection).to have_received(:finish)
+        expect(mock_connection).not_to have_received(:disconnect!)
+        expect(pool).not_to have_received(:release_connection)
+      end
+
       it "rescues errors if closing the raw connection raises an exception" do
         pool = ActiveRecord::Base.connection_pool
         mock_connection = double("ActiveRecord::ConnectionAdapters::PostgreSQLAdapter")

--- a/spec/initializers/timeout_spec.rb
+++ b/spec/initializers/timeout_spec.rb
@@ -29,13 +29,17 @@ RSpec.describe Rack::Timeout, type: :initializer do
         env["rack-timeout.request_thread"] = mock_thread
       end
 
-      it "disconnects and releases the database connection for the tracked thread" do
+      it "closes the raw database connection socket for the tracked thread" do
         pool = ActiveRecord::Base.connection_pool
         mock_connection = double("ActiveRecord::ConnectionAdapters::PostgreSQLAdapter")
+        mock_raw_connection = double("PG::Connection")
         mock_tcc = { mock_thread => mock_connection }
 
         # Mock the connection pool internals
         allow(pool).to receive(:instance_variable_get).with(:@thread_cached_conns).and_return(mock_tcc)
+        allow(mock_connection).to receive(:raw_connection).and_return(mock_raw_connection)
+        allow(mock_raw_connection).to receive(:respond_to?).with(:close).and_return(true)
+        allow(mock_raw_connection).to receive(:close)
         allow(mock_connection).to receive(:disconnect!)
         allow(pool).to receive(:release_connection)
 
@@ -46,19 +50,23 @@ RSpec.describe Rack::Timeout, type: :initializer do
 
         observer_proc.call(env)
 
-        expect(mock_connection).to have_received(:disconnect!)
-        expect(pool).to have_received(:release_connection).with(mock_thread)
+        expect(mock_raw_connection).to have_received(:close)
+        expect(mock_connection).not_to have_received(:disconnect!)
+        expect(pool).not_to have_received(:release_connection)
       end
 
-      it "discards the connection if disconnect! raises an exception" do
+      it "rescues errors if closing the raw connection raises an exception" do
         pool = ActiveRecord::Base.connection_pool
         mock_connection = double("ActiveRecord::ConnectionAdapters::PostgreSQLAdapter")
+        mock_raw_connection = double("PG::Connection")
         mock_tcc = { mock_thread => mock_connection }
 
         # Mock the connection pool internals
         allow(pool).to receive(:instance_variable_get).with(:@thread_cached_conns).and_return(mock_tcc)
-        allow(mock_connection).to receive(:disconnect!).and_raise(StandardError.new("disconnect error"))
-        allow(mock_connection).to receive(:discard!)
+        allow(mock_connection).to receive(:raw_connection).and_return(mock_raw_connection)
+        allow(mock_raw_connection).to receive(:respond_to?).with(:close).and_return(true)
+        allow(mock_raw_connection).to receive(:close).and_raise(StandardError.new("close error"))
+        allow(mock_connection).to receive(:disconnect!)
         allow(pool).to receive(:release_connection)
 
         # Retrieve the observer proc directly from the registry
@@ -66,11 +74,12 @@ RSpec.describe Rack::Timeout, type: :initializer do
         observer_proc = observers[:clear_db_connections_on_timeout]
         expect(observer_proc).not_to be_nil
 
-        observer_proc.call(env)
+        # Verify it rescues the error and does not raise
+        expect { observer_proc.call(env) }.not_to raise_error
 
-        expect(mock_connection).to have_received(:disconnect!)
-        expect(mock_connection).to have_received(:discard!)
-        expect(pool).to have_received(:release_connection).with(mock_thread)
+        expect(mock_raw_connection).to have_received(:close)
+        expect(mock_connection).not_to have_received(:disconnect!)
+        expect(pool).not_to have_received(:release_connection)
       end
     end
 


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
Hopefully fixes failures to establish pool connections