### PR TITLE
Cache upcoming elevated events in homepage sidebar

### DIFF
--- a/app/controllers/sidebars_controller.rb
+++ b/app/controllers/sidebars_controller.rb
@@ -14,7 +14,9 @@ class SidebarsController < ApplicationController
   private
 
   def get_upcoming_events
-    @upcoming_events = Event.published.elevated.includes(:page).where("end_time >= ?", Time.current).order(start_time: :asc).limit(5).to_a
+    @upcoming_events = Rails.cache.fetch("upcoming_elevated_events", expires_in: 5.minutes) do
+      Event.published.elevated.includes(:page).where("end_time >= ?", Time.current).order(start_time: :asc).limit(5).to_a
+    end
   end
 
   def get_latest_campaign_articles

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -25,6 +25,7 @@ class Event < ApplicationRecord
 
   before_save :format_stream_urls
   after_commit :ensure_broadcast_billboards_and_workers, on: [:create, :update]
+  after_commit :bust_upcoming_events_cache, on: [:create, :update, :destroy]
 
   scope :published, -> { where(published: true) }
   scope :elevated, -> { where(elevated: true) }
@@ -140,5 +141,9 @@ class Event < ApplicationRecord
       approved: post_bottom_bb.new_record? ? false : post_bottom_bb.approved,
       published: true
     )
+  end
+
+  def bust_upcoming_events_cache
+    Rails.cache.delete("upcoming_elevated_events")
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -172,4 +172,34 @@ RSpec.describe Event, type: :model do
       expect(post_bb.body_markdown).to include("id=\"event-takeover-image\"")
     end
   end
+
+  describe "caching" do
+    let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
+    before do
+      allow(Rails).to receive(:cache).and_return(memory_store)
+      Rails.cache.clear
+    end
+
+    after do
+      Rails.cache.clear
+    end
+
+    it "clears upcoming_elevated_events cache when created, updated, or destroyed" do
+      Rails.cache.write("upcoming_elevated_events", ["cached_data"])
+      expect(Rails.cache.read("upcoming_elevated_events")).to eq(["cached_data"])
+
+      event = create(:event)
+      expect(Rails.cache.read("upcoming_elevated_events")).to be_nil
+
+      Rails.cache.write("upcoming_elevated_events", ["cached_data"])
+      event.update!(title: "New Title")
+      expect(Rails.cache.read("upcoming_elevated_events")).to be_nil
+
+      Rails.cache.write("upcoming_elevated_events", ["cached_data"])
+      event.destroy
+      expect(Rails.cache.read("upcoming_elevated_events")).to be_nil
+    end
+  end
 end
+

--- a/spec/requests/sidebars_spec.rb
+++ b/spec/requests/sidebars_spec.rb
@@ -158,5 +158,35 @@ RSpec.describe "Sidebars" do
         expect(response.body).not_to include("Unpublished Elevated Event")
       end
     end
+
+    context "with query caching enabled" do
+      let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
+      before do
+        allow(Rails).to receive(:cache).and_return(memory_store)
+        allow(memory_store).to receive(:fetch).and_call_original
+        Rails.cache.clear
+      end
+
+      after do
+        Rails.cache.clear
+      end
+
+      it "caches upcoming elevated events and does not query database repeatedly" do
+        create(:event, title: "Cached Elevated Event", elevated: true, published: true, start_time: 1.hour.from_now, end_time: 2.hours.from_now)
+
+        # First hit should call the block and query DB
+        expect(Rails.cache).to receive(:fetch).with("upcoming_elevated_events", expires_in: 5.minutes).and_call_original
+        get "/sidebars/home"
+        expect(response.body).to include("Cached Elevated Event")
+
+        # Second hit should fetch from cache and avoid DB hit
+        expect(Rails.cache).to receive(:fetch).with("upcoming_elevated_events", expires_in: 5.minutes).and_call_original
+        # Spy on Event query to verify database is not queried
+        expect(Event).not_to receive(:published)
+        get "/sidebars/home"
+        expect(response.body).to include("Cached Elevated Event")
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR caches the upcoming elevated events query in SidebarsController for 5 minutes and busts the cache whenever an event is created, updated, or destroyed. This significantly improves home page sidebar load times.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784314083&installation_id=139885019&pr_number=23482&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23482&signature=2d30b72feb9a28f7c2f961abb363ad1e66f40664faa384842fc55706debf1b7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->