### PR TITLE
Fix dashboard visibility for archived articles

### DIFF
--- a/app/views/dashboards/_dashboard_article_row.html.erb
+++ b/app/views/dashboards/_dashboard_article_row.html.erb
@@ -1,4 +1,4 @@
-<div class="dashboard-story js-dashboard-story spec__dashboard-story single-article <%= "story-unpublished" unless article.published %> <%= "js-dashboard-story story-archived hidden" if article.archived %>">
+<div class="dashboard-story js-dashboard-story spec__dashboard-story single-article <%= "story-unpublished" unless article.published %> <%= "story-archived" if article.archived %> <%= "hidden" if article.archived && !@show_archived %>">
   <div class="dashboard-story__title">
     <h3 class="flex items-center">
       <% if article.archived %>

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -157,6 +157,10 @@ RSpec.describe "Dashboards" do
 
         expect(response.body).to include("Archived Post 0")
         expect(response.body).not_to include("Visible Post 0")
+
+        html = Nokogiri::HTML(response.body)
+        expect(html.css(".story-archived")).to be_present
+        expect(html.css(".story-archived.hidden")).to be_empty
       end
     end
 
@@ -242,6 +246,16 @@ RSpec.describe "Dashboards" do
         get "/dashboard/organization/#{organization.id}"
         expect(response.body).not_to include("Delete")
         expect(response.body).to include(ERB::Util.html_escape(unpublished_article.title))
+      end
+
+      it "renders archived organization articles with the hidden class" do
+        create(:organization_membership, user: user, organization: organization, type_of_user: "admin")
+        archived_article = create(:article, user: user, organization_id: organization.id, archived: true)
+        sign_in user
+        get "/dashboard/organization/#{organization.id}"
+
+        html = Nokogiri::HTML(response.body)
+        expect(html.css(".story-archived.hidden")).to be_present
       end
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR fixes a frontend bug where archived articles were completely invisible in the user dashboard, even when a user explicitly clicked the "Archived" filter button.

The `app/views/dashboards/_dashboard_article_row.html.erb` template was unconditionally applying a `hidden` CSS class to any article row marked as archived. This PR updates the logic to conditionally apply the `hidden` class *only* when the user is not actively viewing the archived filter (`@show_archived`). It also cleans up a redundant CSS class string on the wrapper div.

## Related Tickets & Documents

- Found while investigating #23399 

## QA Instructions, Screenshots, Recordings

1. Go to your user dashboard (`/dashboard`).
2. Archive a post (if you don't already have one). 
3. The post should visually disappear from the main dashboard view.
4. Click the "Archived" filter button (`/dashboard?filter=archived`).
5. Verify that the archived post is now correctly visible on the screen instead of being hidden by CSS.

## Added/updated tests?

- [x] Yes
- [ ] No
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
