### PR TITLE
Modernize remaining background workers to use Sidekiq::Job syntax

### DIFF
--- a/app/workers/algolia_search/search_index_worker.rb
+++ b/app/workers/algolia_search/search_index_worker.rb
@@ -1,6 +1,6 @@
 module AlgoliaSearch
   class SearchIndexWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
     sidekiq_options queue: :medium_priority, retry: 5, tags: ["algolia"]
 
     def perform(klass, id, remove)

--- a/app/workers/billboard_event_rollup_worker.rb
+++ b/app/workers/billboard_event_rollup_worker.rb
@@ -1,5 +1,5 @@
 class BillboardEventRollupWorker
-  include Sidekiq::Worker
+  include Sidekiq::Job
 
   sidekiq_options queue: :low_priority
 

--- a/app/workers/page_view_rollup_worker.rb
+++ b/app/workers/page_view_rollup_worker.rb
@@ -1,5 +1,5 @@
 class PageViewRollupWorker
-  include Sidekiq::Worker
+  include Sidekiq::Job
 
   sidekiq_options queue: :low_priority, retry: false
 

--- a/app/workers/reaction_counter_sync_worker.rb
+++ b/app/workers/reaction_counter_sync_worker.rb
@@ -1,5 +1,5 @@
 class ReactionCounterSyncWorker
-  include Sidekiq::Worker
+  include Sidekiq::Job
 
   sidekiq_options queue: :low_priority, retry: 3, lock: :until_executed
 

--- a/app/workers/spam/block_domain_and_suspend_users_worker.rb
+++ b/app/workers/spam/block_domain_and_suspend_users_worker.rb
@@ -1,6 +1,6 @@
 module Spam
   class BlockDomainAndSuspendUsersWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
     include Sidekiq::Throttled::Job
 
     sidekiq_throttle(concurrency: { limit: 1 })

--- a/app/workers/spam/reaction_ring_detection_worker.rb
+++ b/app/workers/spam/reaction_ring_detection_worker.rb
@@ -3,7 +3,7 @@
 module Spam
   # Background worker to detect reaction rings and adjust reputation modifiers
   class ReactionRingDetectionWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :default, retry: 3, lock: :until_and_while_executing
 

--- a/app/workers/subforems/create_from_scratch_worker.rb
+++ b/app/workers/subforems/create_from_scratch_worker.rb
@@ -1,6 +1,6 @@
 module Subforems
   class CreateFromScratchWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :default, retry: 3
 

--- a/app/workers/sync_liquid_embed_references_worker.rb
+++ b/app/workers/sync_liquid_embed_references_worker.rb
@@ -1,5 +1,5 @@
 class SyncLiquidEmbedReferencesWorker
-  include Sidekiq::Worker
+  include Sidekiq::Job
   sidekiq_options queue: :low_priority
 
   def perform(record_class_name, record_id)


### PR DESCRIPTION
### Summary
This PR modernizes the remaining 8 background worker classes in Forem that were still using the legacy `include Sidekiq::Worker` syntax, transitioning them to the modern `include Sidekiq::Job` syntax.

### Why this is needed
- **Rails 8.0 & Sidekiq Upgrades:** In the march towards Rails 8.0, upgrading to newer versions of Sidekiq (e.g., Sidekiq 7.x/8.x) is necessary. The old `Sidekiq::Worker` module has been deprecated by the Sidekiq team in favor of `Sidekiq::Job` starting around version 6.3.0.
- **Codebase Rule Alignment:** This change aligns directly with the instructions in our `AGENTS.md` and codebase rules: *"Prefer `include Sidekiq::Job` over `Sidekiq::Worker`"*.

### Changed Files
1. [search_index_worker.rb](file:///Users/benhalpern/dev/forem/app/workers/algolia_search/search_index_worker.rb)
2. [billboard_event_rollup_worker.rb](file:///Users/benhalpern/dev/forem/app/workers/billboard_event_rollup_worker.rb)
3. [page_view_rollup_worker.rb](file:///Users/benhalpern/dev/forem/app/workers/page_view_rollup_worker.rb)
4. [reaction_counter_sync_worker.rb](file:///Users/benhalpern/dev/forem/app/workers/reaction_counter_sync_worker.rb)
5. [block_domain_and_suspend_users_worker.rb](file:///Users/benhalpern/dev/forem/app/workers/spam/block_domain_and_suspend_users_worker.rb)
6. [reaction_ring_detection_worker.rb](file:///Users/benhalpern/dev/forem/app/workers/spam/reaction_ring_detection_worker.rb)
7. [create_from_scratch_worker.rb](file:///Users/benhalpern/dev/forem/app/workers/subforems/create_from_scratch_worker.rb)
8. [sync_liquid_embed_references_worker.rb](file:///Users/benhalpern/dev/forem/app/workers/sync_liquid_embed_references_worker.rb)

### Deployment Safety & Precaution Analysis
This is an extremely low-risk change with **zero** deployment impacts:
1. **At Runtime:** In Sidekiq 6.5.x, `Sidekiq::Job` is defined as a direct alias/copy of the `Sidekiq::Worker` module. There is no change in module behavior, method visibility, or configuration options.
2. **Rolling Deployments:** Since the underlying serialized class names enqueued in Redis remain unchanged (e.g. `Spam::ReactionRingDetectionWorker`), the existing and newly enqueued jobs can be seamlessly read and executed by both old and new workers during a rolling deployment, preventing any disruption or jobs getting lost.
3. **Spec suite:** All modified worker specs were run locally and passed successfully (29 examples, 0 failures).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784996165&installation_id=139885019&pr_number=23510&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23510&signature=7087171af3c00a50dbae8daa2125382e02439922b681797b84242f7055a877bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->