### PR TITLE
Enable cache_format_version = 7.1 to align with Rails 7.1 defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -46,8 +46,8 @@ module PracticalDeveloper
     # of existing user sessions and signed/encrypted cookies.
     config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA1
 
-    # Keep cache format version compatible with 7.0 during rolling deploy/rollback phase
-    config.active_support.cache_format_version = 7.0
+    # Enable modern cache format version 7.1
+    config.active_support.cache_format_version = 7.1
 
     ### FRAMEWORK DEFAULT OVERRIDES
     # Override new framework defaults to keep existing behavior.

--- a/spec/initializers/framework_defaults_spec.rb
+++ b/spec/initializers/framework_defaults_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 
 describe "Framework Defaults 7.0 Upgrade Verification" do
   it "uses load_defaults 7.0 but keeps key_generator_hash_digest_class as SHA1" do
-    # Verify load_defaults 7.0 properties are set, except cache format version which is override-compatible with 7.0
+    # Verify load_defaults 7.0 properties are set, with cache format version updated to 7.1
     expect(Rails.application.config.active_support.hash_digest_class).to eq(OpenSSL::Digest::SHA256)
     expect(ActionView::Helpers::UrlHelper.button_to_generates_button_tag).to be(true)
-    expect(ActiveSupport.cache_format_version).to eq(7.0)
+    expect(ActiveSupport.cache_format_version).to eq(7.1)
 
     # Verify key generator uses SHA1 for backward session/cookie compatibility
     expect(Rails.application.config.active_support.key_generator_hash_digest_class).to eq(OpenSSL::Digest::SHA1)


### PR DESCRIPTION
This PR updates the ActiveSupport.cache_format_version from 7.0 to 7.1 in config/application.rb, bringing the application cache configuration fully up-to-date with Rails 7.1 defaults and paving the way for the future Rails 8 upgrade. The corresponding test suite verification in spec/initializers/framework_defaults_spec.rb has also been updated.