### PR TITLE
Use type: keyword argument in ActiveRecord serialize to prepare for Rails 7.2

### DIFF
--- a/app/models/github_issue.rb
+++ b/app/models/github_issue.rb
@@ -7,7 +7,7 @@ class GithubIssue < ApplicationRecord
   PATH_PULL_REQUEST_REGEXP = %r{/pulls/}
   PATH_REPO_REGEXP = %r{.*github.com/repos/}
 
-  serialize :issue_serialized, Hash
+  serialize :issue_serialized, type: Hash
 
   validates :category, inclusion: { in: CATEGORIES }
   validates :url, presence: true, length: { maximum: 400 }, format: API_URL_REGEXP

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -1,7 +1,7 @@
 class GithubRepo < ApplicationRecord
   belongs_to :user
 
-  serialize :info_hash, Hash
+  serialize :info_hash, type: Hash
 
   validates :name, :url, :github_id_code, presence: true
   validates :url, url: true, uniqueness: true


### PR DESCRIPTION
### What does this PR do?
In Rails 7.2, passing the coder class as a positional argument to ActiveRecord `serialize` is deprecated and will be removed. This PR changes the positional `Hash` argument to the keyword argument `type: Hash` in `GithubIssue` and `GithubRepo` to resolve the deprecation warnings and prepare the application for the Rails 7.2 upgrade.

### Deprecation warnings resolved:
```
DEPRECATION WARNING: Passing the class as positional argument is deprecated and will be removed in Rails 7.2.

Please pass the class as a keyword argument:

  serialize :issue_serialized, type: Hash
 (called from <class:GithubIssue> at /Users/benhalpern/dev/forem/app/models/github_issue.rb:10)
```
and
```
DEPRECATION WARNING: Passing the class as positional argument is deprecated and will be removed in Rails 7.2.

Please pass the class as a keyword argument:

  serialize :info_hash, type: Hash
 (called from <class:GithubRepo> at /Users/benhalpern/dev/forem/app/models/github_repo.rb:4)
```

### How to test?
Run the framework defaults spec:
`bundle exec rspec spec/initializers/framework_defaults_spec.rb`
And the Github models spec:
`bundle exec rspec spec/models/github_issue_spec.rb spec/models/github_repo_spec.rb`