### PR TITLE
Guard LogoUploader filename methods against nil file

### DIFF
--- a/app/uploaders/logo_uploader.rb
+++ b/app/uploaders/logo_uploader.rb
@@ -29,13 +29,13 @@ class LogoUploader < BaseUploader
 
   def filename
     # random_string in the filename to avoid caching issues
-    "original_logo_#{random_string}.#{file.extension}"
+    "original_logo_#{random_string}.#{file.extension}" if file.present?
   end
 
   version :resized_logo do
     process resize_to_limit: [nil, 80]
     def full_filename(_for_file = file)
-      "resized_logo_#{random_string}.#{file.extension}"
+      "resized_logo_#{random_string}.#{file.extension}" if file.present?
     end
   end
 

--- a/spec/uploaders/logo_uploader_spec.rb
+++ b/spec/uploaders/logo_uploader_spec.rb
@@ -76,6 +76,12 @@ describe LogoUploader, type: :uploader do
     end
   end
 
+  describe "filename" do
+    it "defaults to nil" do
+      expect(uploader.filename).to be_nil
+    end
+  end
+
   describe "resize_image" do
     it "creates versions of the image with different filenames", :aggregate_failures do
       uploader.store!(image_jpg)


### PR DESCRIPTION
This adds file.present? checks to LogoUploader's filename and full_filename methods to prevent NoMethodError (undefined method 'extension' for nil) when no file is present on the uploader. It also adds a spec to verify filename defaults to nil.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fix this condition

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784325651&installation_id=139885019&pr_number=23488&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23488&signature=5c02c362028ce1281ae1fc80c5ea9354c90d340181c84422ec42729b8bb04fd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->