### PR TITLE
Fix dark-on-dark contrast for bookmark button on static feeds

### DIFF
--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -181,10 +181,10 @@
               data-article-author-id="<%= story.user_id %>"
               aria-label="<%= t("views.articles.save.aria_label", title: story.type_of == "status" && story.title_finalized ? story.title_finalized : story.title) %>"
               title="<%= t("views.articles.save.title", title: story.type_of == "status" && story.title_finalized ? story.title_finalized : story.title) %>">
-              <span class="bm-initial">
+              <span class="bm-initial crayons-icon c-btn__icon">
                 <%= inline_svg_tag("small-save.svg", alt: "", aria_hidden: true) %>
               </span>
-              <span class="bm-success">
+              <span class="bm-success crayons-icon c-btn__icon">
                 <%= inline_svg_tag("small-save-filled.svg", alt: "", aria_hidden: true) %>
               </span>
             </button>


### PR DESCRIPTION
This PR adds the crayons-icon and c-btn__icon classes to the SVG wrapper spans in the Rails single_story partial. This ensures the SVGs inherit currentColor (which correctly scales to a light color in dark mode), resolving the dark-on-dark visual contrast issue on server-side rendered feeds.