### PR TITLE
Add seconds_visible counter on billboards

### DIFF
--- a/app/controllers/ahoy/email_clicks_controller.rb
+++ b/app/controllers/ahoy/email_clicks_controller.rb
@@ -60,7 +60,7 @@ module Ahoy
 
       num_impressions = billboard.billboard_events.impressions.sum(:counts_for)
       num_clicks = billboard.billboard_events.clicks.sum(:counts_for)
-      num_seconds_visible = billboard.billboard_events.sum(:seconds_visible)
+      num_seconds_visible = billboard.billboard_events.impressions.sum(:seconds_visible)
       rate = num_impressions.positive? ? (num_clicks.to_f / num_impressions) : 0
       billboard.update_columns(
         success_rate: rate,

--- a/app/controllers/ahoy/email_clicks_controller.rb
+++ b/app/controllers/ahoy/email_clicks_controller.rb
@@ -60,11 +60,13 @@ module Ahoy
 
       num_impressions = billboard.billboard_events.impressions.sum(:counts_for)
       num_clicks = billboard.billboard_events.clicks.sum(:counts_for)
+      num_seconds_visible = billboard.billboard_events.sum(:seconds_visible)
       rate = num_impressions.positive? ? (num_clicks.to_f / num_impressions) : 0
       billboard.update_columns(
         success_rate: rate,
         clicks_count: num_clicks,
         impressions_count: num_impressions,
+        seconds_visible: num_seconds_visible,
       )
     end
 

--- a/app/views/admin/billboards/show.html.erb
+++ b/app/views/admin/billboards/show.html.erb
@@ -138,6 +138,10 @@
           <strong>Success Rate:</strong>
           <p><%= @billboard.success_rate %></p>
         </div>
+        <div class="crayons-field">
+          <strong>Seconds Visible:</strong>
+          <p><%= @billboard.seconds_visible %></p>
+        </div>
         <% @events.each do |event| %>
           <% next unless event.user %>
           <div class="crayonds-card fs-xs">

--- a/app/workers/billboards/data_update_worker.rb
+++ b/app/workers/billboards/data_update_worker.rb
@@ -41,20 +41,27 @@ module Billboards
                                      .where("created_at > ?", cutoff)
                                      .sum(:counts_for) * CONVERSION_SUCCESS_MODIFIER
 
+        num_seconds_visible = billboard.billboard_events
+                                       .where("created_at > ?", cutoff)
+                                       .sum(:seconds_visible)
+
         new_clicks      = billboard.clicks_count + num_clicks
         new_impressions = billboard.impressions_count + num_impressions
+        new_seconds_visible = billboard.seconds_visible + num_seconds_visible
         rate = (new_clicks + conversion_success).to_f / new_impressions
 
         billboard.update_columns(
           success_rate:        rate,
           clicks_count:        new_clicks,
           impressions_count:   new_impressions,
+          seconds_visible:     new_seconds_visible,
           counts_tabulated_at: timestamp
         )
       else
         num_impressions    = billboard.billboard_events.impressions.sum(:counts_for)
         num_clicks         = billboard.billboard_events.clicks.sum(:counts_for)
         conversion_success = billboard.billboard_events.all_conversion_types.sum(:counts_for) * CONVERSION_SUCCESS_MODIFIER
+        num_seconds_visible = billboard.billboard_events.sum(:seconds_visible)
 
         rate = (num_clicks + conversion_success).to_f / num_impressions
 
@@ -62,6 +69,7 @@ module Billboards
           success_rate:        rate,
           clicks_count:        num_clicks,
           impressions_count:   num_impressions,
+          seconds_visible:     num_seconds_visible,
           counts_tabulated_at: timestamp
         )
       end

--- a/app/workers/billboards/data_update_worker.rb
+++ b/app/workers/billboards/data_update_worker.rb
@@ -42,6 +42,7 @@ module Billboards
                                      .sum(:counts_for) * CONVERSION_SUCCESS_MODIFIER
 
         num_seconds_visible = billboard.billboard_events
+                                       .impressions
                                        .where("created_at > ?", cutoff)
                                        .sum(:seconds_visible)
 
@@ -61,7 +62,7 @@ module Billboards
         num_impressions    = billboard.billboard_events.impressions.sum(:counts_for)
         num_clicks         = billboard.billboard_events.clicks.sum(:counts_for)
         conversion_success = billboard.billboard_events.all_conversion_types.sum(:counts_for) * CONVERSION_SUCCESS_MODIFIER
-        num_seconds_visible = billboard.billboard_events.sum(:seconds_visible)
+        num_seconds_visible = billboard.billboard_events.impressions.sum(:seconds_visible)
 
         rate = (num_clicks + conversion_success).to_f / num_impressions
 

--- a/app/workers/billboards/track_email_click_worker.rb
+++ b/app/workers/billboards/track_email_click_worker.rb
@@ -30,11 +30,13 @@ module Billboards
 
       num_impressions = billboard.billboard_events.impressions.sum(:counts_for)
       num_clicks = billboard.billboard_events.clicks.sum(:counts_for)
+      num_seconds_visible = billboard.billboard_events.sum(:seconds_visible)
       rate = num_impressions.positive? ? (num_clicks.to_f / num_impressions) : 0
       billboard.update_columns(
         success_rate: rate,
         clicks_count: num_clicks,
         impressions_count: num_impressions,
+        seconds_visible: num_seconds_visible,
       )
     end
   end

--- a/app/workers/billboards/track_email_click_worker.rb
+++ b/app/workers/billboards/track_email_click_worker.rb
@@ -30,7 +30,7 @@ module Billboards
 
       num_impressions = billboard.billboard_events.impressions.sum(:counts_for)
       num_clicks = billboard.billboard_events.clicks.sum(:counts_for)
-      num_seconds_visible = billboard.billboard_events.sum(:seconds_visible)
+      num_seconds_visible = billboard.billboard_events.impressions.sum(:seconds_visible)
       rate = num_impressions.positive? ? (num_clicks.to_f / num_impressions) : 0
       billboard.update_columns(
         success_rate: rate,

--- a/db/migrate/20260630143448_add_seconds_visible_to_display_ads.rb
+++ b/db/migrate/20260630143448_add_seconds_visible_to_display_ads.rb
@@ -1,0 +1,5 @@
+class AddSecondsVisibleToDisplayAds < ActiveRecord::Migration[8.0]
+  def change
+    add_column :display_ads, :seconds_visible, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20260630143448_add_seconds_visible_to_display_ads.rb
+++ b/db/migrate/20260630143448_add_seconds_visible_to_display_ads.rb
@@ -1,4 +1,4 @@
-class AddSecondsVisibleToDisplayAds < ActiveRecord::Migration[8.0]
+class AddSecondsVisibleToDisplayAds < ActiveRecord::Migration[7.2]
   def change
     add_column :display_ads, :seconds_visible, :integer, default: 0, null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_29_223500) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_30_143448) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -685,6 +685,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_29_223500) do
     t.boolean "published", default: false
     t.integer "render_mode", default: 0
     t.boolean "requires_cookies", default: false
+    t.integer "seconds_visible", default: 0, null: false
     t.integer "special_behavior", default: 0, null: false
     t.float "success_rate", default: 0.0
     t.text "tags_array", default: [], array: true

--- a/spec/models/billboard_spec.rb
+++ b/spec/models/billboard_spec.rb
@@ -1189,7 +1189,7 @@ RSpec.describe Billboard do
     it "does not update when seconds_visible changes" do
       original_time = billboard.content_updated_at
       Timecop.travel(1.hour.from_now) do
-        billboard.update_column(:seconds_visible, 1000)
+        billboard.update!(seconds_visible: 1000)
         billboard.reload
         expect(billboard.content_updated_at).to eq(original_time)
       end

--- a/spec/models/billboard_spec.rb
+++ b/spec/models/billboard_spec.rb
@@ -1186,6 +1186,15 @@ RSpec.describe Billboard do
       end
     end
 
+    it "does not update when seconds_visible changes" do
+      original_time = billboard.content_updated_at
+      Timecop.travel(1.hour.from_now) do
+        billboard.update_column(:seconds_visible, 1000)
+        billboard.reload
+        expect(billboard.content_updated_at).to eq(original_time)
+      end
+    end
+
     it "does not update when clicks_count changes" do
       original_time = billboard.content_updated_at
       Timecop.travel(1.hour.from_now) do

--- a/spec/requests/api/v1/billboards_spec.rb
+++ b/spec/requests/api/v1/billboards_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Api::V1::Billboards" do
                           "custom_display_label", "template", "render_mode", "preferred_article_ids",
                           "priority", "weight", "target_geolocations", "requires_cookies", "special_behavior", "expires_at",
                           "exclude_survey_completions", "exclude_survey_ids", "content_updated_at", "tags_array", "event_id",
-                          "minimized_body_markdown", "minimized_processed_html")
+                          "minimized_body_markdown", "minimized_processed_html", "seconds_visible")
         expect(response.parsed_body["target_geolocations"]).to contain_exactly("US-WA", "CA-BC")
       end
 
@@ -80,7 +80,7 @@ RSpec.describe "Api::V1::Billboards" do
                           "custom_display_label", "template", "render_mode", "preferred_article_ids",
                           "priority", "weight", "target_geolocations", "requires_cookies", "special_behavior", "expires_at",
                           "exclude_survey_completions", "exclude_survey_ids", "content_updated_at", "tags_array", "event_id",
-                          "minimized_body_markdown", "minimized_processed_html")
+                          "minimized_body_markdown", "minimized_processed_html", "seconds_visible")
         expect(response.parsed_body["target_geolocations"]).to contain_exactly("US-WA", "CA-BC")
       end
 
@@ -149,7 +149,7 @@ RSpec.describe "Api::V1::Billboards" do
                           "custom_display_label", "template", "render_mode", "preferred_article_ids",
                           "priority", "weight", "target_geolocations", "prefer_paired_with_billboard_id", "expires_at",
                           "exclude_survey_completions", "exclude_survey_ids", "content_updated_at", "tags_array", "event_id",
-                          "minimized_body_markdown", "minimized_processed_html")
+                          "minimized_body_markdown", "minimized_processed_html", "seconds_visible")
       end
 
       it "also accepts target geolocations as an array" do

--- a/spec/workers/billboards/data_update_worker_spec.rb
+++ b/spec/workers/billboards/data_update_worker_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Billboards::DataUpdateWorker, type: :worker do
 
   describe "#perform_update" do
     context "when the billboard has never been tabulated before" do
-      let!(:billboard) { create(:billboard, impressions_count: 0, clicks_count: 0, counts_tabulated_at: nil) }
+      let!(:billboard) { create(:billboard, impressions_count: 0, clicks_count: 0, seconds_visible: 0, counts_tabulated_at: nil) }
 
       before do
         # Create some events before now
@@ -22,18 +22,21 @@ RSpec.describe Billboards::DataUpdateWorker, type: :worker do
           billboard: billboard,
           category: "impression",
           counts_for: 5,
+          seconds_visible: 50,
           created_at: now - 2.hours
         )
         create(:billboard_event,
           billboard: billboard,
           category: "click",
           counts_for: 2,
+          seconds_visible: 0,
           created_at: now - 1.hour
         )
         create(:billboard_event,
           billboard: billboard,
           category: "conversion",
           counts_for: 1,
+          seconds_visible: 0,
           created_at: now - 30.minutes
         )
       end
@@ -52,6 +55,7 @@ RSpec.describe Billboards::DataUpdateWorker, type: :worker do
 
           expect(billboard.impressions_count).to eq(5)
           expect(billboard.clicks_count).to eq(2)
+          expect(billboard.seconds_visible).to eq(50)
           expect(billboard.success_rate).to eq(expected_rate)
           expect(billboard.counts_tabulated_at).to eq(now)
         end
@@ -64,6 +68,7 @@ RSpec.describe Billboards::DataUpdateWorker, type: :worker do
           :billboard,
           impressions_count: 10,
           clicks_count: 4,
+          seconds_visible: 120,
           counts_tabulated_at: now - 1.day
         )
       end
@@ -74,18 +79,21 @@ RSpec.describe Billboards::DataUpdateWorker, type: :worker do
           billboard: billboard,
           category: "impression",
           counts_for: 3,
+          seconds_visible: 30,
           created_at: (now - 2.days)
         )
         create(:billboard_event,
           billboard: billboard,
           category: "click",
           counts_for: 1,
+          seconds_visible: 0,
           created_at: (now - 2.days)
         )
         create(:billboard_event,
           billboard: billboard,
           category: "conversion",
           counts_for: 2,
+          seconds_visible: 0,
           created_at: (now - 2.days)
         )
 
@@ -94,18 +102,21 @@ RSpec.describe Billboards::DataUpdateWorker, type: :worker do
           billboard: billboard,
           category: "impression",
           counts_for: 7,
+          seconds_visible: 80,
           created_at: (now - 12.hours)
         )
         create(:billboard_event,
           billboard: billboard,
           category: "click",
           counts_for: 3,
+          seconds_visible: 0,
           created_at: (now - 6.hours)
         )
         create(:billboard_event,
           billboard: billboard,
           category: "conversion",
           counts_for: 1,
+          seconds_visible: 0,
           created_at: (now - 3.hours)
         )
       end
@@ -134,6 +145,7 @@ RSpec.describe Billboards::DataUpdateWorker, type: :worker do
 
           expect(billboard.impressions_count).to eq(17)
           expect(billboard.clicks_count).to eq(7)
+          expect(billboard.seconds_visible).to eq(200) # 120 + 80
           expect(billboard.success_rate).to eq(expected_new_rate)
           expect(billboard.counts_tabulated_at).to eq(now)
         end


### PR DESCRIPTION
Adds a new `seconds_visible` counter on the `Billboard` model (`display_ads` table) that tracks the cumulative seconds the billboard has been visible. This counter updates concurrently with `impressions_count` in both background workers and controllers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785422485&installation_id=139885019&pr_number=23533&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23533&signature=f591d800c5d701f7ff1d0da6c2e48909a71b5d272696daba69297a3e72f796d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->