### PR TITLE
Run yarn build before assets precompilation in Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -92,6 +92,7 @@ RUN echo 'httpTimeout: 300000' >> ~/.yarnrc.yml
 # layer space was done in a later step, which is invalid in at least some
 # Docker storage drivers (resulting in Directory Not Empty errors).
 RUN NODE_ENV=production yarn install && \
+    yarn build && \
     RAILS_ENV=production NODE_ENV=production bundle exec rake assets:precompile && \
     rm -rf node_modules
 


### PR DESCRIPTION
### Goal
Compile javascript assets/packs via `yarn build` before `rake assets:precompile` inside the Containerfile.

### Why this is needed
By inserting `yarn build && \` between `yarn install` and `rake assets:precompile`, we force esbuild to compile all the Javascript packs (homePage.js, webShare.js, etc.) and write them to `app/assets/builds/` before Sprockets/Propshaft precompiles/fingerprints them into `public/assets` in the Docker image.

This ensures that the precompiled assets are fully generated and included in the production image, avoiding errors or runtime compilation during container boots.
