### PR TITLE
Implement customizable concept-specific thresholds and update default to 0.28

### DIFF
--- a/app/controllers/admin/concepts_controller.rb
+++ b/app/controllers/admin/concepts_controller.rb
@@ -97,7 +97,7 @@ module Admin
     end
 
     def concept_params
-      params.require(:concept).permit(:name, :description, :parent_id)
+      params.require(:concept).permit(:name, :description, :parent_id, :similarity_threshold)
     end
   end
 end

--- a/app/models/concept.rb
+++ b/app/models/concept.rb
@@ -18,6 +18,7 @@ class Concept < ApplicationRecord
   validates :slug, presence: true, uniqueness: true
   validates :anchor_embedding, presence: true
   validates :max_lookback_days, presence: true, numericality: { greater_than_or_equal_to: 0, only_integer: true }
+  validates :similarity_threshold, numericality: { greater_than_or_equal_to: 0.0, less_than_or_equal_to: 1.0 }, allow_nil: true
 
   private
 

--- a/app/services/concepts/classifier.rb
+++ b/app/services/concepts/classifier.rb
@@ -1,6 +1,6 @@
 module Concepts
   class Classifier
-    DEFAULT_THRESHOLD = 0.23
+    DEFAULT_THRESHOLD = 0.28
 
     def initialize(record)
       @record = record
@@ -19,7 +19,7 @@ module Concepts
       # Query concepts that match within the threshold
       matching_concepts = Concept
         .select("concepts.*, (anchor_embedding <=> #{quoted_vector}) AS computed_distance")
-        .where("anchor_embedding <=> #{quoted_vector} <= ?", threshold)
+        .where("anchor_embedding <=> #{quoted_vector} <= COALESCE(concepts.similarity_threshold, ?)", threshold)
         .to_a
 
       active_concept_ids = matching_concepts.map(&:id)

--- a/app/views/admin/concepts/_form.html.erb
+++ b/app/views/admin/concepts/_form.html.erb
@@ -20,7 +20,7 @@
 
   <div class="crayons-field mt-3">
     <%= f.label :similarity_threshold, t("views.admin.concepts.form.similarity_threshold"), class: "crayons-field__label" %>
-    <%= f.number_field :similarity_threshold, step: 0.01, min: 0.0, max: 1.0, class: "crayons-textfield", placeholder: t("views.admin.concepts.form.similarity_threshold_placeholder") %>
+    <%= f.number_field :similarity_threshold, step: :any, min: 0.0, max: 1.0, class: "crayons-textfield", placeholder: t("views.admin.concepts.form.similarity_threshold_placeholder") %>
     <p class="fs-xs color-base-60 mt-1"><%= t("views.admin.concepts.form.similarity_threshold_help") %></p>
   </div>
 

--- a/app/views/admin/concepts/_form.html.erb
+++ b/app/views/admin/concepts/_form.html.erb
@@ -18,6 +18,12 @@
     <%= f.select :parent_id, options_from_collection_for_select(parent_options, :id, :name, concept.parent_id), { include_blank: "None" }, class: "crayons-select" %>
   </div>
 
+  <div class="crayons-field mt-3">
+    <%= f.label :similarity_threshold, t("views.admin.concepts.form.similarity_threshold"), class: "crayons-field__label" %>
+    <%= f.number_field :similarity_threshold, step: 0.01, min: 0.0, max: 1.0, class: "crayons-textfield", placeholder: t("views.admin.concepts.form.similarity_threshold_placeholder") %>
+    <p class="fs-xs color-base-60 mt-1"><%= t("views.admin.concepts.form.similarity_threshold_help") %></p>
+  </div>
+
   <div class="flex items-center gap-4 mt-6">
     <%= f.submit class: "crayons-btn" %>
     <%= link_to "Cancel", admin_concepts_path, class: "crayons-btn crayons-btn--outlined" %>

--- a/app/views/admin/concepts/index.html.erb
+++ b/app/views/admin/concepts/index.html.erb
@@ -30,7 +30,7 @@
             </td>
             <td><code><%= concept.slug %></code></td>
             <td><%= concept.parent&.name || "-" %></td>
-            <td><%= concept.similarity_threshold ? concept.similarity_threshold.to_s : "0.28 (#{t('views.admin.concepts.index.default')})" %></td>
+            <td><%= concept.similarity_threshold ? concept.similarity_threshold.to_s : "#{Concepts::Classifier::DEFAULT_THRESHOLD} (#{t('views.admin.concepts.index.default')})" %></td>
             <td><%= @membership_counts[concept.id] || 0 %></td>
             <td>
               <div class="flex gap-2">

--- a/app/views/admin/concepts/index.html.erb
+++ b/app/views/admin/concepts/index.html.erb
@@ -16,6 +16,7 @@
           <th scope="col">Name</th>
           <th scope="col">Slug</th>
           <th scope="col">Parent</th>
+          <th scope="col"><%= t("views.admin.concepts.index.threshold") %></th>
           <th scope="col">Records Mapped</th>
           <th scope="col">Actions</th>
         </tr>
@@ -29,6 +30,7 @@
             </td>
             <td><code><%= concept.slug %></code></td>
             <td><%= concept.parent&.name || "-" %></td>
+            <td><%= concept.similarity_threshold ? concept.similarity_threshold.to_s : "0.28 (#{t('views.admin.concepts.index.default')})" %></td>
             <td><%= @membership_counts[concept.id] || 0 %></td>
             <td>
               <div class="flex gap-2">

--- a/app/views/admin/concepts/show.html.erb
+++ b/app/views/admin/concepts/show.html.erb
@@ -37,7 +37,7 @@
       <div class="mb-3">
         <strong class="color-base-60 fs-xs uppercase block"><%= t("views.admin.concepts.show.similarity_threshold") %></strong>
         <span>
-          <%= @concept.similarity_threshold ? @concept.similarity_threshold.to_s : "0.28 (#{t('views.admin.concepts.index.default')})" %>
+          <%= @concept.similarity_threshold ? @concept.similarity_threshold.to_s : "#{Concepts::Classifier::DEFAULT_THRESHOLD} (#{t('views.admin.concepts.index.default')})" %>
         </span>
       </div>
     </div>

--- a/app/views/admin/concepts/show.html.erb
+++ b/app/views/admin/concepts/show.html.erb
@@ -34,6 +34,12 @@
           <%= @concept.max_lookback_days.positive? ? @concept.max_lookback_days : t("views.admin.concepts.show.max_lookback_days_none") %>
         </span>
       </div>
+      <div class="mb-3">
+        <strong class="color-base-60 fs-xs uppercase block"><%= t("views.admin.concepts.show.similarity_threshold") %></strong>
+        <span>
+          <%= @concept.similarity_threshold ? @concept.similarity_threshold.to_s : "0.28 (#{t('views.admin.concepts.index.default')})" %>
+        </span>
+      </div>
     </div>
     <div>
       <div class="mb-3">

--- a/app/workers/concepts/backfill_classifier_worker.rb
+++ b/app/workers/concepts/backfill_classifier_worker.rb
@@ -13,11 +13,13 @@ module Concepts
       # 1. Clean up existing memberships for this concept
       concept.concept_memberships.delete_all
 
+      threshold = concept.similarity_threshold || Concepts::Classifier::DEFAULT_THRESHOLD
+
       # 2. Query all matching published articles
       matching_articles = Article.published
         .select("articles.id, (semantic_embedding <=> #{quoted_vector}) AS computed_distance")
         .where.not(semantic_embedding: nil)
-        .where("semantic_embedding <=> #{quoted_vector} <= ?", Concepts::Classifier::DEFAULT_THRESHOLD)
+        .where("semantic_embedding <=> #{quoted_vector} <= ?", threshold)
         .to_a
 
       memberships = matching_articles.map do |art|
@@ -35,7 +37,7 @@ module Concepts
       matching_comments = Comment
         .select("comments.id, (semantic_embedding <=> #{quoted_vector}) AS computed_distance")
         .where.not(semantic_embedding: nil)
-        .where("semantic_embedding <=> #{quoted_vector} <= ?", Concepts::Classifier::DEFAULT_THRESHOLD)
+        .where("semantic_embedding <=> #{quoted_vector} <= ?", threshold)
         .to_a
 
       matching_comments.each do |com|

--- a/app/workers/concepts/lookback_worker.rb
+++ b/app/workers/concepts/lookback_worker.rb
@@ -25,11 +25,13 @@ module Concepts
       vector_literal = "[#{concept.anchor_embedding.to_a.join(',')}]"
       quoted_vector = Concept.connection.quote(vector_literal)
 
+      threshold = concept.similarity_threshold || Concepts::Classifier::DEFAULT_THRESHOLD
+
       # 1. Query matching published articles
       articles_query = Article.published
         .select("articles.id, (semantic_embedding <=> #{quoted_vector}) AS computed_distance")
         .where.not(semantic_embedding: nil)
-        .where("semantic_embedding <=> #{quoted_vector} <= ?", Concepts::Classifier::DEFAULT_THRESHOLD)
+        .where("semantic_embedding <=> #{quoted_vector} <= ?", threshold)
         .where("published_at >= ?", start_time)
 
       if end_time
@@ -53,7 +55,7 @@ module Concepts
       comments_query = Comment
         .select("comments.id, (semantic_embedding <=> #{quoted_vector}) AS computed_distance")
         .where.not(semantic_embedding: nil)
-        .where("semantic_embedding <=> #{quoted_vector} <= ?", Concepts::Classifier::DEFAULT_THRESHOLD)
+        .where("semantic_embedding <=> #{quoted_vector} <= ?", threshold)
         .where("created_at >= ?", start_time)
 
       if end_time

--- a/config/locales/views/admin/en.yml
+++ b/config/locales/views/admin/en.yml
@@ -605,3 +605,11 @@ en:
           lookback_desc: "Scans past articles and comments. If previous lookbacks exist, it only scans the new period (e.g. from 40 to 70 days ago) with a bit of timezone overlap."
           lookback_days: "Days to look back"
           lookback_button: "Trigger Lookback"
+          similarity_threshold: "Similarity Threshold"
+        form:
+          similarity_threshold: "Similarity Threshold"
+          similarity_threshold_placeholder: "e.g. 0.25 (optional)"
+          similarity_threshold_help: "Optional. Float between 0.0 and 1.0. If left blank, the system default (0.28) is used."
+        index:
+          threshold: "Threshold"
+          default: "default"

--- a/config/locales/views/admin/fr.yml
+++ b/config/locales/views/admin/fr.yml
@@ -594,3 +594,11 @@ fr:
           lookback_desc: "Analyse les articles et commentaires passés. Si des retours en arrière précédents existent, il analyse uniquement la nouvelle période (par exemple de 40 à 70 jours auparavant) avec un léger chevauchement de fuseau horaire."
           lookback_days: "Jours à analyser en arrière"
           lookback_button: "Déclencher"
+          similarity_threshold: "Seuil de similitude"
+        form:
+          similarity_threshold: "Seuil de similitude"
+          similarity_threshold_placeholder: "ex. 0.25 (optionnel)"
+          similarity_threshold_help: "Optionnel. Nombre décimal entre 0,0 et 1,0. Si laissé vide, la valeur par défaut du système (0,28) est utilisée."
+        index:
+          threshold: "Seuil"
+          default: "défaut"

--- a/config/locales/views/admin/pt.yml
+++ b/config/locales/views/admin/pt.yml
@@ -491,3 +491,11 @@ pt:
           lookback_desc: "Analisa artigos e comentários passados. Se buscas anteriores existirem, analisa apenas o novo período (ex. de 40 a 70 dias atrás) com alguma sobreposição de fuso horário."
           lookback_days: "Dias para olhar para trás"
           lookback_button: "Disparar Busca"
+          similarity_threshold: "Limiar de Similaridade"
+        form:
+          similarity_threshold: "Limiar de Similaridade"
+          similarity_threshold_placeholder: "ex. 0.25 (opcional)"
+          similarity_threshold_help: "Opcional. Float entre 0.0 e 1.0. Se deixado em branco, o padrão do sistema (0.28) será usado."
+        index:
+          threshold: "Limiar"
+          default: "padrão"

--- a/db/migrate/20260605171500_add_similarity_threshold_to_concepts.rb
+++ b/db/migrate/20260605171500_add_similarity_threshold_to_concepts.rb
@@ -1,0 +1,5 @@
+class AddSimilarityThresholdToConcepts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :concepts, :similarity_threshold, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_06_04_143500) do
+ActiveRecord::Schema[7.0].define(version: 2026_06_05_171500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -540,6 +540,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_04_143500) do
     t.integer "max_lookback_days", default: 0, null: false
     t.string "name", null: false
     t.bigint "parent_id"
+    t.float "similarity_threshold"
     t.string "slug", null: false
     t.datetime "updated_at", null: false
     t.index ["anchor_embedding"], name: "index_concepts_on_anchor_embedding", opclass: :vector_cosine_ops, using: :hnsw

--- a/spec/models/concept_spec.rb
+++ b/spec/models/concept_spec.rb
@@ -29,5 +29,20 @@ RSpec.describe Concept, type: :model do
       concept = build(:concept, anchor_embedding: nil)
       expect(concept).not_to be_valid
     end
+
+    it "allows similarity_threshold to be nil" do
+      concept = build(:concept, similarity_threshold: nil)
+      expect(concept).to be_valid
+    end
+
+    it "requires similarity_threshold to be between 0.0 and 1.0" do
+      concept_valid = build(:concept, similarity_threshold: 0.5)
+      concept_low = build(:concept, similarity_threshold: -0.1)
+      concept_high = build(:concept, similarity_threshold: 1.1)
+
+      expect(concept_valid).to be_valid
+      expect(concept_low).not_to be_valid
+      expect(concept_high).not_to be_valid
+    end
   end
 end

--- a/spec/services/concepts/classifier_spec.rb
+++ b/spec/services/concepts/classifier_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Concepts::Classifier do
   let(:embedding1) { Array.new(768, 0.1) }
-  let(:embedding2) { Array.new(768, 0.11) }
+  let(:embedding2) { Array.new(768) { |i| i < 118 ? 0.0 : 0.1 } }
   let(:embedding3) { Array.new(768) { |i| i.even? ? 0.1 : -0.1 } } # orthogonal/far away
 
   let!(:concept1) { create(:concept, anchor_embedding: embedding1) }
@@ -66,6 +66,23 @@ RSpec.describe Concepts::Classifier do
         }.to change(ConceptMembership, :count).by(-2)
 
         expect(comment.concepts).to be_empty
+      end
+    end
+
+    context "with concept-specific thresholds" do
+      let!(:concept_with_custom) { create(:concept, anchor_embedding: embedding2, similarity_threshold: 0.005) }
+
+      it "respects the concept-specific threshold instead of default" do
+        # embedding1 and embedding2 are slightly different.
+        # concept_with_custom has custom threshold 0.005, which is too strict for embedding1.
+        # It should not match, while concept1 matches with distance 0.0.
+        article = create(:article, semantic_embedding: embedding1)
+        classifier = described_class.new(article)
+
+        classifier.call
+
+        expect(article.concepts).to include(concept1)
+        expect(article.concepts).not_to include(concept_with_custom)
       end
     end
   end


### PR DESCRIPTION
This PR implements customizable concept-specific thresholds and updates the global default similarity threshold from 0.23 to 0.28.

### Proposed Changes

1. **Database Migration**
   - Added a `similarity_threshold` float column to the `concepts` table.

2. **Model Validations**
   - Validated that `similarity_threshold` is between `0.0` and `1.0` (inclusive) or `nil`.

3. **Classifier Service & Workers**
   - Adjusted `Concepts::Classifier::DEFAULT_THRESHOLD` to `0.28`.
   - Updated `Concepts::Classifier`, `Concepts::BackfillClassifierWorker`, and `Concepts::LookbackWorker` to fallback to the custom threshold if present (`COALESCE(concepts.similarity_threshold, ?)`).

4. **Admin Interface (UI) & Controller**
   - Permitted `:similarity_threshold` in `Admin::ConceptsController`.
   - Added numeric input field to the concept form.
   - Displayed threshold in the concepts index and show pages.

5. **i18n Translations**
   - Updated translation keys for `en`, `fr`, and `pt`.

6. **Specs**
   - Fixed classifier spec failure by ensuring test embeddings have a realistic, non-zero cosine distance.