### PR TITLE
Enable raise_on_missing_callback_actions framework default to prepare for Rails 8

### DIFF
--- a/app/controllers/admin/badge_automations_controller.rb
+++ b/app/controllers/admin/badge_automations_controller.rb
@@ -4,7 +4,7 @@ module Admin
     helper ScheduledAutomationsHelper
 
     before_action :set_badge
-    before_action :set_automation, only: %i[show edit update destroy toggle_enabled]
+    before_action :set_automation, only: %i[edit update destroy toggle_enabled]
     before_action :set_organizations
 
     def index

--- a/app/controllers/concerns/development_dependency_checks.rb
+++ b/app/controllers/concerns/development_dependency_checks.rb
@@ -4,7 +4,7 @@ module DevelopmentDependencyChecks
   extend ActiveSupport::Concern
 
   included do
-    before_action :verify_sidekiq_running, only: %i[index show], if: proc { Rails.env.development? }
+    before_action :verify_sidekiq_running, if: -> { Rails.env.development? && %w[index show].include?(action_name) }
   end
 
   private

--- a/app/controllers/notifications/counts_controller.rb
+++ b/app/controllers/notifications/counts_controller.rb
@@ -1,6 +1,6 @@
 module Notifications
   class CountsController < ApplicationController
-    before_action :current_user_by_token, only: [:show]
+    before_action :current_user_by_token, only: [:index]
 
     def index
       notifications = current_user ? current_user.notifications.from_subforem : Notification.none

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -282,4 +282,4 @@ Rails.application.config.dom_testing_default_html_version = :html5
 ###
 # Raise ActionController::ActionNotFound when a callback references a missing action.
 #++
-# Rails.application.config.action_controller.raise_on_missing_callback_actions = true
+Rails.application.config.action_controller.raise_on_missing_callback_actions = true

--- a/spec/initializers/framework_defaults_spec.rb
+++ b/spec/initializers/framework_defaults_spec.rb
@@ -49,7 +49,70 @@ describe "Framework Defaults 7.1 Upgrade Preparation" do
     expect(ActionView::Base.sanitizer_vendor).to eq(Rails::HTML::Sanitizer.best_supported_vendor)
     expect(config.action_dispatch.debug_exception_log_level).to eq(:error)
     expect(config.dom_testing_default_html_version).to eq(:html5)
-    expect(config.action_controller.raise_on_missing_callback_actions).to be_nil.or be(false) # reverted to 7.0 default
+    expect(config.action_controller.raise_on_missing_callback_actions).to be(true)
+  end
+
+  it "does not have any controllers with missing callback actions" do
+    # Eager load all classes
+    Rails.application.eager_load!
+
+    # Find all AbstractController::Base subclasses that respond to callback methods
+    controllers = ObjectSpace.each_object(Class).select do |klass|
+      klass < AbstractController::Base && klass.respond_to?(:_process_action_callbacks) && klass.name.present? && !klass.name.start_with?("HTML::")
+    end
+
+    missing_callbacks = []
+
+    controllers.each do |klass|
+      begin
+        controller = klass.new
+      rescue StandardError, ArgumentError
+        controller = nil
+      end
+
+      klass._process_action_callbacks.each do |callback|
+        conditions = (callback.instance_variable_get(:@if) || []) + (callback.instance_variable_get(:@unless) || [])
+        
+        conditions.each do |cond|
+          action_filter = nil
+          if cond.class.name == "AbstractController::Callbacks::ActionFilter"
+            action_filter = cond
+          elsif cond.respond_to?(:target) && cond.target.class.name == "AbstractController::Callbacks::ActionFilter"
+            action_filter = cond.target
+          elsif cond.respond_to?(:instance_variable_get)
+            block = cond.instance_variable_get(:@block)
+            if block && block.class.name == "AbstractController::Callbacks::ActionFilter"
+              action_filter = block
+            end
+          end
+          
+          next unless action_filter
+
+          actions = action_filter.instance_variable_get(:@actions)
+          
+          actions.each do |action|
+            is_available = if controller
+                             controller.available_action?(action)
+                           else
+                             klass.action_methods.include?(action.to_s)
+                           end
+            
+            unless is_available
+              missing_callbacks << {
+                controller: klass.name,
+                filter: callback.filter,
+                action: action
+              }
+            end
+          end
+        end
+      end
+    end
+
+    expect(missing_callbacks).to be_empty, -> {
+      "Found controllers with missing callback actions: " +
+        missing_callbacks.map { |mc| "#{mc[:controller]} has #{mc[:filter]} callback targeting missing action #{mc[:action].inspect}" }.join("; ")
+    }
   end
 end
 # rubocop:enable RSpec/DescribeClass

--- a/spec/initializers/framework_defaults_spec.rb
+++ b/spec/initializers/framework_defaults_spec.rb
@@ -66,43 +66,44 @@ describe "Framework Defaults 7.1 Upgrade Preparation" do
     controllers.each do |klass|
       begin
         controller = klass.new
-      rescue StandardError, ArgumentError
+      rescue StandardError
         controller = nil
       end
 
       klass._process_action_callbacks.each do |callback|
         conditions = (callback.instance_variable_get(:@if) || []) + (callback.instance_variable_get(:@unless) || [])
-        
+
         conditions.each do |cond|
           action_filter = nil
-          if cond.class.name == "AbstractController::Callbacks::ActionFilter"
+          if cond.is_a?(AbstractController::Callbacks::ActionFilter)
             action_filter = cond
-          elsif cond.respond_to?(:target) && cond.target.class.name == "AbstractController::Callbacks::ActionFilter"
+          elsif cond.respond_to?(:target) && cond.target.is_a?(AbstractController::Callbacks::ActionFilter)
             action_filter = cond.target
           elsif cond.respond_to?(:instance_variable_get)
             block = cond.instance_variable_get(:@block)
-            if block && block.class.name == "AbstractController::Callbacks::ActionFilter"
+            if block.is_a?(AbstractController::Callbacks::ActionFilter)
               action_filter = block
             end
           end
-          
+
           next unless action_filter
 
-          actions = action_filter.instance_variable_get(:@actions)
-          
-          actions.each do |action|
-            is_available = if controller
-                             controller.available_action?(action)
-                           else
-                             klass.action_methods.include?(action.to_s)
-                           end
-            
-            unless is_available
-              missing_callbacks << {
-                controller: klass.name,
-                filter: callback.filter,
-                action: action
-              }
+          if controller
+            begin
+              original_val = controller.raise_on_missing_callback_actions
+              controller.raise_on_missing_callback_actions = true
+              action_filter.match?(controller)
+            rescue AbstractController::ActionNotFound => e
+              missing_callbacks << e.message.strip
+            ensure
+              controller.raise_on_missing_callback_actions = original_val
+            end
+          else
+            actions = action_filter.instance_variable_get(:@actions) || []
+            actions.each do |action|
+              unless klass.action_methods.include?(action.to_s)
+                missing_callbacks << "The #{action} action could not be found for #{callback.filter} callback on #{klass.name}."
+              end
             end
           end
         end
@@ -110,8 +111,7 @@ describe "Framework Defaults 7.1 Upgrade Preparation" do
     end
 
     expect(missing_callbacks).to be_empty, -> {
-      "Found controllers with missing callback actions: " +
-        missing_callbacks.map { |mc| "#{mc[:controller]} has #{mc[:filter]} callback targeting missing action #{mc[:action].inspect}" }.join("; ")
+      "Found controllers with missing callback actions:\n" + missing_callbacks.join("\n")
     }
   end
 end

--- a/spec/requests/notification_counts_spec.rb
+++ b/spec/requests/notification_counts_spec.rb
@@ -50,5 +50,39 @@ RSpec.describe "NotificationCounts" do
       get "/notifications/counts"
       expect(response.body).to eq("0")
     end
+
+    context "when sign in is passed via token" do
+      it "returns count for the token user (plain mode)" do
+        payload = {
+          user_id: user.id,
+          exp: 5.minutes.from_now.to_i
+        }
+        token = JWT.encode(payload, Rails.application.secret_key_base)
+        
+        follow_instance = following_user.follow(user)
+        Notification.send_new_follower_notification_without_delay(follow_instance)
+
+        get "/notifications/counts", headers: { "Authorization" => "Bearer #{token}" }
+        expect(response.body).to eq("1")
+      end
+
+      it "returns detailed metadata for the token user (detailed mode)" do
+        payload = {
+          user_id: user.id,
+          exp: 5.minutes.from_now.to_i
+        }
+        token = JWT.encode(payload, Rails.application.secret_key_base)
+
+        new_notification = create(:notification, user: user, action: "New Follower", notified_at: 1.day.ago)
+
+        get "/notifications/counts", params: { mode: "detailed" }, headers: { "Authorization" => "Bearer #{token}" }
+        json_response = JSON.parse(response.body)
+        
+        expect(json_response["count"]).to eq(1)
+        expect(json_response["last_notification_id"]).to eq(new_notification.id)
+        expect(json_response["action"]).to eq("New Follower")
+      end
+    end
   end
 end
+


### PR DESCRIPTION
This pull request enables the `raise_on_missing_callback_actions = true` Rails 7.1 framework default to help prepare the codebase for a future Rails 8 upgrade. 

When enabled, Rails raises an error if a controller callback (like `before_action`) references an action in its `:only` or `:except` lists that is not actually defined on the controller. In our audit, we identified and resolved the following three instances:

1. **`DevelopmentDependencyChecks`**: Used `only: %i[index show]`. Since this concern is included in `ApplicationController`, all inheriting controllers (including those without `index` or `show` actions) had this callback set up. We changed it to check `action_name` dynamically inside the `if:` condition (`if: -> { Rails.env.development? && %w[index show].include?(action_name) }`).
2. **`Notifications::CountsController`**: Had `before_action :current_user_by_token, only: [:show]`, but the controller only defines the `index` action and the routes only route `index`. We updated it to target `only: [:index]`.
3. **`Admin::BadgeAutomationsController`**: Had `before_action :set_automation, only: %i[show edit update destroy toggle_enabled]`, but the controller does not define a `show` action. We removed `:show` from the list.

### Verification
- Updated the assertion in `spec/initializers/framework_defaults_spec.rb` to expect `true` for `raise_on_missing_callback_actions`.
- Added a regression spec to `spec/initializers/framework_defaults_spec.rb` that eager loads the application and programmatically asserts that no controller has missing callback actions in its callback chain, preventing future regressions.
- Ran all modified specs successfully.
