### PR TITLE
Rails 8 prep: Replace deprecated ActiveRecord::Base.clear_active_connections! and fix logger resolution

### DIFF
--- a/lib/sidekiq/sidekiq_connection_cleanup.rb
+++ b/lib/sidekiq/sidekiq_connection_cleanup.rb
@@ -14,12 +14,12 @@ module Sidekiq
           conn.rollback_db_transaction
         rescue StandardError => e
           # If rollback itself fails (rare), log and continue clearing connections
-          Rails.logger.warn "Sidekiq ConnectionCleanup: rollback failed: #{e.class}: #{e.message}"
+          ::Rails.logger.warn "Sidekiq ConnectionCleanup: rollback failed: #{e.class}: #{e.message}"
         end
       end
 
       # Now clear the connection so it's returned to the pool cleanly
-      ActiveRecord::Base.clear_active_connections!
+      ActiveRecord::Base.connection_handler.clear_active_connections!
     end
   end
 end

--- a/spec/lib/sidekiq/sidekiq_connection_cleanup_spec.rb
+++ b/spec/lib/sidekiq/sidekiq_connection_cleanup_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+require "sidekiq/sidekiq_connection_cleanup"
+
+RSpec.describe Sidekiq::SidekiqConnectionCleanup do
+  let(:middleware) { described_class.new }
+  let(:worker) { double("worker") }
+  let(:job) { { "class" => "SomeWorker" } }
+  let(:queue) { "default" }
+
+  describe "#call" do
+    it "yields to the block" do
+      expect { |b| middleware.call(worker, job, queue, &b) }.to yield_control
+    end
+
+    it "clears active connections after execution" do
+      expect(ActiveRecord::Base.connection_handler).to receive(:clear_active_connections!).and_call_original
+      middleware.call(worker, job, queue) {}
+    end
+
+    context "when open transactions are positive" do
+      let(:conn) { ActiveRecord::Base.connection }
+
+      before do
+        allow(ActiveRecord::Base).to receive(:connection).and_return(conn)
+        allow(conn).to receive(:open_transactions).and_return(1)
+        allow(ActiveRecord::Base.connection_handler).to receive(:clear_active_connections!).and_call_original
+      end
+
+      it "rolls back the transaction" do
+        expect(conn).to receive(:rollback_db_transaction)
+        middleware.call(worker, job, queue) {}
+      end
+
+      it "logs a warning and continues if rollback fails" do
+        allow(conn).to receive(:rollback_db_transaction).and_raise(StandardError, "rollback error")
+        expect(::Rails.logger).to receive(:warn).with(/Sidekiq ConnectionCleanup: rollback failed: StandardError: rollback error/)
+        middleware.call(worker, job, queue) {}
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What does this PR do?
This PR prepares the codebase for the transition to Rails 7.2 and 8.0 by removing a usage of the deprecated class-level method `ActiveRecord::Base.clear_active_connections!`, replacing it with `ActiveRecord::Base.connection_handler.clear_active_connections!`.

Additionally, it resolves a name resolution bug in the `Sidekiq::SidekiqConnectionCleanup` middleware where `Rails.logger` was being resolved to the non-existent `Sidekiq::Rails.logger` due to module scoping, causing the middleware to crash if a database rollback failed. We replaced it with the absolute constant reference `::Rails.logger`.

### Why is this safe?
- `ActiveRecord::Base.connection_handler.clear_active_connections!` has been supported in Active Record for a long time and is the direct underlying delegate of the deprecated `ActiveRecord::Base.clear_active_connections!`. It is fully compatible with the current Rails version (7.1.6) and is the standard replacement under Rails 7.2 and 8.0 where the class-level delegator is removed.
- Using `::Rails.logger` explicitly refers to the top-level `Rails` module, avoiding module namespace collision with `Sidekiq::Rails`.

### Deployment & Safety Considerations
- **Connection pooling & cleaning:** Sidekiq jobs run concurrently, and connection pooling/releasing is vital. Calling the connection handler directly ensures connections are returned cleanly to the pool after the job finishes.
- **Rollback handling:** If a database transaction fails or is left open, the middleware rolls it back. Fixing the logger ensures that if a rollback fails, it safely logs the warning rather than throwing a `NoMethodError` and potentially crashing the Sidekiq process.

### Test Coverage
Added a comprehensive suite of unit tests in [sidekiq_connection_cleanup_spec.rb](file:///Users/benhalpern/dev/forem/spec/lib/sidekiq/sidekiq_connection_cleanup_spec.rb) that verifies:
- Control yields to the block.
- Connection handler is invoked to clear active connections.
- Open transactions are rolled back if positive.
- Rollback errors are caught, logged via `::Rails.logger`, and do not crash the job execution.