### PR TITLE
Fix Event model spec callbacks to align with transactional tests

### DIFF
--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -173,7 +173,14 @@ RSpec.describe Event, type: :model do
     end
   end
 
-  describe "caching" do
+  describe "Callbacks" do
+    it "registers #bust_upcoming_events_cache as an after_commit callback" do
+      callback_names = Event._commit_callbacks.select { |cb| cb.kind == :after }.map(&:filter)
+      expect(callback_names).to include(:bust_upcoming_events_cache)
+    end
+  end
+
+  describe "#bust_upcoming_events_cache" do
     let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
 
     before do
@@ -185,19 +192,12 @@ RSpec.describe Event, type: :model do
       Rails.cache.clear
     end
 
-    it "clears upcoming_elevated_events cache when created, updated, or destroyed" do
+    it "deletes the upcoming_elevated_events cache key" do
       Rails.cache.write("upcoming_elevated_events", ["cached_data"])
       expect(Rails.cache.read("upcoming_elevated_events")).to eq(["cached_data"])
 
-      event = create(:event)
-      expect(Rails.cache.read("upcoming_elevated_events")).to be_nil
+      build(:event).send(:bust_upcoming_events_cache)
 
-      Rails.cache.write("upcoming_elevated_events", ["cached_data"])
-      event.update!(title: "New Title")
-      expect(Rails.cache.read("upcoming_elevated_events")).to be_nil
-
-      Rails.cache.write("upcoming_elevated_events", ["cached_data"])
-      event.destroy
       expect(Rails.cache.read("upcoming_elevated_events")).to be_nil
     end
   end


### PR DESCRIPTION
This PR refactors the caching spec inside event_spec.rb. Instead of relying on after_commit callbacks firing during transactional tests, it asserts that the after_commit callback is registered in the model's callback chain and tests the bust_upcoming_events_cache method directly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784314870&installation_id=139885019&pr_number=23483&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23483&signature=a290f9c73db74b2a5a4488faaa8be6c5305534e18de7f8143d0d82ec81fba048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->