### PR TITLE
Fix flaky view user index system spec

### DIFF
--- a/spec/system/user/view_user_index_spec.rb
+++ b/spec/system/user/view_user_index_spec.rb
@@ -76,8 +76,9 @@ RSpec.describe "User index" do
         end
 
         within("#substories .profile-comment-card .profile-comment-row:first-of-type") do
-          comment_date = comment2.readable_publish_date.gsub("  ", " ")
-          expect(page).to have_selector(".comment-date", text: comment_date)
+          comment_date_tz = comment2.readable_publish_date.gsub("  ", " ")
+          comment_date_utc = I18n.l(comment2.created_at.utc, format: :short).gsub("  ", " ")
+          expect(page).to have_selector(".comment-date", text: Regexp.union(comment_date_tz, comment_date_utc))
         end
       end
 


### PR DESCRIPTION
This PR resolves the timezone-related flakiness in spec/system/user/view_user_index_spec.rb by accepting either the localized time formatted in the RSpec thread timezone or formatted in UTC timezone.