### PR TITLE
Enable ActiveRecord validate_migration_timestamps to prepare for Rails 7.2/8

### DIFF
--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -22,7 +22,7 @@
 # Enable validation of migration timestamps. When set, an ActiveRecord::InvalidMigrationTimestampError
 # will be raised if the timestamp prefix for a migration is more than a day ahead of the timestamp
 # associated with the current time.
-# Rails.application.config.active_record.validate_migration_timestamps = true
+Rails.application.config.active_record.validate_migration_timestamps = true
 
 # Controls whether the PostgresqlAdapter should decode dates automatically with manual queries.
 # Rails.application.config.active_record.postgresql_adapter_decode_dates = true

--- a/spec/initializers/framework_defaults_spec.rb
+++ b/spec/initializers/framework_defaults_spec.rb
@@ -120,11 +120,16 @@ describe "Framework Defaults 7.1 Upgrade Verification" do
       expect(File.exist?(Rails.root.join("config/initializers/new_framework_defaults_7_2.rb"))).to be(true)
     end
 
-    it "keeps new Rails 7.2 configurations unset/nil (preserving Rails 7.1 defaults) during preparation" do
+    it "enables key Rails 7.2 defaults to ease the upgrade path" do
+      config = Rails.application.config
+
+      expect(config.active_record.validate_migration_timestamps).to be(true)
+    end
+
+    it "keeps remaining new Rails 7.2 configurations unset/nil (preserving Rails 7.1 defaults) during preparation" do
       config = Rails.application.config
 
       expect(config.active_record.postgresql_adapter_decode_dates).to be_nil
-      expect(config.active_record.validate_migration_timestamps).to be_nil
       expect(config.active_job.enqueue_after_transaction_commit).to be_nil
     end
   end


### PR DESCRIPTION
This PR enables `ActiveRecord::Migration` timestamp validation in Forem by uncommenting the configuration option in the Rails 7.2 framework defaults initializer:
`Rails.application.config.active_record.validate_migration_timestamps = true`

### What it does:
In Rails 7.2 / Rails 8, migration timestamps are validated by default. If a migration is generated or created with a timestamp prefix that is more than one day in the future (relative to the system time running the migration), `ActiveRecord::InvalidMigrationTimestampError` is raised.

### Why it is safe & low-hanging:
1. **Zero Runtime Impact**: This validation is only executed when running database migrations (e.g. `rails db:migrate` or generating migrations). It does not affect application request routing, controllers, background workers, query speed, or database locking in production.
2. **Development-Time Safeguard**: It prevents developers from accidentally committing migrations with dates set far in the future, which can happen due to typos or merge conflicts, helping keep the schema migration sequence clean and chronologically aligned.
3. **Spec Updates**: Updated `spec/initializers/framework_defaults_spec.rb` to assert that this config option is enabled.