### PR TITLE
Make AddIndexesToEventSignups migration idempotent

### DIFF
--- a/db/migrate/20260611190731_add_indexes_to_event_signups.rb
+++ b/db/migrate/20260611190731_add_indexes_to_event_signups.rb
@@ -1,11 +1,19 @@
 class AddIndexesToEventSignups < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
-  def change
-    add_index :event_signups, :user_id, algorithm: :concurrently
-    add_index :event_signups, :event_id, algorithm: :concurrently
-    add_index :event_signups, [:user_id, :event_id], unique: true, algorithm: :concurrently
-    add_index :event_signups, :notified_1_day_before, algorithm: :concurrently
-    add_index :event_signups, :notified_1_hour_before, algorithm: :concurrently
+  def up
+    add_index :event_signups, :user_id, algorithm: :concurrently unless index_exists?(:event_signups, :user_id)
+    add_index :event_signups, :event_id, algorithm: :concurrently unless index_exists?(:event_signups, :event_id)
+    add_index :event_signups, [:user_id, :event_id], unique: true, algorithm: :concurrently unless index_exists?(:event_signups, [:user_id, :event_id])
+    add_index :event_signups, :notified_1_day_before, algorithm: :concurrently unless index_exists?(:event_signups, :notified_1_day_before)
+    add_index :event_signups, :notified_1_hour_before, algorithm: :concurrently unless index_exists?(:event_signups, :notified_1_hour_before)
+  end
+
+  def down
+    remove_index :event_signups, :user_id, algorithm: :concurrently if index_exists?(:event_signups, :user_id)
+    remove_index :event_signups, :event_id, algorithm: :concurrently if index_exists?(:event_signups, :event_id)
+    remove_index :event_signups, [:user_id, :event_id], algorithm: :concurrently if index_exists?(:event_signups, [:user_id, :event_id])
+    remove_index :event_signups, :notified_1_day_before, algorithm: :concurrently if index_exists?(:event_signups, :notified_1_day_before)
+    remove_index :event_signups, :notified_1_hour_before, algorithm: :concurrently if index_exists?(:event_signups, :notified_1_hour_before)
   end
 end


### PR DESCRIPTION
This adds guards using index_exists? in both up and down directions to prevent PG::DuplicateTable errors during deployment if some indexes were already created.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This will fix some deployment issues

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784324014&installation_id=139885019&pr_number=23484&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23484&signature=0eb3e2572bacdc34c766f8363c758eaf1e2969da18d8ab4fb178d2db42fa2763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->