### PR TITLE
feat: Add upcoming events card to homepage sidebar

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -61,6 +61,7 @@ module Admin
         :description, 
         :primary_stream_url, 
         :published, 
+        :elevated,
         :start_time, 
         :end_time, 
         :type_of,

--- a/app/controllers/sidebars_controller.rb
+++ b/app/controllers/sidebars_controller.rb
@@ -14,7 +14,7 @@ class SidebarsController < ApplicationController
   private
 
   def get_upcoming_events
-    @upcoming_events = Event.published.elevated.where("end_time >= ?", Time.current).order(start_time: :asc)
+    @upcoming_events = Event.published.elevated.where("end_time >= ?", Time.current).order(start_time: :asc).limit(5).to_a
   end
 
   def get_latest_campaign_articles

--- a/app/controllers/sidebars_controller.rb
+++ b/app/controllers/sidebars_controller.rb
@@ -8,9 +8,14 @@ class SidebarsController < ApplicationController
       get_active_discussions
       set_onboarding_checklist
     end
+    get_upcoming_events
   end
 
   private
+
+  def get_upcoming_events
+    @upcoming_events = Event.published.elevated.where("end_time >= ?", Time.current).order(start_time: :asc)
+  end
 
   def get_latest_campaign_articles
     @campaign_articles_count = Campaign.current.count

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -23,6 +23,7 @@ class Event < ApplicationRecord
   after_commit :ensure_broadcast_billboards_and_workers, on: [:create, :update]
 
   scope :published, -> { where(published: true) }
+  scope :elevated, -> { where(elevated: true) }
 
   def self.active_broadcast_events
     Rails.cache.fetch("active_broadcast_events", expires_in: 30.seconds) do

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -158,6 +158,14 @@
       <% end %>
     </div>
 
+    <div class="crayons-field crayons-field--checkbox">
+      <%= form.check_box :elevated, class: "crayons-checkbox" %>
+      <%= form.label :elevated, class: "crayons-field__label" do %>
+        Elevated
+        <p class="crayons-field__description">Determines if the event is elevated and displayed in the homepage sidebar.</p>
+      <% end %>
+    </div>
+
     <div class="mt-4">
       <%= form.submit class: "c-btn c-btn--primary" %>
     </div>

--- a/app/views/sidebars/_homepage_content.html.erb
+++ b/app/views/sidebars/_homepage_content.html.erb
@@ -25,6 +25,30 @@
     <% end %>
   <% end %>
 
+  <% if @upcoming_events.any? %>
+    <section class="crayons-card crayons-card--secondary crayons-layout__content" id="upcoming-events">
+      <header class="crayons-card__header">
+        <h3 class="crayons-subtitle-2">
+          <%= t("views.main.side.upcoming_events") %>
+        </h3>
+      </header>
+      <div>
+        <% @upcoming_events.each do |event| %>
+          <a class="crayons-link crayons-link--contentful" href="<%= event_path(event.event_name_slug, event.event_variation_slug) %>">
+            <%= truncate(event.title, length: 100) %>
+            <div class="crayons-link__secondary">
+              <% if event.start_time <= Time.current && event.end_time >= Time.current %>
+                <span class="c-indicator c-indicator--error fw-bold">LIVE</span>
+              <% else %>
+                <%= event.start_time.to_fs(:short) %>
+              <% end %>
+            </div>
+          </a>
+        <% end %>
+      </div>
+    </section>
+  <% end %>
+
   <% if @billboards.second %>
     <%= render partial: "shared/billboard", locals: { billboard: @billboards.second, data_context_type: BillboardEvent::CONTEXT_TYPE_HOME } %>
   <% end %>

--- a/app/views/sidebars/_homepage_content.html.erb
+++ b/app/views/sidebars/_homepage_content.html.erb
@@ -25,7 +25,7 @@
     <% end %>
   <% end %>
 
-  <% if @upcoming_events.any? %>
+  <% if @upcoming_events&.any? %>
     <section class="crayons-card crayons-card--secondary crayons-layout__content" id="upcoming-events">
       <header class="crayons-card__header">
         <h3 class="crayons-subtitle-2">
@@ -40,7 +40,7 @@
               <% if event.start_time <= Time.current && event.end_time >= Time.current %>
                 <span class="c-indicator c-indicator--error fw-bold">LIVE</span>
               <% else %>
-                <%= event.start_time.to_fs(:short) %>
+                <%= event.start_time.in_time_zone.strftime("%b %-d, %H:%M %Z") %>
               <% end %>
             </div>
           </a>

--- a/config/locales/views/main/en.yml
+++ b/config/locales/views/main/en.yml
@@ -52,6 +52,7 @@ en:
         Videos: Videos
       side:
         active_discussions: "Active discussions"
+        upcoming_events: "Upcoming events"
         listings:
           heading: Listings
           all: See all

--- a/config/locales/views/main/fr.yml
+++ b/config/locales/views/main/fr.yml
@@ -50,6 +50,7 @@ fr:
         Terms of use: Terms of Use
         Videos: Videos
       side:
+        upcoming_events: "Événements à venir"
         listings:
           heading: Listings
           all: Tout voir

--- a/config/locales/views/main/pt.yml
+++ b/config/locales/views/main/pt.yml
@@ -51,6 +51,7 @@ pt:
         Videos: Vídeos
       side:
         active_discussions: "Discussões ativas"
+        upcoming_events: "Próximos eventos"
         listings:
           heading: Anúncios
           all: Ver todos

--- a/db/migrate/20260608123500_add_elevated_to_events.rb
+++ b/db/migrate/20260608123500_add_elevated_to_events.rb
@@ -1,0 +1,5 @@
+class AddElevatedToEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_column :events, :elevated, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260608151500_add_index_on_elevated_upcoming_events.rb
+++ b/db/migrate/20260608151500_add_index_on_elevated_upcoming_events.rb
@@ -1,0 +1,10 @@
+class AddIndexOnElevatedUpcomingEvents < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :events, [:end_time, :start_time],
+              where: "published = TRUE AND elevated = TRUE",
+              name: "index_events_on_end_time_and_start_time_elevated_published",
+              algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_06_05_171500) do
+ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -740,6 +740,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_05_171500) do
     t.datetime "created_at", null: false
     t.jsonb "data", default: {}
     t.text "description"
+    t.boolean "elevated", default: false, null: false
     t.datetime "end_time", null: false
     t.string "event_name_slug", null: false
     t.string "event_variation_slug", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
+ActiveRecord::Schema[7.0].define(version: 2026_06_08_151500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -213,7 +213,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
     t.string "search_optimized_description_replacement"
     t.string "search_optimized_title_preamble"
     t.vector "semantic_embedding", limit: 768
-    t.jsonb "semantic_interests", default: {}
     t.boolean "show_comments", default: true
     t.text "slug"
     t.string "social_image"
@@ -255,7 +254,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
     t.index ["published"], name: "index_articles_on_published"
     t.index ["published_at"], name: "index_articles_on_published_at"
     t.index ["reading_list_document"], name: "index_articles_on_reading_list_document", using: :gin
-    t.index ["semantic_interests"], name: "index_articles_on_semantic_interests", using: :gin
+    t.index ["semantic_embedding"], name: "index_articles_on_semantic_embedding", opclass: :vector_cosine_ops, using: :hnsw
     t.index ["slug", "user_id"], name: "index_articles_on_slug_and_user_id", unique: true
     t.index ["subforem_id", "published", "score", "published_at"], name: "index_articles_on_subforem_published_score_published_at"
     t.index ["subforem_id"], name: "index_articles_on_subforem_id"
@@ -438,7 +437,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
     t.text "processed_html"
     t.boolean "published"
     t.string "slug"
-    t.text "tags_array", default: [], array: true
     t.string "title"
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "user_id"
@@ -446,7 +444,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
     t.index ["classified_listing_category_id"], name: "index_classified_listings_on_classified_listing_category_id"
     t.index ["organization_id"], name: "index_classified_listings_on_organization_id"
     t.index ["published"], name: "index_classified_listings_on_published"
-    t.index ["tags_array"], name: "index_classified_listings_on_tags_array", using: :gin
     t.index ["user_id"], name: "index_classified_listings_on_user_id"
   end
 
@@ -566,11 +563,9 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
     t.datetime "created_at", null: false
     t.text "processed_html", null: false
     t.bigint "tag_id"
-    t.bigint "trend_id"
     t.datetime "updated_at", null: false
     t.index ["article_id"], name: "index_context_notes_on_article_id"
     t.index ["tag_id"], name: "index_context_notes_on_tag_id"
-    t.index ["trend_id"], name: "index_context_notes_on_trend_id"
   end
 
   create_table "context_notifications", force: :cascade do |t|
@@ -754,6 +749,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
     t.integer "type_of", default: 0
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.index ["end_time", "start_time"], name: "index_events_on_end_time_and_start_time_elevated_published", where: "((published = true) AND (elevated = true))"
     t.index ["event_name_slug", "event_variation_slug"], name: "index_events_on_event_name_slug_and_event_variation_slug", unique: true
     t.index ["organization_id"], name: "index_events_on_organization_id"
     t.index ["tags_array"], name: "index_events_on_tags_array", using: :gin
@@ -790,10 +786,8 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
     t.integer "recent_tag_count_min", default: 0
     t.float "recently_active_past_day_bonus_weight", default: 0.0, null: false
     t.float "score_weight", default: 1.0
-    t.float "semantic_match_weight", default: 0.0
     t.float "semantic_similarity_weight", default: 0.0, null: false
     t.float "shuffle_weight", default: 0.0, null: false
-    t.integer "status_target", default: 0
     t.float "status_weight", default: 0.0, null: false
     t.float "subforem_follow_weight", default: 0.0, null: false
     t.float "tag_follow_weight", default: 1.0
@@ -1053,13 +1047,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
     t.index ["tag_name", "url"], name: "index_liquid_embed_references_on_tag_name_and_url"
   end
 
-  create_table "media_sources", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.string "display_url", null: false
-    t.string "input_url", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "media_stores", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "media_type", default: 0, null: false
@@ -1080,7 +1067,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
 
   create_table "navigation_links", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.text "description"
     t.boolean "display_only_when_signed_in", default: false
     t.integer "display_to", default: 0, null: false
     t.string "icon"
@@ -1257,7 +1243,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
     t.bigint "user_id"
     t.bigint "viewable_id"
     t.string "viewable_type"
-    t.index ["article_id", "created_at"], name: "index_page_views_on_article_id_and_created_at"
     t.index ["article_id"], name: "index_page_views_on_article_id"
     t.index ["created_at"], name: "index_page_views_on_created_at"
     t.index ["user_id"], name: "index_page_views_on_user_id"
@@ -1432,7 +1417,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
   create_table "polls", force: :cascade do |t|
     t.bigint "article_id"
     t.datetime "created_at", precision: nil, null: false
-    t.boolean "optional", default: false, null: false
     t.integer "poll_options_count", default: 0, null: false
     t.integer "poll_skips_count", default: 0, null: false
     t.integer "poll_votes_count", default: 0, null: false
@@ -1487,7 +1471,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
     t.datetime "created_at", null: false
     t.jsonb "data", default: {}, null: false
     t.string "location"
-    t.string "social_image"
     t.text "summary"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
@@ -1608,6 +1591,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
     t.datetime "updated_at", null: false
     t.text "value"
     t.string "var", null: false
+    t.index ["subforem_id"], name: "index_settings_authentications_on_subforem_id"
     t.index ["var", "subforem_id"], name: "index_settings_authentications_on_var_and_subforem_id", unique: true
   end
 
@@ -1617,6 +1601,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
     t.datetime "updated_at", null: false
     t.text "value"
     t.string "var", null: false
+    t.index ["subforem_id"], name: "index_settings_campaigns_on_subforem_id"
     t.index ["var", "subforem_id"], name: "index_settings_campaigns_on_var_and_subforem_id", unique: true
   end
 
@@ -1626,6 +1611,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
     t.datetime "updated_at", null: false
     t.text "value"
     t.string "var", null: false
+    t.index ["subforem_id"], name: "index_settings_communities_on_subforem_id"
     t.index ["var", "subforem_id"], name: "index_settings_communities_on_var_and_subforem_id", unique: true
   end
 
@@ -1635,6 +1621,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
     t.datetime "updated_at", null: false
     t.text "value"
     t.string "var", null: false
+    t.index ["subforem_id"], name: "index_settings_rate_limits_on_subforem_id"
     t.index ["var", "subforem_id"], name: "index_settings_rate_limits_on_var_and_subforem_id", unique: true
   end
 
@@ -1644,6 +1631,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
     t.datetime "updated_at", null: false
     t.text "value"
     t.string "var", null: false
+    t.index ["subforem_id"], name: "index_settings_smtp_on_subforem_id"
     t.index ["var", "subforem_id"], name: "index_settings_smtp_on_var_and_subforem_id", unique: true
   end
 
@@ -1653,15 +1641,17 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
     t.datetime "updated_at", null: false
     t.text "value"
     t.string "var", null: false
+    t.index ["subforem_id"], name: "index_settings_user_experiences_on_subforem_id"
     t.index ["var", "subforem_id"], name: "index_settings_user_experiences_on_var_and_subforem_id", unique: true
   end
 
   create_table "site_configs", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
-    t.integer "subforem_id"
+    t.bigint "subforem_id"
     t.datetime "updated_at", precision: nil, null: false
     t.text "value"
     t.string "var", null: false
+    t.index ["subforem_id"], name: "index_site_configs_on_subforem_id"
     t.index ["var", "subforem_id"], name: "index_site_configs_on_var_and_subforem_id", unique: true
   end
 
@@ -1724,14 +1714,10 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
   end
 
   create_table "tag_subforem_relationships", force: :cascade do |t|
-    t.string "bg_color_hex"
     t.datetime "created_at", null: false
-    t.string "pretty_name"
-    t.text "short_summary"
     t.bigint "subforem_id", null: false
     t.boolean "supported", default: true
     t.bigint "tag_id", null: false
-    t.string "text_color_hex"
     t.datetime "updated_at", null: false
     t.index ["subforem_id"], name: "index_tag_subforem_relationships_on_subforem_id"
     t.index ["tag_id"], name: "index_tag_subforem_relationships_on_tag_id"
@@ -1866,6 +1852,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
     t.jsonb "recently_viewed_articles", default: []
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.index ["interest_embedding"], name: "index_user_activities_on_interest_embedding", opclass: :vector_cosine_ops, using: :hnsw
     t.index ["user_id"], name: "index_user_activities_on_user_id"
   end
 
@@ -2091,7 +2078,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_08_123500) do
   end
 
   create_table "users_settings", force: :cascade do |t|
-    t.boolean "auto_relocation_enabled", default: true, null: false
     t.string "brand_color1", default: "#000000"
     t.integer "config_font", default: 0, null: false
     t.integer "config_homepage_feed", default: 0, null: false

--- a/spec/requests/admin/events_spec.rb
+++ b/spec/requests/admin/events_spec.rb
@@ -122,6 +122,14 @@ RSpec.describe "Admin::Events", type: :request do
         expect(Event.last.manual_broadcast_end).to eq(true)
       end
     end
+
+    context "with elevated config" do
+      let(:attributes_with_elevated) { valid_attributes.merge(elevated: true) }
+      it "permits and sets the elevated flag" do
+        post admin_events_path, params: { event: attributes_with_elevated }
+        expect(Event.last.elevated).to eq(true)
+      end
+    end
   end
 
   describe "PATCH /admin/content_manager/events/:id/end_broadcast" do

--- a/spec/requests/sidebars_spec.rb
+++ b/spec/requests/sidebars_spec.rb
@@ -123,5 +123,40 @@ RSpec.describe "Sidebars" do
         expect(response.body).not_to include(CGI.escapeHTML(second_article.title))
       end
     end
+
+    context "when upcoming elevated events exist" do
+      let!(:elevated_upcoming_event) do
+        create(:event, title: "Elevated Upcoming Event", elevated: true, published: true, start_time: 1.hour.from_now, end_time: 2.hours.from_now)
+      end
+      let!(:non_elevated_upcoming_event) do
+        create(:event, title: "Non-Elevated Upcoming Event", elevated: false, published: true, start_time: 1.hour.from_now, end_time: 2.hours.from_now)
+      end
+      let!(:elevated_past_event) do
+        create(:event, title: "Elevated Past Event", elevated: true, published: true, start_time: 2.days.ago, end_time: 1.day.ago)
+      end
+      let!(:unpublished_elevated_event) do
+        create(:event, title: "Unpublished Elevated Event", elevated: true, published: false, start_time: 1.hour.from_now, end_time: 2.hours.from_now)
+      end
+
+      it "includes elevated upcoming event" do
+        get "/sidebars/home"
+        expect(response.body).to include("Elevated Upcoming Event")
+      end
+
+      it "does not include non-elevated upcoming event" do
+        get "/sidebars/home"
+        expect(response.body).not_to include("Non-Elevated Upcoming Event")
+      end
+
+      it "does not include elevated past event" do
+        get "/sidebars/home"
+        expect(response.body).not_to include("Elevated Past Event")
+      end
+
+      it "does not include unpublished elevated event" do
+        get "/sidebars/home"
+        expect(response.body).not_to include("Unpublished Elevated Event")
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds a new 'Upcoming Events' card to the right-hand sidebar below 'Active Discussions' as requested. It displays all published, elevated events that have not ended yet, with timezone/timing information.