### PR TITLE
Only run sitemap rate limit if SITEMAP_RATE_LIMIT_ENABLED is set

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -80,7 +80,7 @@ module Rack
     end
 
     throttle("sitemap_throttle", limit: 10, period: 1.minute) do |request|
-      if request.path.starts_with?("/sitemap-")
+      if ENV["SITEMAP_RATE_LIMIT_ENABLED"] == "true" && request.path.starts_with?("/sitemap-")
         ip = request.track_and_return_ip
         ip unless GooglebotVerifier.googlebot?(ip)
       end

--- a/spec/requests/rack_attack_sitemaps_spec.rb
+++ b/spec/requests/rack_attack_sitemaps_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe "Rack::Attack Sitemaps Throttling", type: :request do
     Rack::Attack.reset!
     allow(ApplicationConfig).to receive(:[]).and_call_original
     allow(ApplicationConfig).to receive(:[]).with("FASTLY_API_KEY").and_return(nil)
+    stub_const("ENV", ENV.to_h.merge("SITEMAP_RATE_LIMIT_ENABLED" => "true"))
     allow(Rails).to receive(:cache).and_return(memory_store)
     Rails.cache.clear
 
@@ -88,6 +89,21 @@ RSpec.describe "Rack::Attack Sitemaps Throttling", type: :request do
 
         get "/sitemap-index.xml", headers: headers
         expect(response).to have_http_status(:too_many_requests)
+      end
+    end
+
+    context "when rate limit is disabled (SITEMAP_RATE_LIMIT_ENABLED != true)" do
+      let(:headers) { { "REMOTE_ADDR" => "1.2.3.4" } }
+
+      before do
+        stub_const("ENV", ENV.to_h.merge("SITEMAP_RATE_LIMIT_ENABLED" => "false"))
+      end
+
+      it "does not throttle sitemap requests even beyond 10 requests per minute" do
+        15.times do
+          get "/sitemap-index.xml", headers: headers
+          expect(response).not_to have_http_status(:too_many_requests)
+        end
       end
     end
   end


### PR DESCRIPTION
Wraps the sitemap rate-limiting middleware rule in a check for the SITEMAP_RATE_LIMIT_ENABLED environment variable. If set to true, sitemaps are throttled to 10 requests/minute per IP (bypassing verified Googlebot IPs). Otherwise, rate limiting is skipped.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785525451&installation_id=139885019&pr_number=23538&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23538&signature=d80a1c2448a3deb50ade48cd7309f0db7636208da3a63942f8688079dbeba97e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->