### PR TITLE
Enable safe Rails 7.1 framework defaults to prepare for upgrade

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -65,7 +65,7 @@ Rails.application.config.action_controller.allow_deprecated_parameters_hash_equa
 # state which matches what was committed to the database, typically the last
 # instance to save.
 #++
-Rails.application.config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction = false
+# Rails.application.config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction = false
 
 ###
 # Configures SQLite with a strict strings mode, which disables double-quoted string literals.
@@ -138,7 +138,7 @@ Rails.application.config.active_record.query_log_tags_format = :sqlcommenter
 # servers, first deploy without changing the serializer, then set the serializer
 # in a subsequent deploy.
 #++
-Rails.application.config.active_support.message_serializer = :json_allow_marshal
+# Rails.application.config.active_support.message_serializer = :json_allow_marshal
 
 ###
 # Enable a performance optimization that serializes message data and metadata
@@ -151,7 +151,7 @@ Rails.application.config.active_support.message_serializer = :json_allow_marshal
 # leave this optimization off on the first deploy, then enable it on a
 # subsequent deploy.
 #++
-Rails.application.config.active_support.use_message_serializer_for_metadata = true
+# Rails.application.config.active_support.use_message_serializer_for_metadata = true
 
 ###
 # Set the maximum size for Rails log files.
@@ -175,7 +175,7 @@ Rails.application.config.active_record.raise_on_assign_to_attr_readonly = true
 # The previous behavior was to validate the presence of the parent record, which performed an extra query
 # to get the parent every time the child record was updated, even when parent has not changed.
 #++
-Rails.application.config.active_record.belongs_to_required_validates_foreign_key = false
+# Rails.application.config.active_record.belongs_to_required_validates_foreign_key = false
 
 ###
 # Enable precompilation of `config.filter_parameters`. Precompilation can
@@ -188,7 +188,7 @@ Rails.application.config.precompile_filter_parameters = true
 # The previous behavior was to only run the callbacks on the first copy of a record
 # if there were multiple copies of the same record enrolled in the transaction.
 #++
-Rails.application.config.active_record.before_committed_on_all_records = true
+# Rails.application.config.active_record.before_committed_on_all_records = true
 
 ###
 # Disable automatic column serialization into YAML.
@@ -214,12 +214,12 @@ Rails.application.config.active_record.before_committed_on_all_records = true
 # This matches the behaviour of all other callbacks.
 # In previous versions of Rails, they ran in the inverse order.
 #++
-Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true
+# Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true
 
 ###
 # Whether a `transaction` block is committed or rolled back when exited via `return`, `break` or `throw`.
 #++
-Rails.application.config.active_record.commit_transaction_on_non_local_return = true
+# Rails.application.config.active_record.commit_transaction_on_non_local_return = true
 
 ###
 # Controls when to generate a value for <tt>has_secure_token</tt> declarations.

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -23,19 +23,19 @@
 # Remove the default X-Download-Options headers since it is used only by Internet Explorer.
 # If you need to support Internet Explorer, add back `"X-Download-Options" => "noopen"`.
 #++
-# Rails.application.config.action_dispatch.default_headers = {
-#   "X-Frame-Options" => "SAMEORIGIN",
-#   "X-XSS-Protection" => "0",
-#   "X-Content-Type-Options" => "nosniff",
-#   "X-Permitted-Cross-Domain-Policies" => "none",
-#   "Referrer-Policy" => "strict-origin-when-cross-origin"
-# }
+Rails.application.config.action_dispatch.default_headers = {
+  "X-Frame-Options" => "SAMEORIGIN",
+  "X-XSS-Protection" => "0",
+  "X-Content-Type-Options" => "nosniff",
+  "X-Permitted-Cross-Domain-Policies" => "none",
+  "Referrer-Policy" => "strict-origin-when-cross-origin"
+}
 
 ###
 # Do not treat an `ActionController::Parameters` instance
 # as equal to an equivalent `Hash` by default.
 #++
-# Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
+Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
 
 ###
 # Active Record Encryption now uses SHA-256 as its hash digest algorithm.
@@ -65,7 +65,7 @@
 # state which matches what was committed to the database, typically the last
 # instance to save.
 #++
-# Rails.application.config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction = false
+Rails.application.config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction = false
 
 ###
 # Configures SQLite with a strict strings mode, which disables double-quoted string literals.
@@ -81,7 +81,7 @@
 ###
 # Disable deprecated singular associations names.
 #++
-# Rails.application.config.active_record.allow_deprecated_singular_associations_name = false
+Rails.application.config.active_record.allow_deprecated_singular_associations_name = false
 
 ###
 # Enable the Active Job `BigDecimal` argument serializer, which guarantees
@@ -101,14 +101,14 @@
 # Options are `true`, and `false`. If `false`, the exception will be reported
 # as `handled` and logged instead.
 #++
-# Rails.application.config.active_support.raise_on_invalid_cache_expiration_time = true
+Rails.application.config.active_support.raise_on_invalid_cache_expiration_time = true
 
 ###
 # Specify whether Query Logs will format tags using the SQLCommenter format
 # (https://open-telemetry.github.io/opentelemetry-sqlcommenter/), or using the legacy format.
 # Options are `:legacy` and `:sqlcommenter`.
 #++
-# Rails.application.config.active_record.query_log_tags_format = :sqlcommenter
+Rails.application.config.active_record.query_log_tags_format = :sqlcommenter
 
 ###
 # Specify the default serializer used by `MessageEncryptor` and `MessageVerifier`
@@ -138,7 +138,7 @@
 # servers, first deploy without changing the serializer, then set the serializer
 # in a subsequent deploy.
 #++
-# Rails.application.config.active_support.message_serializer = :json_allow_marshal
+Rails.application.config.active_support.message_serializer = :json_allow_marshal
 
 ###
 # Enable a performance optimization that serializes message data and metadata
@@ -151,7 +151,7 @@
 # leave this optimization off on the first deploy, then enable it on a
 # subsequent deploy.
 #++
-# Rails.application.config.active_support.use_message_serializer_for_metadata = true
+Rails.application.config.active_support.use_message_serializer_for_metadata = true
 
 ###
 # Set the maximum size for Rails log files.
@@ -159,36 +159,36 @@
 # `config.load_defaults 7.1` does not set this value for environments other than
 # development and test.
 #++
-# if Rails.env.local?
-#   Rails.application.config.log_file_size = 100 * 1024 * 1024
-# end
+if Rails.env.local?
+  Rails.application.config.log_file_size = 100 * 1024 * 1024
+end
 
 ###
 # Enable raising on assignment to attr_readonly attributes. The previous
 # behavior would allow assignment but silently not persist changes to the
 # database.
 #++
-# Rails.application.config.active_record.raise_on_assign_to_attr_readonly = true
+Rails.application.config.active_record.raise_on_assign_to_attr_readonly = true
 
 ###
 # Enable validating only parent-related columns for presence when the parent is mandatory.
 # The previous behavior was to validate the presence of the parent record, which performed an extra query
 # to get the parent every time the child record was updated, even when parent has not changed.
 #++
-# Rails.application.config.active_record.belongs_to_required_validates_foreign_key = false
+Rails.application.config.active_record.belongs_to_required_validates_foreign_key = false
 
 ###
 # Enable precompilation of `config.filter_parameters`. Precompilation can
 # improve filtering performance, depending on the quantity and types of filters.
 #++
-# Rails.application.config.precompile_filter_parameters = true
+Rails.application.config.precompile_filter_parameters = true
 
 ###
 # Enable before_committed! callbacks on all enrolled records in a transaction.
 # The previous behavior was to only run the callbacks on the first copy of a record
 # if there were multiple copies of the same record enrolled in the transaction.
 #++
-# Rails.application.config.active_record.before_committed_on_all_records = true
+Rails.application.config.active_record.before_committed_on_all_records = true
 
 ###
 # Disable automatic column serialization into YAML.
@@ -214,17 +214,17 @@
 # This matches the behaviour of all other callbacks.
 # In previous versions of Rails, they ran in the inverse order.
 #++
-# Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true
+Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true
 
 ###
 # Whether a `transaction` block is committed or rolled back when exited via `return`, `break` or `throw`.
 #++
-# Rails.application.config.active_record.commit_transaction_on_non_local_return = true
+Rails.application.config.active_record.commit_transaction_on_non_local_return = true
 
 ###
 # Controls when to generate a value for <tt>has_secure_token</tt> declarations.
 #++
-# Rails.application.config.active_record.generate_secure_token_on = :initialize
+Rails.application.config.active_record.generate_secure_token_on = :initialize
 
 ###
 # ** Please read carefully, this must be configured in config/application.rb **
@@ -250,7 +250,7 @@
 #
 # In previous versions of Rails, Action View always used `Rails::HTML4::Sanitizer` as its vendor.
 #++
-# Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
+Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
 
 ###
 # Configure Action Text to use an HTML5 standards-compliant sanitizer when it is supported on your
@@ -267,7 +267,7 @@
 # Configure the log level used by the DebugExceptions middleware when logging
 # uncaught exceptions during requests.
 #++
-# Rails.application.config.action_dispatch.debug_exception_log_level = :error
+Rails.application.config.action_dispatch.debug_exception_log_level = :error
 
 ###
 # Configure the test helpers in Action View, Action Dispatch, and rails-dom-testing to use HTML5
@@ -277,9 +277,9 @@
 #
 # In previous versions of Rails, these test helpers always used an HTML4 parser.
 #++
-# Rails.application.config.dom_testing_default_html_version = :html5
+Rails.application.config.dom_testing_default_html_version = :html5
 
 ###
 # Raise ActionController::ActionNotFound when a callback references a missing action.
 #++
-# Rails.application.config.action_controller.raise_on_missing_callback_actions = true
+Rails.application.config.action_controller.raise_on_missing_callback_actions = true

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -282,4 +282,4 @@ Rails.application.config.dom_testing_default_html_version = :html5
 ###
 # Raise ActionController::ActionNotFound when a callback references a missing action.
 #++
-Rails.application.config.action_controller.raise_on_missing_callback_actions = true
+# Rails.application.config.action_controller.raise_on_missing_callback_actions = true

--- a/spec/initializers/framework_defaults_spec.rb
+++ b/spec/initializers/framework_defaults_spec.rb
@@ -27,5 +27,29 @@ describe "Framework Defaults 7.1 Upgrade Preparation" do
   it "has the new_framework_defaults_7_1.rb initializer file" do
     expect(File.exist?(Rails.root.join("config/initializers/new_framework_defaults_7_1.rb"))).to be(true)
   end
+
+  it "enables key Rails 7.1 defaults to ease the upgrade path" do
+    config = Rails.application.config
+
+    expect(config.action_dispatch.default_headers).not_to have_key("X-Download-Options")
+    expect(config.action_controller.allow_deprecated_parameters_hash_equality).to be(false)
+    expect(config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction).to be(false)
+    expect(config.active_record.allow_deprecated_singular_associations_name).to be(false)
+    expect(config.active_support.raise_on_invalid_cache_expiration_time).to be(true)
+    expect(config.active_record.query_log_tags_format).to eq(:sqlcommenter)
+    expect(config.active_support.message_serializer).to eq(:json_allow_marshal)
+    expect(config.active_support.use_message_serializer_for_metadata).to be(true)
+    expect(config.active_record.raise_on_assign_to_attr_readonly).to be(true)
+    expect(config.active_record.belongs_to_required_validates_foreign_key).to be(false)
+    expect(config.precompile_filter_parameters).to be(true)
+    expect(config.active_record.before_committed_on_all_records).to be(true)
+    expect(config.active_record.run_after_transaction_callbacks_in_order_defined).to be(true)
+    expect(config.active_record.commit_transaction_on_non_local_return).to be(true)
+    expect(config.active_record.generate_secure_token_on).to eq(:initialize)
+    expect(ActionView::Base.sanitizer_vendor).to eq(Rails::HTML::Sanitizer.best_supported_vendor)
+    expect(config.action_dispatch.debug_exception_log_level).to eq(:error)
+    expect(config.dom_testing_default_html_version).to eq(:html5)
+    expect(config.action_controller.raise_on_missing_callback_actions).to be(true)
+  end
 end
 # rubocop:enable RSpec/DescribeClass

--- a/spec/initializers/framework_defaults_spec.rb
+++ b/spec/initializers/framework_defaults_spec.rb
@@ -33,18 +33,18 @@ describe "Framework Defaults 7.1 Upgrade Preparation" do
 
     expect(config.action_dispatch.default_headers).not_to have_key("X-Download-Options")
     expect(config.action_controller.allow_deprecated_parameters_hash_equality).to be(false)
-    expect(config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction).to be(false)
+    expect(config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction).to be_nil.or be(true) # reverted to 7.0 default
     expect(config.active_record.allow_deprecated_singular_associations_name).to be(false)
     expect(config.active_support.raise_on_invalid_cache_expiration_time).to be(true)
     expect(config.active_record.query_log_tags_format).to eq(:sqlcommenter)
-    expect(config.active_support.message_serializer).to eq(:json_allow_marshal)
-    expect(config.active_support.use_message_serializer_for_metadata).to be(true)
+    expect(config.active_support.message_serializer).to be_nil.or eq(:marshal) # reverted to 7.0 default
+    expect(config.active_support.use_message_serializer_for_metadata).to be_nil.or be(false) # reverted to 7.0 default
     expect(config.active_record.raise_on_assign_to_attr_readonly).to be(true)
-    expect(config.active_record.belongs_to_required_validates_foreign_key).to be(false)
+    expect(config.active_record.belongs_to_required_validates_foreign_key).to be(true) # reverted to 7.0 default
     expect(config.precompile_filter_parameters).to be(true)
-    expect(config.active_record.before_committed_on_all_records).to be(true)
-    expect(config.active_record.run_after_transaction_callbacks_in_order_defined).to be(true)
-    expect(config.active_record.commit_transaction_on_non_local_return).to be(true)
+    expect(config.active_record.before_committed_on_all_records).to be_nil.or be(false) # reverted to 7.0 default
+    expect(config.active_record.run_after_transaction_callbacks_in_order_defined).to be_nil.or be(false) # reverted to 7.0 default
+    expect(config.active_record.commit_transaction_on_non_local_return).to be_nil.or be(false) # reverted to 7.0 default
     expect(config.active_record.generate_secure_token_on).to eq(:initialize)
     expect(ActionView::Base.sanitizer_vendor).to eq(Rails::HTML::Sanitizer.best_supported_vendor)
     expect(config.action_dispatch.debug_exception_log_level).to eq(:error)

--- a/spec/initializers/framework_defaults_spec.rb
+++ b/spec/initializers/framework_defaults_spec.rb
@@ -49,7 +49,7 @@ describe "Framework Defaults 7.1 Upgrade Preparation" do
     expect(ActionView::Base.sanitizer_vendor).to eq(Rails::HTML::Sanitizer.best_supported_vendor)
     expect(config.action_dispatch.debug_exception_log_level).to eq(:error)
     expect(config.dom_testing_default_html_version).to eq(:html5)
-    expect(config.action_controller.raise_on_missing_callback_actions).to be(true)
+    expect(config.action_controller.raise_on_missing_callback_actions).to be_nil.or be(false) # reverted to 7.0 default
   end
 end
 # rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
This PR uncomments and configures a subset of safe and standard Rails 7.1 framework defaults in the `new_framework_defaults_7_1.rb` initializer. This is a critical intermediate step preparing the application to safely load all Rails 7.1 defaults (`config.load_defaults 7.1`), which in turn paves the way for the Rails 8 upgrade.