### PR TITLE
Enable ActiveRecord marshalling format version 7.1

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -207,7 +207,7 @@ Rails.application.config.active_record.default_column_serializer = nil
 # leave this optimization off on the first deploy, then enable it on a
 # subsequent deploy.
 #++
-# Rails.application.config.active_record.marshalling_format_version = 7.1
+Rails.application.config.active_record.marshalling_format_version = 7.1
 
 ###
 # Run `after_commit` and `after_*_commit` callbacks in the order they are defined in a model.

--- a/spec/initializers/framework_defaults_spec.rb
+++ b/spec/initializers/framework_defaults_spec.rb
@@ -49,7 +49,7 @@ describe "Framework Defaults 7.1 Upgrade Preparation" do
     expect(config.active_record.commit_transaction_on_non_local_return).to be(true)
     active_job_val = config.respond_to?(:active_job) && config.active_job.respond_to?(:use_big_decimal_serializer) ? config.active_job.use_big_decimal_serializer : nil
     expect(active_job_val).to be(false).or be_nil
-    expect(config.active_record.marshalling_format_version).to be_nil.or eq(6.1)
+    expect(config.active_record.marshalling_format_version).to eq(7.1)
     expect(config.active_record.default_column_serializer).to be_nil
     expect(config.active_record.generate_secure_token_on).to eq(:initialize)
     expect(ActionView::Base.sanitizer_vendor).to eq(Rails::HTML::Sanitizer.best_supported_vendor)


### PR DESCRIPTION
### Description

As part of the preparation for upgrading to Rails 8, we need to ensure that the application is fully aligned with Rails 7.1 defaults. The `config.active_record.marshalling_format_version = 7.1` setting enables a more efficient and reliable `Marshal` serializer for Active Record models (by implementing `marshal_dump` and `marshal_load` directly on `ActiveRecord::Base`).

This was previously commented out in `config/initializers/new_framework_defaults_7_1.rb` as a precaution for rolling deployments (where old and new code runs side-by-side, potentially reading mismatched marshalling formats from shared cache). Since the Forem application has already been running on Rails 7.1.6 in production for some time, there is no risk of rolling deploy incompatibilities between 7.0 and 7.1 anymore.

This PR uncomments and enables the setting, and updates the upgrade verification test in `spec/initializers/framework_defaults_spec.rb` to expect the new default.

### Impact/Risk Analysis

- **Risk:** Low. The Rails 7.1 upgrade has already completed, and all production servers are running Rails 7.1.6.
- **Verification:** The `spec/initializers/framework_defaults_spec.rb` test suite verifies that all defaults load correctly on boot, and it passes successfully.