### PR TITLE
Enable to_time_preserves_timezone = :zone for Rails 8 preparation

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,6 +49,9 @@ module PracticalDeveloper
     # Enable modern cache format version 7.1
     config.active_support.cache_format_version = 7.1
 
+    # Preserve receiver timezone when calling to_time (preparing for Rails 8.0/8.1)
+    config.active_support.to_time_preserves_timezone = :zone
+
     # Enable validating only parent-related columns for presence when the parent is mandatory.
     config.active_record.belongs_to_required_validates_foreign_key = true
 

--- a/spec/initializers/framework_defaults_spec.rb
+++ b/spec/initializers/framework_defaults_spec.rb
@@ -126,6 +126,7 @@ describe "Framework Defaults 7.1 Upgrade Verification" do
       expect(config.active_record.validate_migration_timestamps).to be(true)
       expect(config.active_record.postgresql_adapter_decode_dates).to be(true)
       expect(config.active_job.enqueue_after_transaction_commit).to eq(:default)
+      expect(config.active_support.to_time_preserves_timezone).to eq(:zone)
     end
 
     it "keeps remaining new Rails 7.2 configurations unset/nil (preserving Rails 7.1 defaults) during preparation" do


### PR DESCRIPTION
This PR configures `config.active_support.to_time_preserves_timezone = :zone` in `config/application.rb` as part of the preparation for upgrading to Rails 8.0.

### Context
In Rails 8.0, `to_time` methods default to preserving the timezone of the receiver (`:zone`). In Rails 8.1, this becomes the only behavior and the configuration option is deprecated/removed. Opting in early to `:zone` prevents deprecation warnings during the Rails 7.2/8.0 transition and aligns our time-handling semantics.

### Safety & Deployment Precautions
- **Code Audit**: A search of the codebase for `.to_time` returned zero direct usages in `app/`, `lib/`, and `spec/`.
- **System Timezone Independence**: Forem uses Zonebie in its test environment to randomize the timezone per run. The test suite passing successfully under random zones confirms the code is independent of local system time offsets.
- **Timezone Isolation**: Setting this config to `:zone` keeps times in their receiver zone (usually UTC) rather than leaking the local server timezone, which is a significant safety improvement.

### Changes
- Configured `config.active_support.to_time_preserves_timezone = :zone` in `config/application.rb`.
- Added a regression test in `spec/initializers/framework_defaults_spec.rb` to verify the value.
