### PR TITLE
Rate limit sitemap requests by IP with Googlebot verification bypass

### DIFF
--- a/app/services/googlebot_verifier.rb
+++ b/app/services/googlebot_verifier.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "ipaddr"
+
+class GooglebotVerifier
+  GOOGLEBOT_IP_RANGES_URL = "https://developers.google.com/static/crawling/ipranges/common-crawlers.json"
+  CACHE_KEY = "googlebot_ip_prefixes"
+  CACHE_EXPIRY = 24.hours
+
+  def self.googlebot?(ip_string)
+    return false if ip_string.blank?
+
+    begin
+      client_ip = IPAddr.new(ip_string)
+    rescue IPAddr::InvalidAddressError, ArgumentError
+      return false
+    end
+
+    prefixes = Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_EXPIRY) do
+      fetched = fetch_googlebot_prefixes
+      fetched.presence
+    end
+
+    if prefixes.nil?
+      prefixes = fetch_googlebot_prefixes
+      if prefixes.present?
+        Rails.cache.write(CACHE_KEY, prefixes, expires_in: CACHE_EXPIRY)
+      else
+        # Cache empty result for a shorter duration (5 minutes) to avoid thrashing Google's servers
+        Rails.cache.write(CACHE_KEY, [], expires_in: 5.minutes)
+        prefixes = []
+      end
+    end
+
+    prefixes.any? do |prefix|
+      begin
+        IPAddr.new(prefix).include?(client_ip)
+      rescue IPAddr::InvalidAddressError, ArgumentError
+        false
+      end
+    end
+  end
+
+  def self.fetch_googlebot_prefixes
+    response = HTTParty.get(GOOGLEBOT_IP_RANGES_URL, timeout: 5)
+    return [] unless response.success?
+
+    data = JSON.parse(response.body)
+    prefixes = []
+    data["prefixes"]&.each do |p|
+      prefixes << p["ipv4Prefix"] if p["ipv4Prefix"].present?
+      prefixes << p["ipv6Prefix"] if p["ipv6Prefix"].present?
+    end
+    prefixes
+  rescue => e
+    Rails.logger.error("Failed to fetch Googlebot IP ranges: #{e.message}")
+    []
+  end
+end

--- a/app/services/googlebot_verifier.rb
+++ b/app/services/googlebot_verifier.rb
@@ -18,15 +18,10 @@ class GooglebotVerifier
 
     prefixes = Rails.cache.read(CACHE_KEY)
 
-    if prefixes.nil?
+    unless prefixes.is_a?(Array)
       prefixes = fetch_googlebot_prefixes
-      if prefixes.present?
-        Rails.cache.write(CACHE_KEY, prefixes, expires_in: CACHE_EXPIRY)
-      else
-        # Cache empty result for a shorter duration (5 minutes) to avoid thrashing Google's servers
-        Rails.cache.write(CACHE_KEY, [], expires_in: 5.minutes)
-        prefixes = []
-      end
+      expires_in = prefixes.present? ? CACHE_EXPIRY : 5.minutes
+      Rails.cache.write(CACHE_KEY, prefixes, expires_in: expires_in)
     end
 
     prefixes.any? do |prefix|

--- a/app/services/googlebot_verifier.rb
+++ b/app/services/googlebot_verifier.rb
@@ -16,10 +16,7 @@ class GooglebotVerifier
       return false
     end
 
-    prefixes = Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_EXPIRY) do
-      fetched = fetch_googlebot_prefixes
-      fetched.presence
-    end
+    prefixes = Rails.cache.read(CACHE_KEY)
 
     if prefixes.nil?
       prefixes = fetch_googlebot_prefixes

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -79,6 +79,12 @@ module Rack
       end
     end
 
+    throttle("sitemap_throttle", limit: 10, period: 1.minute) do |request|
+      if request.path.starts_with?("/sitemap-") && !GooglebotVerifier.googlebot?(request.track_and_return_ip)
+        request.track_and_return_ip
+      end
+    end
+
     # Removed user_signed_in? helper method - no longer needed
     # since we removed authentication-based throttling rules
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -80,8 +80,9 @@ module Rack
     end
 
     throttle("sitemap_throttle", limit: 10, period: 1.minute) do |request|
-      if request.path.starts_with?("/sitemap-") && !GooglebotVerifier.googlebot?(request.track_and_return_ip)
-        request.track_and_return_ip
+      if request.path.starts_with?("/sitemap-")
+        ip = request.track_and_return_ip
+        ip unless GooglebotVerifier.googlebot?(ip)
       end
     end
 

--- a/spec/requests/rack_attack_sitemaps_spec.rb
+++ b/spec/requests/rack_attack_sitemaps_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe "Rack::Attack Sitemaps Throttling", type: :request do
     Rack::Attack.enabled = true
     Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
     Rack::Attack.reset!
+    allow(ApplicationConfig).to receive(:[]).and_call_original
+    allow(ApplicationConfig).to receive(:[]).with("FASTLY_API_KEY").and_return(nil)
     allow(Rails).to receive(:cache).and_return(memory_store)
     Rails.cache.clear
 

--- a/spec/requests/rack_attack_sitemaps_spec.rb
+++ b/spec/requests/rack_attack_sitemaps_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Rack::Attack Sitemaps Throttling", type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:googlebot_ip_ranges_url) { GooglebotVerifier::GOOGLEBOT_IP_RANGES_URL }
+  let(:mock_response_body) do
+    {
+      creationTime: "2021-11-08T09:00:00Z",
+      prefixes: [
+        { ipv4Prefix: "66.249.64.0/27" }
+      ]
+    }.to_json
+  end
+
+  let(:memory_store) { ActiveSupport::Cache::MemoryStore.new }
+
+  before do
+    Rack::Attack.enabled = true
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    Rack::Attack.reset!
+    allow(Rails).to receive(:cache).and_return(memory_store)
+    Rails.cache.clear
+
+    stub_request(:get, googlebot_ip_ranges_url)
+      .to_return(status: 200, body: mock_response_body, headers: { "Content-Type" => "application/json" })
+  end
+
+  after do
+    Rack::Attack.enabled = false
+  end
+
+  describe "sitemap_throttle" do
+    context "when requested by a normal IP" do
+      let(:headers) { { "REMOTE_ADDR" => "1.2.3.4" } }
+
+      it "throttles sitemap requests to 10 per minute per IP" do
+        10.times do
+          get "/sitemap-index.xml", headers: headers
+          expect(response).not_to have_http_status(:too_many_requests)
+        end
+
+        get "/sitemap-index.xml", headers: headers
+        expect(response).to have_http_status(:too_many_requests)
+
+        travel 1.minute + 1.second do
+          get "/sitemap-index.xml", headers: headers
+          expect(response).not_to have_http_status(:too_many_requests)
+        end
+      end
+
+      it "does not throttle non-sitemap requests" do
+        11.times do
+          get "/about", headers: headers
+          expect(response).not_to have_http_status(:too_many_requests)
+        end
+      end
+    end
+
+    context "when requested by a verified Googlebot IP" do
+      let(:headers) { { "REMOTE_ADDR" => "66.249.64.1" } }
+
+      it "does not throttle sitemap requests even beyond 10 requests per minute" do
+        15.times do
+          get "/sitemap-index.xml", headers: headers
+          expect(response).not_to have_http_status(:too_many_requests)
+        end
+      end
+    end
+
+    context "when client IP spoofing Googlebot via User-Agent but not in Googlebot IP range" do
+      let(:headers) do
+        {
+          "REMOTE_ADDR" => "1.2.3.4",
+          "HTTP_USER_AGENT" => "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+        }
+      end
+
+      it "throttles sitemap requests to 10 per minute" do
+        10.times do
+          get "/sitemap-index.xml", headers: headers
+          expect(response).not_to have_http_status(:too_many_requests)
+        end
+
+        get "/sitemap-index.xml", headers: headers
+        expect(response).to have_http_status(:too_many_requests)
+      end
+    end
+  end
+end

--- a/spec/services/googlebot_verifier_spec.rb
+++ b/spec/services/googlebot_verifier_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe GooglebotVerifier, type: :service do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:googlebot_ip_ranges_url) { GooglebotVerifier::GOOGLEBOT_IP_RANGES_URL }
+  let(:mock_response_body) do
+    {
+      creationTime: "2021-11-08T09:00:00Z",
+      prefixes: [
+        { ipv4Prefix: "66.249.64.0/27" },
+        { ipv4Prefix: "66.249.66.0/24" },
+        { ipv6Prefix: "2001:4860:4801:30::/64" }
+      ]
+    }.to_json
+  end
+  let(:memory_store) { ActiveSupport::Cache::MemoryStore.new }
+
+  before do
+    allow(Rails).to receive(:cache).and_return(memory_store)
+    Rails.cache.clear
+  end
+
+  describe ".googlebot?" do
+    context "when API fetch is successful" do
+      before do
+        stub_request(:get, googlebot_ip_ranges_url)
+          .to_return(status: 200, body: mock_response_body, headers: { "Content-Type" => "application/json" })
+      end
+
+      it "returns true for IPs inside the IPv4 ranges" do
+        expect(described_class.googlebot?("66.249.64.1")).to be(true)
+        expect(described_class.googlebot?("66.249.66.100")).to be(true)
+      end
+
+      it "returns true for IPs inside the IPv6 ranges" do
+        expect(described_class.googlebot?("2001:4860:4801:30::1")).to be(true)
+      end
+
+      it "returns false for IPs outside the ranges" do
+        expect(described_class.googlebot?("1.2.3.4")).to be(false)
+        expect(described_class.googlebot?("2001:4860:4801:31::1")).to be(false)
+      end
+
+      it "returns false for invalid IPs" do
+        expect(described_class.googlebot?("invalid-ip")).to be(false)
+        expect(described_class.googlebot?("")).to be(false)
+        expect(described_class.googlebot?(nil)).to be(false)
+      end
+
+      it "caches the prefixes for 24 hours and does not perform HTTP request on subsequent calls" do
+        expect(described_class.googlebot?("66.249.64.1")).to be(true)
+        
+        # Stub subsequent calls to fail/timeout to verify cache is hit
+        stub_request(:get, googlebot_ip_ranges_url).to_timeout
+
+        expect(described_class.googlebot?("66.249.64.2")).to be(true)
+        expect(described_class.googlebot?("1.2.3.4")).to be(false)
+      end
+    end
+
+    context "when API fetch fails" do
+      before do
+        stub_request(:get, googlebot_ip_ranges_url).to_return(status: 500)
+      end
+
+      it "returns false for all IPs" do
+        expect(described_class.googlebot?("66.249.64.1")).to be(false)
+      end
+
+      it "caches the empty failure response for 5 minutes" do
+        expect(described_class.googlebot?("66.249.64.1")).to be(false)
+
+        # Stub subsequent call to succeed
+        stub_request(:get, googlebot_ip_ranges_url)
+          .to_return(status: 200, body: mock_response_body, headers: { "Content-Type" => "application/json" })
+
+        # Should still return false due to the cached empty result
+        expect(described_class.googlebot?("66.249.64.1")).to be(false)
+
+        # Travel past the 5-minute cache window
+        travel 6.minutes do
+          expect(described_class.googlebot?("66.249.64.1")).to be(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/googlebot_verifier_spec.rb
+++ b/spec/services/googlebot_verifier_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe GooglebotVerifier, type: :service do
 
       it "caches the prefixes for 24 hours and does not perform HTTP request on subsequent calls" do
         expect(described_class.googlebot?("66.249.64.1")).to be(true)
-        
+
         # Stub subsequent calls to fail/timeout to verify cache is hit
         stub_request(:get, googlebot_ip_ranges_url).to_timeout
 


### PR DESCRIPTION
Enforces a sitemap-specific rate limit of 10 requests/minute per IP, with a cached bypass for verified Googlebot IP ranges.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785441648&installation_id=139885019&pr_number=23534&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23534&signature=3dfd151221ae20f33cb19ae6230d9127f5ff3d8e7898626c16b95f00128a8d20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->