### PR TITLE
Enable remaining Rails 7.2 framework defaults for upgrade preparation

### DIFF
--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -11,13 +11,13 @@
 
 # Controls whether Active Job's `#perform_later` and similar methods automatically defer
 # the job queuing to after the current Active Record transaction is committed.
-# Rails.application.config.active_job.enqueue_after_transaction_commit = :default
+Rails.application.config.active_job.enqueue_after_transaction_commit = :default
 
 # Adds image/webp to the list of content types Active Storage considers as an image.
 # Guarded with respond_to? since Active Storage is not loaded in Forem.
-# if Rails.application.config.respond_to?(:active_storage)
-#   Rails.application.config.active_storage.web_image_content_types = %w[image/png image/jpeg image/gif image/webp]
-# end
+if Rails.application.config.respond_to?(:active_storage)
+  Rails.application.config.active_storage.web_image_content_types = %w[image/png image/jpeg image/gif image/webp]
+end
 
 # Enable validation of migration timestamps. When set, an ActiveRecord::InvalidMigrationTimestampError
 # will be raised if the timestamp prefix for a migration is more than a day ahead of the timestamp
@@ -30,6 +30,6 @@ Rails.application.config.active_record.postgresql_adapter_decode_dates = true
 # Enables YJIT as of Ruby 3.3, to bring sizeable performance improvements. If you are
 # deploying to a memory constrained environment you may want to set this to `false`.
 # Guarded because config.yjit is only introduced in Rails 7.2.
-# if Rails.application.config.respond_to?(:yjit)
-#   Rails.application.config.yjit = true
-# end
+if Rails.application.config.respond_to?(:yjit)
+  Rails.application.config.yjit = true
+end

--- a/spec/initializers/framework_defaults_spec.rb
+++ b/spec/initializers/framework_defaults_spec.rb
@@ -125,12 +125,15 @@ describe "Framework Defaults 7.1 Upgrade Verification" do
 
       expect(config.active_record.validate_migration_timestamps).to be(true)
       expect(config.active_record.postgresql_adapter_decode_dates).to be(true)
+      expect(config.active_job.enqueue_after_transaction_commit).to eq(:default)
     end
 
     it "keeps remaining new Rails 7.2 configurations unset/nil (preserving Rails 7.1 defaults) during preparation" do
       config = Rails.application.config
 
-      expect(config.active_job.enqueue_after_transaction_commit).to be_nil
+      # active_storage and yjit are not loaded/supported in Rails 7.1, so they remain undefined
+      expect(config.respond_to?(:active_storage)).to be(false)
+      expect(config.respond_to?(:yjit)).to be(false)
     end
   end
 end


### PR DESCRIPTION
This PR enables the remaining framework defaults in `config/initializers/new_framework_defaults_7_2.rb` to prepare for the Rails 7.2 / 8.0 upgrade.

### Changes:
1. **`active_job.enqueue_after_transaction_commit`**: Set to `:default`. This prevents background job enqueuing race conditions inside Active Record transactions (specifically relevant to ActionMailer's async `#deliver_later` calls).
2. **`active_storage.web_image_content_types`**: Uncommented and guarded with `respond_to?` since ActiveStorage is not currently loaded in Forem.
3. **`config.yjit`**: Uncommented and guarded with `respond_to?` since `config.yjit` is only introduced in Rails 7.2.

### Testing:
- Verified all examples pass in `spec/initializers/framework_defaults_spec.rb`.