### PR TITLE
Enable belongs_to_required_validates_foreign_key and resolve Podcast alias_attribute deprecation

### DIFF
--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -30,7 +30,7 @@ class Podcast < ApplicationRecord
   scope :eager_load_serialized_data, -> { includes(:user, :podcast, :tags) }
 
   alias_attribute :path, :slug
-  alias_attribute :profile_image_url, :image_url
+  alias_method :profile_image_url, :image_url
   alias_attribute :name, :title
 
   def existing_episode(item)

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -175,7 +175,7 @@ Rails.application.config.active_record.raise_on_assign_to_attr_readonly = true
 # The previous behavior was to validate the presence of the parent record, which performed an extra query
 # to get the parent every time the child record was updated, even when parent has not changed.
 #++
-Rails.application.config.active_record.belongs_to_required_validates_foreign_key = false
+Rails.application.config.active_record.belongs_to_required_validates_foreign_key = true
 
 ###
 # Enable precompilation of `config.filter_parameters`. Precompilation can

--- a/spec/initializers/framework_defaults_spec.rb
+++ b/spec/initializers/framework_defaults_spec.rb
@@ -42,7 +42,7 @@ describe "Framework Defaults 7.1 Upgrade Preparation" do
     expect(config.active_record.encryption.hash_digest_class).to eq(OpenSSL::Digest::SHA256)
     expect(config.active_record.encryption.support_sha1_for_non_deterministic_encryption).to be(false)
     expect(config.active_record.raise_on_assign_to_attr_readonly).to be(true)
-    expect(config.active_record.belongs_to_required_validates_foreign_key).to be(false)
+    expect(config.active_record.belongs_to_required_validates_foreign_key).to be(true)
     expect(config.precompile_filter_parameters).to be(true)
     expect(config.active_record.before_committed_on_all_records).to be(true)
     expect(config.active_record.run_after_transaction_callbacks_in_order_defined).to be(true)


### PR DESCRIPTION
This PR implements a clear and safe low-hanging-fruit tweak to help the codebase upgrade towards Rails 8.0:

1. **Enables `belongs_to_required_validates_foreign_key = true`** (the default in Rails 7.1+): This configures Active Record to validate the presence of parent-related columns (e.g., `user_id`) instead of fetching the parent record itself (e.g., `user`). This eliminates redundant database queries during child record updates and aligns us with Rails 7.1+ defaults.
2. **Resolves a Rails 7.2/8.0 Deprecation Warning in `Podcast` model**: The model used `alias_attribute` for `profile_image_url` pointing to `image_url`. Because `image_url` is a CarrierWave uploader helper method rather than an ActiveRecord attribute/column, this triggers a deprecation warning in Rails 7.2 that would raise in Rails 8.0. We replaced it with a clean `alias_method :profile_image_url, :image_url` to silence the warning and maintain compatibility.

### Verification
- Ran `bundle exec rspec spec/initializers/framework_defaults_spec.rb` successfully.
- Ran `bundle exec rspec spec/models/podcast_spec.rb` successfully (which also confirmed the silencing of the deprecation warning).