### PR TITLE
Prepare for Rails 7.2 upgrade by introducing new_framework_defaults_7_2.rb

### DIFF
--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -1,0 +1,35 @@
+# Be sure to restart your server when you modify this file.
+#
+# This file eases your Rails 7.2 framework defaults upgrade.
+#
+# Uncomment each configuration one by one to switch to the new default.
+# Once your application is ready to run with all new defaults, you can remove
+# this file and set the `config.load_defaults` to `7.2`.
+#
+# Read the Guide for Upgrading Ruby on Rails for more info on each option.
+# https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
+
+# Controls whether Active Job's `#perform_later` and similar methods automatically defer
+# the job queuing to after the current Active Record transaction is committed.
+# Rails.application.config.active_job.enqueue_after_transaction_commit = :default
+
+# Adds image/webp to the list of content types Active Storage considers as an image.
+# Guarded with respond_to? since Active Storage is not loaded in Forem.
+# if Rails.application.config.respond_to?(:active_storage)
+#   Rails.application.config.active_storage.web_image_content_types = %w[image/png image/jpeg image/gif image/webp]
+# end
+
+# Enable validation of migration timestamps. When set, an ActiveRecord::InvalidMigrationTimestampError
+# will be raised if the timestamp prefix for a migration is more than a day ahead of the timestamp
+# associated with the current time.
+# Rails.application.config.active_record.validate_migration_timestamps = true
+
+# Controls whether the PostgresqlAdapter should decode dates automatically with manual queries.
+# Rails.application.config.active_record.postgresql_adapter_decode_dates = true
+
+# Enables YJIT as of Ruby 3.3, to bring sizeable performance improvements. If you are
+# deploying to a memory constrained environment you may want to set this to `false`.
+# Guarded because config.yjit is only introduced in Rails 7.2.
+# if Rails.application.config.respond_to?(:yjit)
+#   Rails.application.config.yjit = true
+# end

--- a/spec/initializers/framework_defaults_spec.rb
+++ b/spec/initializers/framework_defaults_spec.rb
@@ -114,5 +114,19 @@ describe "Framework Defaults 7.1 Upgrade Verification" do
       "Found controllers with missing callback actions:\n" + missing_callbacks.join("\n")
     }
   end
+
+  describe "Framework Defaults 7.2 Upgrade Preparation" do
+    it "has the new_framework_defaults_7_2.rb initializer file present" do
+      expect(File.exist?(Rails.root.join("config/initializers/new_framework_defaults_7_2.rb"))).to be(true)
+    end
+
+    it "keeps new Rails 7.2 configurations unset/nil (preserving Rails 7.1 defaults) during preparation" do
+      config = Rails.application.config
+
+      expect(config.active_record.postgresql_adapter_decode_dates).to be_nil
+      expect(config.active_record.validate_migration_timestamps).to be_nil
+      expect(config.active_job.enqueue_after_transaction_commit).to be_nil
+    end
+  end
 end
 # rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
### Objective
This PR introduces the `new_framework_defaults_7_2.rb` initializer to prepare the Forem codebase for Rails 7.2 and eventually Rails 8 upgrades, following the same incremental adoption pattern previously used for Rails 7.1.

### Changes
1. **New Initializer**: Created `config/initializers/new_framework_defaults_7_2.rb` containing all five new defaults introduced in Rails 7.2, kept commented out by default for incremental adoption.
2. **Guards for Optional Frameworks**: Added `respond_to?` checks around Rails 7.2 settings for optional frameworks (`active_storage` and `yjit`) to ensure the app boots safely on Rails 7.1.6.
3. **Spec Verification**: Added tests in `spec/initializers/framework_defaults_spec.rb` to:
   - Ensure the initializer exists.
   - Assert that the new 7.2 configurations are nil/unset, thereby preserving the existing Rails 7.1 defaults.

### Deployment & Rollout Safety
- **Risk Level**: Zero-risk. Since all configurations are commented out, there is no change in production behavior or runtime characteristics.
- **Rollback Safety**: This change can be safely rolled back at any time without any data, queue, or cache corruption issues.
- **Next Steps**: Future PRs can safely uncomment these options one at a time (e.g. `validate_migration_timestamps` which has no runtime footprint) to test and transition before updating `load_defaults 7.2`.