### PR TITLE
Prepare for Rails 8: Disable default column serialization into YAML

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -383,11 +383,11 @@ class Article < ApplicationRecord
 
   # @todo Enforce the serialization class (e.g., Articles::CachedEntity)
   # @see https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html#method-i-serialize
-  serialize :cached_user
+  serialize :cached_user, coder: YAML
 
   # @todo Enforce the serialization class (e.g., Articles::CachedEntity)
   # @see https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html#method-i-serialize
-  serialize :cached_organization
+  serialize :cached_organization, coder: YAML
 
   # TODO: [@rhymes] Rename the article column and the trigger name.
   # What was initially meant just for the reading list (filtered using the `reactions` table),

--- a/app/models/github_issue.rb
+++ b/app/models/github_issue.rb
@@ -7,7 +7,7 @@ class GithubIssue < ApplicationRecord
   PATH_PULL_REQUEST_REGEXP = %r{/pulls/}
   PATH_REPO_REGEXP = %r{.*github.com/repos/}
 
-  serialize :issue_serialized, type: Hash
+  serialize :issue_serialized, coder: YAML, type: Hash
 
   validates :category, inclusion: { in: CATEGORIES }
   validates :url, presence: true, length: { maximum: 400 }, format: API_URL_REGEXP

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -1,7 +1,7 @@
 class GithubRepo < ApplicationRecord
   belongs_to :user
 
-  serialize :info_hash, type: Hash
+  serialize :info_hash, coder: YAML, type: Hash
 
   validates :name, :url, :github_id_code, presence: true
   validates :url, url: true, uniqueness: true

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -20,7 +20,7 @@ class Identity < ApplicationRecord
                                                             }
 
   # TODO: [@forem/oss] should this be transitioned to JSON?
-  serialize :auth_data_dump
+  serialize :auth_data_dump, coder: YAML
 
   # Builds an identity from OmniAuth's authentication payload
   def self.build_from_omniauth(provider)

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -1,8 +1,6 @@
 class Poll < ApplicationRecord
   attr_accessor :poll_options_input_array, :poll_options_supplementary_text_array
 
-  serialize :voting_data
-
   # Poll types enum
   enum type_of: {
     single_choice: 0,    # Current behavior - only one option can be selected

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -3,12 +3,12 @@ class Tweet < ApplicationRecord
 
   belongs_to :user, optional: true
 
-  serialize :extended_entities_serialized
-  serialize :full_fetched_object_serialized
-  serialize :hashtags_serialized
-  serialize :media_serialized
-  serialize :mentioned_usernames_serialized
-  serialize :urls_serialized
+  serialize :extended_entities_serialized, coder: YAML
+  serialize :full_fetched_object_serialized, coder: YAML
+  serialize :hashtags_serialized, coder: YAML
+  serialize :media_serialized, coder: YAML
+  serialize :mentioned_usernames_serialized, coder: YAML
+  serialize :urls_serialized, coder: YAML
 
   validates :full_fetched_object_serialized, presence: true
   validates :twitter_id_code, presence: true

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -196,7 +196,7 @@ Rails.application.config.active_record.before_committed_on_all_records = true
 # recommended to explicitly define the serialization method for each column
 # rather than to rely on a global default.
 #++
-# Rails.application.config.active_record.default_column_serializer = nil
+Rails.application.config.active_record.default_column_serializer = nil
 
 ###
 # Enable a performance optimization that serializes Active Record models

--- a/spec/initializers/framework_defaults_spec.rb
+++ b/spec/initializers/framework_defaults_spec.rb
@@ -50,6 +50,7 @@ describe "Framework Defaults 7.1 Upgrade Preparation" do
     active_job_val = config.respond_to?(:active_job) && config.active_job.respond_to?(:use_big_decimal_serializer) ? config.active_job.use_big_decimal_serializer : nil
     expect(active_job_val).to be(false).or be_nil
     expect(config.active_record.marshalling_format_version).to be_nil.or eq(6.1)
+    expect(config.active_record.default_column_serializer).to be_nil
     expect(config.active_record.generate_secure_token_on).to eq(:initialize)
     expect(ActionView::Base.sanitizer_vendor).to eq(Rails::HTML::Sanitizer.best_supported_vendor)
     expect(config.action_dispatch.debug_exception_log_level).to eq(:error)


### PR DESCRIPTION
This PR prepares Forem for the upcoming Rails 8 upgrade by resolving a key deprecation from Rails 7.1.

### Context
In Rails 7.1+, `config.active_record.default_column_serializer` defaults to `nil` (whereas in Rails 7.0 and earlier it defaulted to `YAML`). When it is set to `nil`, calling `serialize` without an explicit coder raises an error because Active Record doesn't know how to serialize the column. 

Additionally, Rails 7.1+ deprecates passing the coder as a positional argument, so coders must be passed explicitly as a keyword argument (e.g. `coder: YAML`).

### Changes
1. Added explicit `coder: YAML` to all existing `serialize` calls in ActiveRecord models:
   - `Article` (`cached_user`, `cached_organization`)
   - `GithubIssue` (`issue_serialized`)
   - `GithubRepo` (`info_hash`)
   - `Identity` (`auth_data_dump`)
   - `Tweet` (`extended_entities_serialized`, `full_fetched_object_serialized`, `hashtags_serialized`, `media_serialized`, `mentioned_usernames_serialized`, `urls_serialized`)
2. Removed a redundant/misleading `serialize :voting_data` declaration in the `Poll` model. `voting_data` is not a database column but rather an instance method returning a Hash.
3. Enabled the new framework default by uncommenting `Rails.application.config.active_record.default_column_serializer = nil` in `config/initializers/new_framework_defaults_7_1.rb`.
4. Added an assertion to `spec/initializers/framework_defaults_spec.rb` to guarantee that this setting remains disabled/nil moving forward.

### Testing
Ran all relevant model spec suites (`Article`, `GithubIssue`, `GithubRepo`, `Identity`, `Poll`, `Tweet`) along with `framework_defaults_spec.rb` and they all pass with 0 failures.
