### PR TITLE
Fix ActiveRecord::RecordNotUnique in admin/users#update_email

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -122,7 +122,7 @@ module Admin
     def update_email
       @user = User.find(params[:id])
       old_email = @user.email
-      new_email = user_params[:email]&.strip
+new_email = user_params[:email].to_s.strip.presence
 
       # Validate email using a temp User object to avoid rate limit checks and other model side-effects
       temp_user = User.new(email: new_email)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -122,25 +122,49 @@ module Admin
     def update_email
       @user = User.find(params[:id])
       old_email = @user.email
-      new_email = user_params[:email]
-      if @user.update_columns(email: new_email)
-        Note.create(
-          author_id: current_user.id,
-          noteable_id: @user.id,
-          noteable_type: "User",
-          reason: "Update Email",
-          content: "Updated email from #{old_email} to #{new_email}",
-        )
-        Audit::Logger.log(:moderator, current_user, {
-                            "action" => params[:action],
-                            "controller" => params[:controller],
-                            "target_user_id" => @user.id,
-                            "old_email" => old_email,
-                            "new_email" => new_email
-                          })
-        flash[:success] = I18n.t("views.admin.users.update_email.success")
-      else
-        flash[:error] = I18n.t("views.admin.users.update_email.error")
+      new_email = user_params[:email]&.strip
+
+      # Validate email using a temp User object to avoid rate limit checks and other model side-effects
+      temp_user = User.new(email: new_email)
+      temp_user.valid?
+
+      email_errors = temp_user.errors.where(:email)
+      if new_email.present? && old_email.present? && new_email.casecmp?(old_email)
+        email_errors = email_errors.reject { |e| e.type == :taken }
+      end
+
+      if email_errors.any?
+        flash[:error] = email_errors.map(&:full_message).to_sentence
+        redirect_to admin_user_path(@user)
+        return
+      end
+
+      begin
+        downcased_email = new_email&.downcase
+        # Bypassing validations/callbacks is intentional here to match the behavior of updating
+        # user emails via the admin UI directly and immediately without sending confirmation emails.
+        if @user.update_columns(email: downcased_email, unconfirmed_email: nil)
+          Note.create(
+            author_id: current_user.id,
+            noteable_id: @user.id,
+            noteable_type: "User",
+            reason: "Update Email",
+            content: "Updated email from #{old_email} to #{downcased_email}",
+          )
+          Audit::Logger.log(:moderator, current_user, {
+                              "action" => params[:action],
+                              "controller" => params[:controller],
+                              "target_user_id" => @user.id,
+                              "old_email" => old_email,
+                              "new_email" => downcased_email
+                            })
+          Users::BustCacheWorker.perform_async(@user.id)
+          flash[:success] = I18n.t("views.admin.users.update_email.success")
+        else
+          flash[:error] = I18n.t("views.admin.users.update_email.error")
+        end
+      rescue ActiveRecord::RecordNotUnique
+        flash[:error] = I18n.t("errors.messages.taken")
       end
       redirect_to admin_user_path(@user)
     end

--- a/spec/requests/admin/users/users_update_email_spec.rb
+++ b/spec/requests/admin/users/users_update_email_spec.rb
@@ -49,5 +49,41 @@ RSpec.describe "/admin/member_manager/users" do
 
       expect(response).to redirect_to(admin_user_path(user))
     end
+
+    context "when the new email is already taken by another user" do
+      let!(:other_user) { create(:user, email: "taken@example.com") }
+
+      it "does not update the email and sets an error flash message" do
+        old_email = user.email
+
+        patch update_email_admin_user_path(user.id), params: {
+          user: {
+            email: "taken@example.com"
+          }
+        }
+
+        user.reload
+        expect(user.email).to eq(old_email)
+        expect(flash[:error]).to include("Email has already been taken")
+        expect(response).to redirect_to(admin_user_path(user))
+      end
+    end
+
+    context "when the new email format is invalid" do
+      it "does not update the email and sets an error flash message" do
+        old_email = user.email
+
+        patch update_email_admin_user_path(user.id), params: {
+          user: {
+            email: "invalid-email-format"
+          }
+        }
+
+        user.reload
+        expect(user.email).to eq(old_email)
+        expect(flash[:error]).to include("Email is invalid")
+        expect(response).to redirect_to(admin_user_path(user))
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR addresses an ActiveRecord::RecordNotUnique exception that occurs when an administrator updates a user's email to an address that is already taken by another user or is in an invalid format.

### Key Changes
- Validate the input email (stripping whitespace and downcasing) using a temporary User object to check format and uniqueness before attempting any database writes. This avoids triggering user-specific rate limiting or other callbacks on the actual record.
- Display a friendly validation error in flash[:error] (such as 'Email has already been taken') and redirect instead of throwing a 500 error.
- Clear out the unconfirmed_email field on success, and run Users::BustCacheWorker to clear user caches.
- Wrap update_columns in a rescue ActiveRecord::RecordNotUnique block as a fallback.
- Added regression test coverage in spec/requests/admin/users/users_update_email_spec.rb.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784824799&installation_id=139885019&pr_number=23502&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23502&signature=b5961438172663b606b5a67b731183590ee356175c7966266722e2b20958b161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->