### PR TITLE
Allow legacy Marshal serializer fallback for unsubscribe tokens

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,8 +49,9 @@ module PracticalDeveloper
     # Enable modern cache format version 7.1
     config.active_support.cache_format_version = 7.1
 
-    # Enable modern message serializer to prepare for Rails 8.0
-    config.active_support.message_serializer = :json
+    # Enable modern message serializer with temporary Marshal fallback support for legacy unsubscribe links.
+    # TODO: Revert to :json after legacy links (valid for 31 days) have expired.
+    config.active_support.message_serializer = :json_allow_marshal
 
 
     # Enable validating only parent-related columns for presence when the parent is mandatory.

--- a/spec/initializers/framework_defaults_spec.rb
+++ b/spec/initializers/framework_defaults_spec.rb
@@ -37,7 +37,7 @@ describe "Framework Defaults 7.2 Upgrade Verification" do
     end
     expect(config.active_support.raise_on_invalid_cache_expiration_time).to be(true)
     expect(config.active_record.query_log_tags_format).to eq(:sqlcommenter)
-    expect(config.active_support.message_serializer).to eq(:json)
+    expect(config.active_support.message_serializer).to eq(:json).or eq(:json_allow_marshal)
     expect(config.active_support.use_message_serializer_for_metadata).to be(true)
     expect(config.active_record.encryption.hash_digest_class).to eq(OpenSSL::Digest::SHA256)
     expect(config.active_record.encryption.support_sha1_for_non_deterministic_encryption).to be(false)

--- a/spec/requests/email_subscriptions_spec.rb
+++ b/spec/requests/email_subscriptions_spec.rb
@@ -21,6 +21,22 @@ RSpec.describe "EmailSubscriptions" do
       expect(response).to have_http_status(:ok)
     end
 
+    it "returns 200 if token is in legacy Marshal format" do
+      secret_generator = Rails.application.message_verifiers.instance_variable_get(:@secret_generator)
+      secret = secret_generator.call(:unsubscribe.to_s)
+      marshal_verifier = ActiveSupport::MessageVerifier.new(secret, digest: "SHA1", serializer: Marshal)
+      legacy_token = marshal_verifier.generate({
+                                                 user_id: user.id,
+                                                 email_type: "email_mention_notifications",
+                                                 expires_at: 31.days.from_now.iso8601
+                                               })
+
+      get email_subscriptions_unsubscribe_url(ut: legacy_token)
+      expect(response).to have_http_status(:ok)
+      user.reload
+      expect(user.notification_setting.email_mention_notifications).to be(false)
+    end
+
     it "does unsubscribe the user" do
       get email_subscriptions_unsubscribe_url(ut: generate_token(user.id))
       user.reload


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR resolves the intermittent `RuntimeError: Unsupported serialization format` errors occurring in `EmailSubscriptionsController#unsubscribe`.
When the application upgraded and configured `config.active_support.message_serializer = :json`, it disabled support for reading older tokens serialized using the legacy `Marshal` format. Because unsubscribe links have a 31-day lifespan, any emails containing Marshal-serialized unsubscribe links sent prior to the upgrade failed when clicked.
To bridge this gap without breaking existing links, we configure the transitional `:json_allow_marshal` message serializer. This ensures that:
1. All new tokens and cookies are written in the modern `JSON` format.
2. Older `Marshal` format tokens still "in the wild" in users' inboxes can be successfully verified.
### Verification Plan
- Verified via Rails runner that Marshal-serialized tokens are successfully verified under this configuration.
- Added a request spec regression test to `spec/requests/email_subscriptions_spec.rb` verifying legacy Marshal token compatibility, which passes successfully.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785527925&installation_id=139885019&pr_number=23539&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23539&signature=59f6a22dad20e1b668080b01f277153d75ebc356f664a4d9e853d3c59154c737"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->