### PR TITLE
Rails 8 Prep: Enable postgresql_adapter_decode_dates

### DIFF
--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -25,7 +25,7 @@
 Rails.application.config.active_record.validate_migration_timestamps = true
 
 # Controls whether the PostgresqlAdapter should decode dates automatically with manual queries.
-# Rails.application.config.active_record.postgresql_adapter_decode_dates = true
+Rails.application.config.active_record.postgresql_adapter_decode_dates = true
 
 # Enables YJIT as of Ruby 3.3, to bring sizeable performance improvements. If you are
 # deploying to a memory constrained environment you may want to set this to `false`.

--- a/spec/initializers/framework_defaults_spec.rb
+++ b/spec/initializers/framework_defaults_spec.rb
@@ -124,12 +124,12 @@ describe "Framework Defaults 7.1 Upgrade Verification" do
       config = Rails.application.config
 
       expect(config.active_record.validate_migration_timestamps).to be(true)
+      expect(config.active_record.postgresql_adapter_decode_dates).to be(true)
     end
 
     it "keeps remaining new Rails 7.2 configurations unset/nil (preserving Rails 7.1 defaults) during preparation" do
       config = Rails.application.config
 
-      expect(config.active_record.postgresql_adapter_decode_dates).to be_nil
       expect(config.active_job.enqueue_after_transaction_commit).to be_nil
     end
   end


### PR DESCRIPTION
### Summary
This PR enables `postgresql_adapter_decode_dates = true` in the Rails 7.2 framework defaults configuration file (`new_framework_defaults_7_2.rb`).

### Details
In Rails 7.2 and 8.0, the PostgreSQL adapter automatically decodes date objects from manual queries (like `ActiveRecord::Base.connection.select_all`) into Ruby `Date` objects instead of leaving them as raw strings. 
Enabling this now ensures we are prepared for this default behavior change in Rails 7.2/8.0.

### Precautions & Safety
- **Manual queries check**: A codebase scan shows that Forem has only a single usage of manual SQL extraction using `select_all` (in `AnalyticsService`), and it does not return any date columns, meaning this configuration change has zero immediate functional impact on existing manual queries.
- **Test coverage**: All existing framework defaults specs and analytics service specs have been verified to pass successfully.