### PR TITLE
Remove obsolete Action View and Production Encrypted Secrets configs to ease Rails 8 transition

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -52,15 +52,10 @@ module PracticalDeveloper
     # Therefore we disable "per_form_csrf_tokens" for the time being.
     config.action_controller.per_form_csrf_tokens = false
 
-    ## Rails 6.0
-    # Determines whether forms are generated with a hidden tag that forces older versions of Internet
-    # Explorer to submit forms encoded in UTF-8
-    config.action_view.default_enforce_utf8 = true
-
     ## Rails 6.1
     # Make `form_with` generate non-remote forms by default. We want this to be true as it was the default in 5.2
     config.action_view.form_with_generates_remote_forms = true
-    
+
     # Disable partial writes to avoid issues with strong_migrations
     config.active_record.partial_inserts = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,11 +30,6 @@ Rails.application.configure do
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true
 
-  # Attempt to read encrypted secrets from `config/secrets.yml.enc`.
-  # Requires an encryption key in `ENV["RAILS_MASTER_KEY"]` or
-  # `config/secrets.yml.key`.
-  config.read_encrypted_secrets = true
-
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
@@ -105,7 +100,7 @@ Rails.application.configure do
   ]
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
+  config.log_formatter = Logger::Formatter.new
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     # Use a different logger for distributed setups.

--- a/spec/initializers/framework_defaults_spec.rb
+++ b/spec/initializers/framework_defaults_spec.rb
@@ -1,5 +1,4 @@
-# frozen_string_literal: true
-
+# rubocop:disable RSpec/DescribeClass
 require "rails_helper"
 
 describe "Framework Defaults 7.0 Upgrade Verification" do
@@ -12,4 +11,15 @@ describe "Framework Defaults 7.0 Upgrade Verification" do
     # Verify key generator uses SHA1 for backward session/cookie compatibility
     expect(Rails.application.config.active_support.key_generator_hash_digest_class).to eq(OpenSSL::Digest::SHA1)
   end
+
+  it "does not enable obsolete default_enforce_utf8" do
+    expect(Rails.application.config.action_view.default_enforce_utf8).to be(false).or be_nil
+  end
+
+  it "does not enable obsolete read_encrypted_secrets" do
+    config = Rails.application.config
+    val = config.respond_to?(:read_encrypted_secrets) ? config.read_encrypted_secrets : nil
+    expect(val).to be(false).or be_nil
+  end
 end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
### Summary
This PR cleans up obsolete/deprecated Rails framework configurations to prepare the Forem codebase for Rails 8 and intermediate upgrades (e.g., 7.1/7.2).

### Changes
1. **Remove `config.action_view.default_enforce_utf8`**: Removed from [config/application.rb](file:///Users/benhalpern/dev/forem/config/application.rb). This configuration is deprecated and removed in Rails 7.1. Modern browsers submit UTF-8 natively, so the legacy hidden form tag helper is no longer needed.
2. **Remove `config.read_encrypted_secrets`**: Removed from [config/environments/production.rb](file:///Users/benhalpern/dev/forem/config/environments/production.rb). This option is obsolete in Rails 8.0. Forem manages secrets using standard environment variables and `config/secrets.yml`, so it doesn't use `config/secrets.yml.enc`.
3. **Correct Logger Formatter namespace**: Changed `::Logger::Formatter.new` to `Logger::Formatter.new` in [config/environments/production.rb](file:///Users/benhalpern/dev/forem/config/environments/production.rb).
4. **Specs**: Added verification specs in [spec/initializers/framework_defaults_spec.rb](file:///Users/benhalpern/dev/forem/spec/initializers/framework_defaults_spec.rb) to ensure these deprecated options are not re-enabled in the future.

### Verification
- Ran `bundle exec rspec spec/initializers/framework_defaults_spec.rb` -> 3 passing, 0 failures.
- Ran `bundle exec rubocop` on the modified files -> 0 offenses detected.