### PR TITLE
Auto-follow configured tag names when signing up for a challenge event

### DIFF
--- a/app/models/event_signup.rb
+++ b/app/models/event_signup.rb
@@ -7,14 +7,28 @@ class EventSignup < ApplicationRecord
   validates :user_id, uniqueness: { scope: :event_id, message: "has already signed up for this event" }
 
   before_validation :initialize_notification_flags, on: :create
+  after_create_commit :auto_follow_challenge_tags, if: -> { event&.challenge? }
 
   private
+
+  def auto_follow_challenge_tags
+    tag_names = event.data&.dig("auto_follow_tag_names")
+    tags = if tag_names.present?
+             Tag.where(name: tag_names.split(",").map(&:strip))
+           else
+             [event.tags.first].compact
+           end
+
+    tags.each do |tag|
+      user.follow(tag) unless user.following?(tag)
+    end
+  end
 
   def initialize_notification_flags
     return unless event&.start_time
 
     # Skip the "1 day" reminder if we're already inside the last 23 hours.
-    self.notified_1_day_before = event.start_time < Time.current + 23.hours
+    self.notified_1_day_before = event.start_time < 23.hours.from_now
 
     # Skip the "1 hour" reminder only once the event has started.
     self.notified_1_hour_before = event.start_time <= Time.current

--- a/app/models/event_signup.rb
+++ b/app/models/event_signup.rb
@@ -12,9 +12,12 @@ class EventSignup < ApplicationRecord
   private
 
   def auto_follow_challenge_tags
+    return unless event&.challenge?
+
     tag_names = event.data&.dig("auto_follow_tag_names")
     tags = if tag_names.present?
-             Tag.where(name: tag_names.split(",").map(&:strip))
+             names = tag_names.split(",").map(&:strip).reject(&:blank?).uniq
+             Tag.where(name: names)
            else
              [event.tags.first].compact
            end

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -73,6 +73,16 @@
     </div>
 
     <div class="crayons-field">
+      <%= form.fields_for :data, event.data || {} do |data_form| %>
+        <%= data_form.label :auto_follow_tag_names, "Auto-Follow Tag Names on Signup (Challenges)", class: "crayons-field__label" do %>
+          Auto-Follow Tag Names on Signup (Challenges Only)
+          <p class="crayons-field__description">Optional. Comma-separated list of tag names (e.g., 'devchallenge, writeathon') that users will automatically follow when signing up for this challenge. Defaults to the event's first tag if left blank.</p>
+        <% end %>
+        <input type="text" name="event[data][auto_follow_tag_names]" id="event_data_auto_follow_tag_names" class="crayons-textfield" value="<%= event.data&.dig('auto_follow_tag_names') %>" placeholder="e.g., devchallenge, writeathon">
+      <% end %>
+    </div>
+
+    <div class="crayons-field">
       <%= form.label :tag_list, "Tags", class: "crayons-field__label" do %>
         Tags
         <p class="crayons-field__description">Comma separated tags. The first tag is used to fetch related articles.</p>

--- a/app/views/events/challenge.html.erb
+++ b/app/views/events/challenge.html.erb
@@ -128,6 +128,32 @@
 
     <!-- Sidebar Right Column -->
     <aside class="w-100 m:w-80 flex-shrink-0">
+      <% if @event.end_time > Time.current %>
+        <div class="crayons-card p-4 mb-6 text-center">
+          <h3 class="font-bold mb-2">Join the Challenge</h3>
+          <p class="fs-s color-base-70 mb-4">Express interest to receive challenge reminders and updates.</p>
+          <% if current_user %>
+            <% if current_user.event_signups.exists?(event: @event) %>
+              <%= button_to event_signup_path(@event.event_name_slug, @event.event_variation_slug), 
+                            method: :delete, 
+                            class: "crayons-btn crayons-btn--outlined w-100 text-center justify-center", 
+                            data: { confirm: "Are you sure you want to cancel your interest?" } do %>
+                <svg class="c-icon mr-1" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+                Joined
+              <% end %>
+            <% else %>
+              <%= button_to event_signup_path(@event.event_name_slug, @event.event_variation_slug), 
+                            method: :post, 
+                            class: "crayons-btn crayons-btn--primary w-100 text-center justify-center" do %>
+                Join Challenge
+              <% end %>
+            <% end %>
+          <% else %>
+            <%= link_to "Join Challenge", sign_up_path(return_to: request.fullpath), class: "crayons-btn crayons-btn--primary w-100 text-center justify-center" %>
+          <% end %>
+        </div>
+      <% end %>
+
       <div class="crayons-card p-4 mb-6">
         <h3 class="font-bold mb-4">Key Dates</h3>
         <ul class="space-y-3 fs-s color-base-80">

--- a/spec/models/event_signup_spec.rb
+++ b/spec/models/event_signup_spec.rb
@@ -55,7 +55,14 @@ RSpec.describe EventSignup, type: :model do
       end
     end
 
-    describe "auto_follow_challenge_tags" do
+    describe "Callbacks" do
+      it "registers #auto_follow_challenge_tags as an after_commit callback" do
+        callback_names = EventSignup._commit_callbacks.select { |cb| cb.kind == :after }.map(&:filter)
+        expect(callback_names).to include(:auto_follow_challenge_tags)
+      end
+    end
+
+    describe "#auto_follow_challenge_tags" do
       let(:user) { create(:user) }
       let(:tag1) { create(:tag, name: "devchallenge") }
       let(:tag2) { create(:tag, name: "writeathon") }
@@ -63,9 +70,10 @@ RSpec.describe EventSignup, type: :model do
       context "when the event is a challenge" do
         it "auto-follows the tag configured in auto_follow_tag_names" do
           event = create(:event, type_of: :challenge, data: { "auto_follow_tag_names" => "#{tag1.name}, #{tag2.name}" })
+          signup = build(:event_signup, user: user, event: event)
           
           expect {
-            create(:event_signup, user: user, event: event)
+            signup.send(:auto_follow_challenge_tags)
           }.to change { user.reload.following_tags_count }.by(2)
 
           expect(user.following?(tag1)).to be(true)
@@ -75,9 +83,10 @@ RSpec.describe EventSignup, type: :model do
         it "falls back to following the event's first tag if auto_follow_tag_names is empty" do
           event = create(:event, type_of: :challenge)
           event.tags << tag1
+          signup = build(:event_signup, user: user, event: event)
 
           expect {
-            create(:event_signup, user: user, event: event)
+            signup.send(:auto_follow_challenge_tags)
           }.to change { user.reload.following_tags_count }.by(1)
 
           expect(user.following?(tag1)).to be(true)
@@ -85,10 +94,22 @@ RSpec.describe EventSignup, type: :model do
 
         it "handles non-existent tags gracefully" do
           event = create(:event, type_of: :challenge, data: { "auto_follow_tag_names" => "nonexistent_tag" })
+          signup = build(:event_signup, user: user, event: event)
 
           expect {
-            create(:event_signup, user: user, event: event)
-          }.not_to change { user.following_tags_count }
+            signup.send(:auto_follow_challenge_tags)
+          }.not_to change { user.reload.following_tags_count }
+        end
+
+        it "de-duplicates and rejects empty tags" do
+          event = create(:event, type_of: :challenge, data: { "auto_follow_tag_names" => "  , #{tag1.name}, , #{tag1.name} " })
+          signup = build(:event_signup, user: user, event: event)
+
+          expect {
+            signup.send(:auto_follow_challenge_tags)
+          }.to change { user.reload.following_tags_count }.by(1)
+
+          expect(user.following?(tag1)).to be(true)
         end
       end
 
@@ -96,10 +117,11 @@ RSpec.describe EventSignup, type: :model do
         it "does not auto-follow any tags even if configured" do
           event = create(:event, type_of: :live_stream, data: { "auto_follow_tag_names" => "#{tag1.name}" })
           event.tags << tag2
+          signup = build(:event_signup, user: user, event: event)
 
           expect {
-            create(:event_signup, user: user, event: event)
-          }.not_to change { user.following_tags_count }
+            signup.send(:auto_follow_challenge_tags)
+          }.not_to change { user.reload.following_tags_count }
 
           expect(user.following?(tag1)).to be(false)
           expect(user.following?(tag2)).to be(false)

--- a/spec/models/event_signup_spec.rb
+++ b/spec/models/event_signup_spec.rb
@@ -54,5 +54,57 @@ RSpec.describe EventSignup, type: :model do
         expect(signup.notified_1_hour_before).to be(true)
       end
     end
+
+    describe "auto_follow_challenge_tags" do
+      let(:user) { create(:user) }
+      let(:tag1) { create(:tag, name: "devchallenge") }
+      let(:tag2) { create(:tag, name: "writeathon") }
+
+      context "when the event is a challenge" do
+        it "auto-follows the tag configured in auto_follow_tag_names" do
+          event = create(:event, type_of: :challenge, data: { "auto_follow_tag_names" => "#{tag1.name}, #{tag2.name}" })
+          
+          expect {
+            create(:event_signup, user: user, event: event)
+          }.to change { user.reload.following_tags_count }.by(2)
+
+          expect(user.following?(tag1)).to be(true)
+          expect(user.following?(tag2)).to be(true)
+        end
+
+        it "falls back to following the event's first tag if auto_follow_tag_names is empty" do
+          event = create(:event, type_of: :challenge)
+          event.tags << tag1
+
+          expect {
+            create(:event_signup, user: user, event: event)
+          }.to change { user.reload.following_tags_count }.by(1)
+
+          expect(user.following?(tag1)).to be(true)
+        end
+
+        it "handles non-existent tags gracefully" do
+          event = create(:event, type_of: :challenge, data: { "auto_follow_tag_names" => "nonexistent_tag" })
+
+          expect {
+            create(:event_signup, user: user, event: event)
+          }.not_to change { user.following_tags_count }
+        end
+      end
+
+      context "when the event is not a challenge" do
+        it "does not auto-follow any tags even if configured" do
+          event = create(:event, type_of: :live_stream, data: { "auto_follow_tag_names" => "#{tag1.name}" })
+          event.tags << tag2
+
+          expect {
+            create(:event_signup, user: user, event: event)
+          }.not_to change { user.following_tags_count }
+
+          expect(user.following?(tag1)).to be(false)
+          expect(user.following?(tag2)).to be(false)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785540587&installation_id=139885019&pr_number=23540&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23540&signature=e2f72f391b12efc53ba98b639de462d3ac2324856ebf23804e67be75c3b9ef4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->