### PR TITLE
Added Mod Icon on the Article Card

### DIFF
--- a/app/assets/javascripts/utilities/buildArticleHTML.js
+++ b/app/assets/javascripts/utilities/buildArticleHTML.js
@@ -402,6 +402,22 @@ function buildArticleHTML(article, currentUserId = null) {
         </button>`;
     }
 
+    var modButton = '';
+    if (article.class_name === 'Article' && currentUserId) {
+      modButton = `
+        <div class="only-sidebar-menu-item">
+          <div id="mod-actions-menu-btn-area" class="print-hidden trusted-visible-block align-center">
+            <button class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn" data-article-path="${article.path}">
+              <svg width="24" height="24" class="crayons-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-labelledby="mod-actions-button-title-${article.id}">
+                <title id="mod-actions-button-title-${article.id}">Moderation</title>
+                <path d="M3.783 2.826L12 1l8.217 1.826a1 1 0 01.783.976v9.987a6 6 0 01-2.672 4.992L12 23l-6.328-4.219A6 6 0 013 13.79V3.802a1 1 0 01.783-.976zM5 4.604v9.185a4 4 0 001.781 3.328L12 20.597l5.219-3.48A4 4 0 0019 13.79V4.604L12 3.05 5 4.604zM13 10h3l-5 7v-5H8l5-7v5z" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      `;
+    }
+
     var videoHTML = '';
     if (article.cloudinary_video_url) {
       videoHTML =
@@ -456,8 +472,7 @@ function buildArticleHTML(article, currentUserId = null) {
                 </div>\
                 <div class="crayons-story__save">\
                   ${readingTimeHTML}\
-                  ${saveButton}
-                </div>\
+                  ${saveButton}                  ${modButton}\                </div>\
               </div>\
             </div>\
           </div>\

--- a/app/assets/javascripts/utilities/buildArticleHTML.js
+++ b/app/assets/javascripts/utilities/buildArticleHTML.js
@@ -406,7 +406,7 @@ function buildArticleHTML(article, currentUserId = null) {
     if (article.class_name === 'Article' && currentUserId) {
       modButton = `
         <div class="only-sidebar-menu-item">
-          <div id="mod-actions-menu-btn-area" class="print-hidden trusted-visible-block align-center">
+          <div class="print-hidden trusted-visible-block align-center">
             <button class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn" data-article-path="${article.path}">
               <svg width="24" height="24" class="crayons-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-labelledby="mod-actions-button-title-${article.id}">
                 <title id="mod-actions-button-title-${article.id}">Moderation</title>

--- a/app/javascript/actionsPanel/__tests__/initializeActionsPanelToggle.test.js
+++ b/app/javascript/actionsPanel/__tests__/initializeActionsPanelToggle.test.js
@@ -16,7 +16,7 @@ describe('toggling the actions panel', () => {
     const path = '/fakeuser/fake-article-slug-1d3a';
 
     test('it should have a click listener that toggles the appropriate classes', () => {
-      initializeActionsPanel(path);
+      initializeActionsPanel({}, path);
 
       const modContainer = document.getElementById('mod-container');
       modContainer.contentWindow.document.write(
@@ -39,6 +39,31 @@ describe('toggling the actions panel', () => {
         'close-actions-panel',
       )[0];
       expect(closeButton.classList.contains('hidden')).toBeFalsy();
+    });
+
+    test('it should create the moderation menu container when one is missing', () => {
+      document.body.innerHTML = `
+        <div id="mod-actions-menu-btn-area">
+          <button class="mod-actions-menu-btn" data-article-path="/fakeuser/fake-article-slug">
+            Moderate
+          </button>
+        </div>
+      `;
+
+      initializeActionsPanel({}, '/fallback-path');
+
+      const modActionsMenuBtn = document.getElementsByClassName(
+        'mod-actions-menu-btn',
+      )[0];
+      modActionsMenuBtn.click();
+
+      const modActionsMenu = document.getElementsByClassName('mod-actions-menu')[0];
+      const modContainer = document.getElementById('mod-container');
+
+      expect(modActionsMenu).toBeTruthy();
+      expect(modContainer.getAttribute('src')).toBe(
+        '/fakeuser/fake-article-slug/actions_panel',
+      );
     });
   });
 });

--- a/app/javascript/actionsPanel/initializeActionsPanelToggle.js
+++ b/app/javascript/actionsPanel/initializeActionsPanelToggle.js
@@ -1,23 +1,41 @@
 import { isModerationPage } from '@utilities/moderation';
 
 /** This initializes the mod actions button on the article show page (app/views/articles/show.html.erb). */
-export function initializeActionsPanel(user, path) {
-  const modActionsMenuHTML = `
-    <iframe id="mod-container" src=${path}/actions_panel title="Moderation panel actions">
-    </iframe>
-  `;
+export function initializeActionsPanel(user, path = '') {
+  function getOrCreateModActionsMenu() {
+    let modActionsMenu = document.getElementsByClassName('mod-actions-menu')[0];
 
-  function toggleModActionsMenu() {
-    document
-      .getElementById('mod-actions-menu-btn-area')
-      .classList.remove('hidden');
-    document
-      .getElementsByClassName('mod-actions-menu')[0]
-      .classList.toggle('showing');
+    if (!modActionsMenu) {
+      modActionsMenu = document.createElement('div');
+      modActionsMenu.className = 'mod-actions-menu print-hidden';
+      document.body.appendChild(modActionsMenu);
+    }
+
+    return modActionsMenu;
+  }
+
+  function toggleModActionsMenu(event) {
+    const targetButton =
+      event?.currentTarget || event?.target?.closest('.mod-actions-menu-btn');
+    const articlePath = targetButton?.dataset?.articlePath || path;
+    const modActionsMenu = getOrCreateModActionsMenu();
+
+    const modContainer = document.getElementById('mod-container');
+
+    if (
+      !modContainer ||
+      modContainer.getAttribute('src') !== `${articlePath}/actions_panel`
+    ) {
+      modActionsMenu.innerHTML = `
+        <iframe id="mod-container" src="${articlePath}/actions_panel" title="Moderation panel actions">
+        </iframe>
+      `;
+    }
+
+    modActionsMenu.classList.toggle('showing');
 
     // showing close icon in the mod panel if it is opened by clicking the button
-    const modContainer = document.getElementById('mod-container');
-    const panelDocument = modContainer.contentDocument;
+    const panelDocument = document.getElementById('mod-container')?.contentDocument;
 
     if (panelDocument) {
       const closePanel = panelDocument.getElementsByClassName(
@@ -28,18 +46,21 @@ export function initializeActionsPanel(user, path) {
     }
   }
 
-  document.getElementsByClassName('mod-actions-menu')[0].innerHTML =
-    modActionsMenuHTML;
-  // eslint-disable-next-line no-restricted-globals
-  if (!isModerationPage()) {
-    // don't show mod button in mod center page
+  function bindModActionsMenuButtons() {
+    if (isModerationPage()) {
+      return;
+    }
 
-    const modActionsMenuBtns = document.getElementsByClassName(
-      'mod-actions-menu-btn',
-    );
-    modActionsMenuBtns &&
-      Array.from(modActionsMenuBtns).forEach((btn) => {
-        btn.addEventListener('click', toggleModActionsMenu);
-      });
+    document.addEventListener('click', (event) => {
+      const button = event.target.closest('.mod-actions-menu-btn');
+      if (!button) {
+        return;
+      }
+
+      event.preventDefault();
+      toggleModActionsMenu({ currentTarget: button });
+    });
   }
+
+  bindModActionsMenuButtons();
 }

--- a/app/javascript/actionsPanel/initializeActionsPanelToggle.js
+++ b/app/javascript/actionsPanel/initializeActionsPanelToggle.js
@@ -70,5 +70,15 @@ export function initializeActionsPanel(user, path = '') {
     });
   }
 
+  if (path) {
+    const modActionsMenu = getOrCreateModActionsMenu();
+    if (!document.getElementById('mod-container')) {
+      modActionsMenu.innerHTML = `
+        <iframe id="mod-container" src="${path}/actions_panel" title="Moderation panel actions">
+        </iframe>
+      `;
+    }
+  }
+
   bindModActionsMenuButtons();
 }

--- a/app/javascript/actionsPanel/initializeActionsPanelToggle.js
+++ b/app/javascript/actionsPanel/initializeActionsPanelToggle.js
@@ -18,6 +18,9 @@ export function initializeActionsPanel(user, path = '') {
     const targetButton =
       event?.currentTarget || event?.target?.closest('.mod-actions-menu-btn');
     const articlePath = targetButton?.dataset?.articlePath || path;
+    if (!articlePath) {
+      return;
+    }
     const modActionsMenu = getOrCreateModActionsMenu();
 
     const modContainer = document.getElementById('mod-container');
@@ -47,9 +50,14 @@ export function initializeActionsPanel(user, path = '') {
   }
 
   function bindModActionsMenuButtons() {
-    if (isModerationPage()) {
+    if (
+      isModerationPage() ||
+      document.documentElement.dataset.modActionsMenuBound === 'true'
+    ) {
       return;
     }
+
+    document.documentElement.dataset.modActionsMenuBound = 'true';
 
     document.addEventListener('click', (event) => {
       const button = event.target.closest('.mod-actions-menu-btn');

--- a/app/javascript/articles/Article.jsx
+++ b/app/javascript/articles/Article.jsx
@@ -140,13 +140,29 @@ export const Article = ({
 
               <div className="crayons-story__save">
                 <ReadingTime readingTime={article.reading_time} typeOf={article.type_of} />
-                { isRoot && (<small class="crayons-story__tertiary mr-2 fs-xs fw-bold">{domain}</small>)}
+                {isRoot && (
+                  <small class="crayons-story__tertiary mr-2 fs-xs fw-bold">{domain}</small>
+                )}
                 <SaveButton
                   article={article}
                   isBookmarked={isBookmarked}
                   onClick={bookmarkClick}
                   saveable={saveable}
                 />
+                <div className="only-sidebar-menu-item">
+                  <div className="trusted-visible-block align-center">
+                    <button
+                      type="button"
+                      className="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn"
+                      data-article-path={article.url}
+                      aria-label="Moderation"
+                    >
+                      <svg width="24" height="24" className="crayons-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                        <path d="M3.783 2.826L12 1l8.217 1.826a1 1 0 01.783.976v9.987a6 6 0 01-2.672 4.992L12 23l-6.328-4.219A6 6 0 013 13.79V3.802a1 1 0 01.783-.976zM5 4.604v9.185a4 4 0 001.781 3.328L12 20.597l5.219-3.48A4 4 0 0019 13.79V4.604L12 3.05 5 4.604zM13 10h3l-5 7v-5H8l5-7v5z" />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/app/javascript/articles/Article.jsx
+++ b/app/javascript/articles/Article.jsx
@@ -154,7 +154,7 @@ export const Article = ({
                     <button
                       type="button"
                       className="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn"
-                      data-article-path={article.url}
+                      data-article-path={article.path}
                       aria-label="Moderation"
                     >
                       <svg width="24" height="24" className="crayons-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">

--- a/app/javascript/articles/__tests__/ArticleModerationButton.test.jsx
+++ b/app/javascript/articles/__tests__/ArticleModerationButton.test.jsx
@@ -25,7 +25,7 @@ describe('<Article /> moderation button', () => {
     const modButton = container.querySelector('.mod-actions-menu-btn');
 
     expect(modButton).toBeInTheDocument();
-    expect(modButton).toHaveAttribute('data-article-path', article.url);
+    expect(modButton).toHaveAttribute('data-article-path', article.path);
     expect(modButton).toHaveAttribute('aria-label', 'Moderation');
   });
 });

--- a/app/javascript/articles/__tests__/ArticleModerationButton.test.jsx
+++ b/app/javascript/articles/__tests__/ArticleModerationButton.test.jsx
@@ -16,6 +16,7 @@ describe('<Article /> moderation button', () => {
       <Article
         {...commonProps}
         isBookmarked={false}
+        bookmarkClick={jest.fn()}
         article={article}
         currentTag="javascript"
       />,

--- a/app/javascript/articles/__tests__/ArticleModerationButton.test.jsx
+++ b/app/javascript/articles/__tests__/ArticleModerationButton.test.jsx
@@ -1,0 +1,30 @@
+/* eslint-disable no-irregular-whitespace */
+import { h } from 'preact';
+import { render } from '@testing-library/preact';
+import '@testing-library/jest-dom';
+import { Article } from '..';
+import { article } from './utilities/articleUtilities';
+
+const commonProps = {
+  commentsIcon: '/images/comments-bubble.png',
+  videoIcon: '/images/video-camera.svg',
+};
+
+describe('<Article /> moderation button', () => {
+  it('renders a moderation button for articles when trusted-visible block is present', () => {
+    const { container } = render(
+      <Article
+        {...commonProps}
+        isBookmarked={false}
+        article={article}
+        currentTag="javascript"
+      />,
+    );
+
+    const modButton = container.querySelector('.mod-actions-menu-btn');
+
+    expect(modButton).toBeInTheDocument();
+    expect(modButton).toHaveAttribute('data-article-path', article.url);
+    expect(modButton).toHaveAttribute('aria-label', 'Moderation');
+  });
+});

--- a/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
+++ b/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
@@ -313,6 +313,33 @@ Object {
                       />
                     </svg>
                   </button>
+                  <div
+                    class="only-sidebar-menu-item"
+                  >
+                    <div
+                      class="trusted-visible-block align-center"
+                    >
+                      <button
+                        aria-label="Moderation"
+                        class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn"
+                        data-article-path="http://example.com/some-post/path"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="crayons-icon"
+                          height="24"
+                          viewBox="0 0 24 24"
+                          width="24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M3.783 2.826L12 1l8.217 1.826a1 1 0 01.783.976v9.987a6 6 0 01-2.672 4.992L12 23l-6.328-4.219A6 6 0 013 13.79V3.802a1 1 0 01.783-.976zM5 4.604v9.185a4 4 0 001.781 3.328L12 20.597l5.219-3.48A4 4 0 0019 13.79V4.604L12 3.05 5 4.604zM13 10h3l-5 7v-5H8l5-7v5z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
@@ -584,6 +611,33 @@ Object {
                     />
                   </svg>
                 </button>
+                <div
+                  class="only-sidebar-menu-item"
+                >
+                  <div
+                    class="trusted-visible-block align-center"
+                  >
+                    <button
+                      aria-label="Moderation"
+                      class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn"
+                      data-article-path="http://example.com/some-post/path"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="crayons-icon"
+                        height="24"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M3.783 2.826L12 1l8.217 1.826a1 1 0 01.783.976v9.987a6 6 0 01-2.672 4.992L12 23l-6.328-4.219A6 6 0 013 13.79V3.802a1 1 0 01.783-.976zM5 4.604v9.185a4 4 0 001.781 3.328L12 20.597l5.219-3.48A4 4 0 0019 13.79V4.604L12 3.05 5 4.604zM13 10h3l-5 7v-5H8l5-7v5z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
+++ b/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
@@ -322,7 +322,7 @@ Object {
                       <button
                         aria-label="Moderation"
                         class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn"
-                        data-article-path="http://example.com/some-post/path"
+                        data-article-path="/some-post/path"
                         type="button"
                       >
                         <svg
@@ -620,7 +620,7 @@ Object {
                     <button
                       aria-label="Moderation"
                       class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn"
-                      data-article-path="http://example.com/some-post/path"
+                      data-article-path="/some-post/path"
                       type="button"
                     >
                       <svg

--- a/app/javascript/packs/__tests__/articleModerationTools.test.js
+++ b/app/javascript/packs/__tests__/articleModerationTools.test.js
@@ -1,0 +1,38 @@
+import '@testing-library/jest-dom';
+
+jest.mock('../../actionsPanel/initializeActionsPanelToggle', () => ({
+  initializeActionsPanel: jest.fn(),
+}));
+
+describe('articleModerationTools pack', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = '<div id="index-container"></div>';
+    global.getCsrfToken = jest.fn(() => Promise.resolve('csrf-token'));
+    global.userData = jest.fn(() => ({
+      id: 123,
+      policies: [
+        {
+          dom_class: 'js-policy-article-moderate',
+          visible: true,
+        },
+      ],
+    }));
+  });
+
+  afterEach(() => {
+    delete global.getCsrfToken;
+    delete global.userData;
+  });
+
+  it('initializes moderation tools when a feed container exists', async () => {
+    const { initializeActionsPanel } = await import(
+      '../../actionsPanel/initializeActionsPanelToggle'
+    );
+
+    await import('../articleModerationTools');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(initializeActionsPanel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/javascript/packs/articleModerationTools.js
+++ b/app/javascript/packs/articleModerationTools.js
@@ -3,10 +3,14 @@ import { isModerationPage } from '@utilities/moderation';
 
 getCsrfToken().then(() => {
   const articleContainer = document.getElementById('article-show-container');
+  const feedContainer = document.getElementById('index-container') || document.getElementById('homepage-feed');
+  const hasModerationButtons = document.getElementsByClassName(
+    'mod-actions-menu-btn',
+  ).length;
 
-  if (articleContainer) {
+  if (articleContainer || feedContainer || hasModerationButtons) {
     const user = userData();
-    const { authorId: articleAuthorId, path } = articleContainer.dataset;
+    const { authorId: articleAuthorId, path } = articleContainer?.dataset || {};
 
     const initializeModerationsTools = async () => {
       const { initializeActionsPanel } = await import(
@@ -14,23 +18,20 @@ getCsrfToken().then(() => {
       );
 
       // If the user can moderate an article give them access to this panel.
-      // Note: this assumes we're within the article context (which is the case
-      // given the articleContainer)
       const canModerateArticles = user?.policies?.find(
         (o) =>
           o.dom_class === 'js-policy-article-moderate' && o.visible === true,
       );
 
-      // article show page
       if (canModerateArticles) {
         // <2022-05-09 Mon> [@jeremyf] the user.id is an integer and
         // articleAuthorId is a string so our logic is such that we always
         // initializeActionsPanel and initializeFlagUserModal; I'm asking
         // product to clarify if we want mods to boost their own posts.
-        if (user?.id !== articleAuthorId && !isModerationPage()) {
+        if (articleContainer && user?.id !== articleAuthorId && !isModerationPage()) {
           initializeActionsPanel(user, path);
-          // "/mod" page
-        } else if (isModerationPage()) {
+          // "/mod" page or feed cards
+        } else if (isModerationPage() || !articleContainer) {
           initializeActionsPanel(user, path);
         }
       }

--- a/app/lib/middlewares/set_subforem.rb
+++ b/app/lib/middlewares/set_subforem.rb
@@ -50,7 +50,7 @@ module Middlewares
         # Set Content-Security-Policy header to allow embedding in iframes for all subforems
         headers.delete("X-Frame-Options")
         allowed_domains = Subforem.cached_all_domains + [Settings::General.app_domain]
-        csp_value = "frame-ancestors " + allowed_domains.map { |d| "https://#{d}" }.join(" ")
+        csp_value = "frame-ancestors " + allowed_domains.map { |d| "#{request.scheme}://#{d}" }.join(" ")
         headers["Content-Security-Policy"] = csp_value
 
       rescue PublicSuffix::DomainInvalid

--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -37,7 +37,7 @@ module URL
 
   def self.url(uri = nil, domain_or_subforem = nil)
     base_url = "#{protocol}#{domain(domain_or_subforem)}"
-    base_url += ":#{dev_port}" if Rails.env.development? && !base_url.include?(":#{dev_port}")
+    base_url += ":#{dev_port}" if Rails.env.development? && !base_url.include?(":#{dev_port}") && !base_url.match?(/:[0-9]+/)
     return base_url unless uri
     Addressable::URI.parse(base_url).join(uri).normalize.to_s
   end

--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -13,7 +13,7 @@
       <div class="only-sidebar-menu-item">
         <div id="mod-actions-menu-btn-area" class="print-hidden trusted-visible-block align-center">
           <% if user_signed_in? %>
-            <button class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn">
+            <button class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn" data-article-path="<%= URL.article(@article) %>">
               <svg width="24" height="24" class="crayons-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-labelledby="d6cd43ffbad3fe639e2e95c901ee88c8">
                 <title id="d6cd43ffbad3fe639e2e95c901ee88c8">Moderation</title>
                 <path d="M3.783 2.826L12 1l8.217 1.826a1 1 0 01.783.976v9.987a6 6 0 01-2.672 4.992L12 23l-6.328-4.219A6 6 0 013 13.79V3.802a1 1 0 01.783-.976zM5 4.604v9.185a4 4 0 001.781 3.328L12 20.597l5.219-3.48A4 4 0 0019 13.79V4.604L12 3.05 5 4.604zM13 10h3l-5 7v-5H8l5-7v5z" />
@@ -30,7 +30,7 @@
         <div id="article-show-more-dropdown" class="crayons-dropdown side-bar left-2 right-2 m:right-auto m:left-100 s:left-auto mb-1 m:mb-0 top-unset bottom-100 m:top-0 m:bottom-unset">
           <% if user_signed_in? %>
             <div class="only-mobile-menu-item trusted-visible-block">
-              <button class="mod-actions-menu-btn crayons-link crayons-link--block w-100 bg-transparent border-0 fw-bold">
+              <button class="mod-actions-menu-btn crayons-link crayons-link--block w-100 bg-transparent border-0 fw-bold" data-article-path="<%= URL.article(@article) %>">
                 Moderate
               </button>
             </div>

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -189,6 +189,20 @@
               </span>
             </button>
           <% end %>
+          
+          <div class="only-sidebar-menu-item">
+            <div id="mod-actions-menu-btn-area" class="print-hidden trusted-visible-block align-center">
+              <% if user_signed_in? %>
+                <button class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn">
+                  <svg width="24" height="24" class="crayons-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-labelledby="d6cd43ffbad3fe639e2e95c901ee88c8">
+                    <title id="d6cd43ffbad3fe639e2e95c901ee88c8">Moderation</title>
+                    <path d="M3.783 2.826L12 1l8.217 1.826a1 1 0 01.783.976v9.987a6 6 0 01-2.672 4.992L12 23l-6.328-4.219A6 6 0 013 13.79V3.802a1 1 0 01.783-.976zM5 4.604v9.185a4 4 0 001.781 3.328L12 20.597l5.219-3.48A4 4 0 0019 13.79V4.604L12 3.05 5 4.604zM13 10h3l-5 7v-5H8l5-7v5z" />
+                  </svg>
+                </button>
+              <% end %>
+            </div>
+          </div>
+
         </div>
       </div>
     </div>

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -193,7 +193,7 @@
           <div class="only-sidebar-menu-item">
             <div id="mod-actions-menu-btn-area" class="print-hidden trusted-visible-block align-center">
               <% if user_signed_in? %>
-                <button class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn">
+                <button class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn" data-article-path="<%= URL.article(story) %>">
                   <svg width="24" height="24" class="crayons-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-labelledby="d6cd43ffbad3fe639e2e95c901ee88c8">
                     <title id="d6cd43ffbad3fe639e2e95c901ee88c8">Moderation</title>
                     <path d="M3.783 2.826L12 1l8.217 1.826a1 1 0 01.783.976v9.987a6 6 0 01-2.672 4.992L12 23l-6.328-4.219A6 6 0 013 13.79V3.802a1 1 0 01.783-.976zM5 4.604v9.185a4 4 0 001.781 3.328L12 20.597l5.219-3.48A4 4 0 0019 13.79V4.604L12 3.05 5 4.604zM13 10h3l-5 7v-5H8l5-7v5z" />

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -47,14 +47,14 @@
             <a href="/<%= story.cached_user.username %>" class="crayons-story__secondary fw-medium m:hidden">
               <%= story.cached_user.name %>
             </a>
-            <% if user_signed_in? %>
+            <div class="trusted-visible-block print-hidden">
               <button class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn" data-article-path="<%= story.path %>">
                 <svg width="24" height="24" class="crayons-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                   <title>Moderation</title>
                   <path d="M3.783 2.826L12 1l8.217 1.826a1 1 0 01.783.976v9.987a6 6 0 01-2.672 4.992L12 23l-6.328-4.219A6 6 0 013 13.79V3.802a1 1 0 01.783-.976zM5 4.604v9.185a4 4 0 001.781 3.328L12 20.597l5.219-3.48A4 4 0 0019 13.79V4.604L12 3.05 5 4.604zM13 10h3l-5 7v-5H8l5-7v5z" />
                 </svg>
               </button>
-            <% end %>
+            </div>
           </div>
             <div class="profile-preview-card relative mb-4 s:mb-0 fw-medium hidden m:inline-block">
               <button id="story-author-preview-trigger-<%= story.id %>" aria-controls="story-author-preview-content-<%= story.id %>" class="profile-preview-card__trigger fs-s p-1 -ml-1 -my-2 crayons-btn crayons-btn--ghost" aria-label="<%= t("views.users.details",
@@ -201,14 +201,12 @@
           
           <div class="only-sidebar-menu-item">
             <div class="print-hidden trusted-visible-block align-center">
-              <% if user_signed_in? %>
                 <button class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn" data-article-path="<%= story.path %>">
                     <svg width="24" height="24" class="crayons-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-labelledby="mod-actions-button-title-<%= story.id %>">
                      <title id="mod-actions-button-title-<%= story.id %>">Moderation</title>
                     <path d="M3.783 2.826L12 1l8.217 1.826a1 1 0 01.783.976v9.987a6 6 0 01-2.672 4.992L12 23l-6.328-4.219A6 6 0 013 13.79V3.802a1 1 0 01.783-.976zM5 4.604v9.185a4 4 0 001.781 3.328L12 20.597l5.219-3.48A4 4 0 0019 13.79V4.604L12 3.05 5 4.604zM13 10h3l-5 7v-5H8l5-7v5z" />
                   </svg>
                 </button>
-              <% end %>
             </div>
           </div>
 

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -43,10 +43,19 @@
           </a>
         </div>
         <div>
-          <div>
+          <div class="flex items-center gap-2">
             <a href="/<%= story.cached_user.username %>" class="crayons-story__secondary fw-medium m:hidden">
               <%= story.cached_user.name %>
             </a>
+            <% if user_signed_in? %>
+              <button class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn" data-article-path="<%= URL.article(story) %>">
+                <svg width="24" height="24" class="crayons-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                  <title>Moderation</title>
+                  <path d="M3.783 2.826L12 1l8.217 1.826a1 1 0 01.783.976v9.987a6 6 0 01-2.672 4.992L12 23l-6.328-4.219A6 6 0 013 13.79V3.802a1 1 0 01.783-.976zM5 4.604v9.185a4 4 0 001.781 3.328L12 20.597l5.219-3.48A4 4 0 0019 13.79V4.604L12 3.05 5 4.604zM13 10h3l-5 7v-5H8l5-7v5z" />
+                </svg>
+              </button>
+            <% end %>
+          </div>
             <div class="profile-preview-card relative mb-4 s:mb-0 fw-medium hidden m:inline-block">
               <button id="story-author-preview-trigger-<%= story.id %>" aria-controls="story-author-preview-content-<%= story.id %>" class="profile-preview-card__trigger fs-s p-1 -ml-1 -my-2 crayons-btn crayons-btn--ghost" aria-label="<%= t("views.users.details",
                                                                                                                                                                                                                                                  user: story.cached_user.name) %>">
@@ -191,11 +200,11 @@
           <% end %>
           
           <div class="only-sidebar-menu-item">
-            <div id="mod-actions-menu-btn-area" class="print-hidden trusted-visible-block align-center">
+            <div class="print-hidden trusted-visible-block align-center">
               <% if user_signed_in? %>
                 <button class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn" data-article-path="<%= URL.article(story) %>">
-                  <svg width="24" height="24" class="crayons-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-labelledby="d6cd43ffbad3fe639e2e95c901ee88c8">
-                    <title id="d6cd43ffbad3fe639e2e95c901ee88c8">Moderation</title>
+                    <svg width="24" height="24" class="crayons-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-labelledby="mod-actions-button-title-<%= story.id %>">
+                     <title id="mod-actions-button-title-<%= story.id %>">Moderation</title>
                     <path d="M3.783 2.826L12 1l8.217 1.826a1 1 0 01.783.976v9.987a6 6 0 01-2.672 4.992L12 23l-6.328-4.219A6 6 0 013 13.79V3.802a1 1 0 01.783-.976zM5 4.604v9.185a4 4 0 001.781 3.328L12 20.597l5.219-3.48A4 4 0 0019 13.79V4.604L12 3.05 5 4.604zM13 10h3l-5 7v-5H8l5-7v5z" />
                   </svg>
                 </button>

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -43,7 +43,8 @@
           </a>
         </div>
         <div>
-          <div class="flex items-center gap-2">
+          <div>
+            <div class="flex items-center gap-2">
             <a href="/<%= story.cached_user.username %>" class="crayons-story__secondary fw-medium m:hidden">
               <%= story.cached_user.name %>
             </a>

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -48,7 +48,7 @@
               <%= story.cached_user.name %>
             </a>
             <% if user_signed_in? %>
-              <button class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn" data-article-path="<%= URL.article(story) %>">
+              <button class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn" data-article-path="<%= story.path %>">
                 <svg width="24" height="24" class="crayons-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                   <title>Moderation</title>
                   <path d="M3.783 2.826L12 1l8.217 1.826a1 1 0 01.783.976v9.987a6 6 0 01-2.672 4.992L12 23l-6.328-4.219A6 6 0 013 13.79V3.802a1 1 0 01.783-.976zM5 4.604v9.185a4 4 0 001.781 3.328L12 20.597l5.219-3.48A4 4 0 0019 13.79V4.604L12 3.05 5 4.604zM13 10h3l-5 7v-5H8l5-7v5z" />
@@ -202,7 +202,7 @@
           <div class="only-sidebar-menu-item">
             <div class="print-hidden trusted-visible-block align-center">
               <% if user_signed_in? %>
-                <button class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn" data-article-path="<%= URL.article(story) %>">
+                <button class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn" data-article-path="<%= story.path %>">
                     <svg width="24" height="24" class="crayons-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-labelledby="mod-actions-button-title-<%= story.id %>">
                      <title id="mod-actions-button-title-<%= story.id %>">Moderation</title>
                     <path d="M3.783 2.826L12 1l8.217 1.826a1 1 0 01.783.976v9.987a6 6 0 01-2.672 4.992L12 23l-6.328-4.219A6 6 0 013 13.79V3.802a1 1 0 01.783-.976zM5 4.604v9.185a4 4 0 001.781 3.328L12 20.597l5.219-3.48A4 4 0 0019 13.79V4.604L12 3.05 5 4.604zM13 10h3l-5 7v-5H8l5-7v5z" />

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -71,5 +71,5 @@
     <%= render "articles/sidebar_additional" %>
   </div>
 
-  <%= javascript_include_tag "storiesList", "feedPreviewCards", "heroBannerClose", "localizeArticleDates", "feedEvents", "sidebar-sticky", defer: true %>
+  <%= javascript_include_tag "storiesList", "feedPreviewCards", "heroBannerClose", "localizeArticleDates", "feedEvents", "sidebar-sticky", "articleModerationTools", defer: true %>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -175,5 +175,6 @@
 <%= javascript_include_tag "storiesList",
                            "feedPreviewCards", "hideBookmarkButtons",
                            "profileDropdown", "users/profilePage",
+                           "articleModerationTools",
                            "localizeArticleDates", "asyncUserStatusCheck",
                            defer: true %>

--- a/testSetup.js
+++ b/testSetup.js
@@ -1,6 +1,7 @@
 /* eslint-env jest, node */
 import 'jest-axe/extend-expect';
 import './app/assets/javascripts/lib/xss';
+import './app/assets/javascripts/utilities/timeAgo';
 
 global.setImmediate = global.setTimeout;
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update





## Description

This PR features where if you are a mod or higher, you are able to access the "Mod Shield" icon located on the bottom right of the article feed card. This makes it more accessible for Moderators instead of having to click on the article and access the features there based on the issue request.

<img width="724" height="607" alt="image" src="https://github.com/user-attachments/assets/cd088228-7e8e-4fdf-ab6e-911d8534f00e" />





## Related Tickets & Documents

- Related Issue #10753
- Closes #10753





## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests





## What gif best describes this PR or how it makes you feel?

<img width="420" height="323" alt="power" src="https://github.com/user-attachments/assets/18422457-194e-42c7-b682-e48853268f0d" />
