### PR TITLE
Fix fullscreen code block exit control on touch and non-hover devices

### DIFF
--- a/app/assets/stylesheets/components/syntax.scss
+++ b/app/assets/stylesheets/components/syntax.scss
@@ -91,7 +91,8 @@ div.highlight {
   position: fixed;
   top: 0;
   left: 0;
-  z-index: var(--z-modal);
+  // placed above the fixed header (#topbar, z-index: 10000) so the exit control is reachable;
+  z-index: 10001;
   width: 100%;
   height: 100vh;
   background: var(--syntax-background-color);
@@ -109,6 +110,8 @@ div.highlight {
 
   .highlight__panel {
     position: fixed;
+    // exit affordance must stay visible without hover (touch/non-hover devices)
+    visibility: visible;
   }
 
   .highlight-action--fullscreen-on {

--- a/app/javascript/utilities/__tests__/codeFullscreenModeSwitcher.test.js
+++ b/app/javascript/utilities/__tests__/codeFullscreenModeSwitcher.test.js
@@ -34,7 +34,7 @@ describe('CodeFullScreenModeSwitcher Utility', () => {
     document.getElementsByClassName('js-fullscreen-code-action');
 
   beforeAll(() => {
-    global.scrollTo = jest.fn();
+    globalThis.scrollTo = jest.fn();
 
     document.body.innerHTML = `
       <div class="js-code-highlight">
@@ -52,7 +52,7 @@ describe('CodeFullScreenModeSwitcher Utility', () => {
   it('enters fullscreen mode on click', () => {
     const goFullScreenButtons = getEnterFullScreenButtons();
     const spyDoc = jest.spyOn(document.body, 'addEventListener');
-    const spyWindow = jest.spyOn(window, 'addEventListener');
+    const spyWindow = jest.spyOn(globalThis, 'addEventListener');
 
     goFullScreenButtons[0].click();
 
@@ -63,7 +63,7 @@ describe('CodeFullScreenModeSwitcher Utility', () => {
 
   it('exits fullscreen mode on Escape key', () => {
     const spyDocRemove = jest.spyOn(document.body, 'removeEventListener');
-    const spyWindowRemove = jest.spyOn(window, 'removeEventListener');
+    const spyWindowRemove = jest.spyOn(globalThis, 'removeEventListener');
 
     testFullScreen();
     document.body.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape' }));
@@ -76,7 +76,7 @@ describe('CodeFullScreenModeSwitcher Utility', () => {
   it('re-enters fullscreen mode on click', () => {
     const goFullScreenButtons = getEnterFullScreenButtons();
     const spyDoc = jest.spyOn(document.body, 'addEventListener');
-    const spyWindow = jest.spyOn(window, 'addEventListener');
+    const spyWindow = jest.spyOn(globalThis, 'addEventListener');
 
     testNonFullScreen();
     goFullScreenButtons[0].click();
@@ -88,13 +88,129 @@ describe('CodeFullScreenModeSwitcher Utility', () => {
 
   it('exits fullscreen mode on popstate event', () => {
     const spyDocRemove = jest.spyOn(document.body, 'removeEventListener');
-    const spyWindowRemove = jest.spyOn(window, 'removeEventListener');
+    const spyWindowRemove = jest.spyOn(globalThis, 'removeEventListener');
 
     testFullScreen();
-    window.dispatchEvent(new PopStateEvent('popstate', { state: { key: '' } }));
+    globalThis.dispatchEvent(
+      new PopStateEvent('popstate', { state: { key: '' } }),
+    );
     testNonFullScreen();
 
     expect(spyDocRemove).toHaveBeenCalledWith('keyup', onPressEscape);
     expect(spyWindowRemove).toHaveBeenCalledWith('popstate', onPopstate);
+  });
+});
+
+describe('CodeFullScreenModeSwitcher edge cases', () => {
+  const getButtons = () =>
+    document.getElementsByClassName('js-fullscreen-code-action');
+
+  const setupDom = () => {
+    document.body.innerHTML = `
+      <div class="js-code-highlight">
+        <div class="js-fullscreen-code-action"></div>
+      </div>
+      <div class="js-fullscreen-code"></div>
+    `;
+    addFullScreenModeControl(getButtons());
+  };
+
+  beforeEach(() => {
+    globalThis.scrollTo = jest.fn();
+    setupDom();
+  });
+
+  afterEach(() => {
+    // close any session a test left open so its listeners don't leak forward
+    if (getFullScreenModeStatus()) {
+      globalThis.dispatchEvent(new PopStateEvent('popstate'));
+    }
+    jest.restoreAllMocks();
+  });
+
+  it('ignores non-Escape key presses while fullscreen', () => {
+    getButtons()[0].click();
+    expect(getFullScreenModeStatus()).toBe(true);
+
+    onPressEscape(new KeyboardEvent('keyup', { key: 'a' }));
+    expect(getFullScreenModeStatus()).toBe(true);
+  });
+
+  it('does not throw or open on popstate when not in fullscreen', () => {
+    expect(getFullScreenModeStatus()).toBe(false);
+    expect(() =>
+      globalThis.dispatchEvent(new PopStateEvent('popstate')),
+    ).not.toThrow();
+    expect(getFullScreenModeStatus()).toBe(false);
+  });
+
+  it('restores the page when the container is gone before popstate', () => {
+    getButtons()[0].click();
+    expect(getFullScreenModeStatus()).toBe(true);
+    expect(document.body.style.overflow).toBe('hidden');
+
+    const spyBodyRemove = jest.spyOn(document.body, 'removeEventListener');
+    const spyWindowRemove = jest.spyOn(globalThis, 'removeEventListener');
+
+    // simulate a soft navigation swapping out the page body
+    document.body.innerHTML = '';
+
+    expect(() =>
+      globalThis.dispatchEvent(new PopStateEvent('popstate')),
+    ).not.toThrow();
+
+    expect(getFullScreenModeStatus()).toBe(false);
+    // the interrupted session must release the scroll lock and its listeners
+    expect(document.body.style.overflow).toBe('');
+    expect(spyBodyRemove).toHaveBeenCalledWith('keyup', onPressEscape);
+    expect(spyWindowRemove).toHaveBeenCalledWith('popstate', onPopstate);
+  });
+
+  it('restores the pre-fullscreen scroll position on exit', () => {
+    Object.defineProperty(globalThis, 'scrollY', {
+      value: 250,
+      writable: true,
+      configurable: true,
+    });
+
+    getButtons()[0].click();
+    document.body.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape' }));
+
+    expect(globalThis.scrollTo).toHaveBeenCalledWith(0, 250);
+  });
+
+  it('re-enters fullscreen and Escape still works after a back > forward sequence', () => {
+    getButtons()[0].click();
+    document.body.innerHTML = ''; // back: soft nav drops the container
+    globalThis.dispatchEvent(new PopStateEvent('popstate'));
+    expect(getFullScreenModeStatus()).toBe(false);
+
+    setupDom(); // forward: article DOM restored
+
+    getButtons()[0].click();
+    expect(getFullScreenModeStatus()).toBe(true);
+
+    document.body.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape' }));
+    expect(getFullScreenModeStatus()).toBe(false);
+  });
+
+  it('still opens with a single click after the pack re-binds controls', () => {
+    // InstantClick re-runs the pack on soft navigation, re-calling this bind.
+    addFullScreenModeControl(getButtons());
+    addFullScreenModeControl(getButtons());
+
+    getButtons()[0].click();
+    expect(getFullScreenModeStatus()).toBe(true);
+  });
+
+  it('derives open/closed from the DOM, so a click always matches the overlay', () => {
+    // The old module tracked state in a boolean that could stick "open" after an
+    // interrupted navigation, inverting the next click into a no-op collapse.
+    getButtons()[0].click();
+    expect(getFullScreenModeStatus()).toBe(true);
+    getButtons()[0].click();
+    expect(getFullScreenModeStatus()).toBe(false);
+    getButtons()[0].click();
+    expect(getFullScreenModeStatus()).toBe(true);
   });
 });

--- a/app/javascript/utilities/codeFullscreenModeSwitcher.js
+++ b/app/javascript/utilities/codeFullscreenModeSwitcher.js
@@ -1,17 +1,20 @@
-let isFullScreenModeCodeOn = false;
 let screenScroll = 0;
-const { body } = document;
+
+function getFullScreenWindow() {
+  return document.getElementsByClassName('js-fullscreen-code')[0];
+}
 
 export function getFullScreenModeStatus() {
-  return isFullScreenModeCodeOn;
+  // derive from the DOM so state can never desync from a stale module flag
+  return Boolean(getFullScreenWindow()?.classList.contains('is-open'));
 }
 
 function setAfterFullScreenScrollPosition() {
-  window.scrollTo(0, screenScroll);
+  globalThis.scrollTo(0, screenScroll);
 }
 
 function getBeforeFullScreenScrollPosition() {
-  screenScroll = window.scrollY;
+  screenScroll = globalThis.scrollY;
 }
 
 export function onPressEscape(event) {
@@ -34,18 +37,15 @@ export function onPopstate() {
 
 function listenToWindowForPopstate(listen) {
   if (listen) {
-    window.addEventListener('popstate', onPopstate);
+    globalThis.addEventListener('popstate', onPopstate);
   } else {
-    window.removeEventListener('popstate', onPopstate);
+    globalThis.removeEventListener('popstate', onPopstate);
   }
 }
 
 function toggleOverflowForDocument(overflow) {
-  if (overflow) {
-    body.style.overflow = 'hidden';
-  } else {
-    body.style.overflow = '';
-  }
+  // read document.body live; a cached reference goes stale after a soft navigation
+  document.body.style.overflow = overflow ? 'hidden' : '';
 }
 
 export function addFullScreenModeControl(elements) {
@@ -65,8 +65,7 @@ function removeFullScreenModeControl(elements) {
 }
 
 function fullScreenModeControl(event) {
-  const fullScreenWindow =
-    document.getElementsByClassName('js-fullscreen-code')[0];
+  const fullScreenWindow = getFullScreenWindow();
   const codeBlock = event?.currentTarget.closest('.js-code-highlight')
     ? event.currentTarget.closest('.js-code-highlight').cloneNode(true)
     : null;
@@ -74,7 +73,7 @@ function fullScreenModeControl(event) {
     ? codeBlock.getElementsByClassName('js-fullscreen-code-action')
     : null;
 
-  if (isFullScreenModeCodeOn) {
+  if (getFullScreenModeStatus()) {
     toggleOverflowForDocument(false);
     setAfterFullScreenScrollPosition();
     listenToKeyboardForEscape(false);
@@ -82,10 +81,18 @@ function fullScreenModeControl(event) {
     removeFullScreenModeControl(codeBlockControls);
 
     fullScreenWindow.classList.remove('is-open');
-    fullScreenWindow.removeChild(fullScreenWindow.childNodes[0]);
-
-    isFullScreenModeCodeOn = false;
+    // clears an already-emptied container and any stale leftovers alike
+    fullScreenWindow.replaceChildren();
   } else {
+    if (!codeBlock || !fullScreenWindow) {
+      // popstate/escape fire with no event; an interrupted session must still
+      // release the scroll lock and its listeners (all idempotent)
+      toggleOverflowForDocument(false);
+      listenToKeyboardForEscape(false);
+      listenToWindowForPopstate(false);
+      return;
+    }
+
     toggleOverflowForDocument(true);
     getBeforeFullScreenScrollPosition();
     listenToKeyboardForEscape(true);
@@ -96,7 +103,5 @@ function fullScreenModeControl(event) {
     fullScreenWindow.classList.add('is-open');
 
     addFullScreenModeControl(codeBlockControls);
-
-    isFullScreenModeCodeOn = true;
   }
 }

--- a/cypress/e2e/seededFlows/articleFlows/fullscreenCodeBlock.spec.js
+++ b/cypress/e2e/seededFlows/articleFlows/fullscreenCodeBlock.spec.js
@@ -1,0 +1,104 @@
+describe('Fullscreen code block exit control', () => {
+  beforeEach(() => {
+    cy.testSetup();
+    cy.fixture('users/articleEditorV1User.json').as('user');
+
+    cy.get('@user').then((user) => {
+      cy.loginUser(user).then(() => {
+        cy.createArticle({
+          title: 'Fullscreen code article',
+          tags: ['beginner'],
+          content: ['```ruby', 'def hello', '  puts "hi"', 'end', '```'].join(
+            '\n',
+          ),
+          published: true,
+        }).then((response) => {
+          cy.visitAndWaitForUserSideEffects(response.body.current_state_path);
+        });
+      });
+    });
+  });
+
+  // The enter control lives in a hover-revealed panel on the article page, so we
+  // force the click. Everything the tests actually assert is the EXIT experience.
+  const enterFullscreen = () =>
+    cy
+      .get('main .js-code-highlight .js-fullscreen-code-action')
+      .first()
+      .click({ force: true });
+
+  const overlay = () => cy.get('.fullscreen-code.is-open');
+  const exitControl = () =>
+    cy.get('.fullscreen-code.is-open .highlight-action--fullscreen-off');
+
+  it('opens on a single click and stays open (does not collapse)', () => {
+    // The old boolean state could invert a click, opening then instantly closing
+    // the overlay. A single click must leave it open with its cloned code intact.
+    enterFullscreen();
+
+    overlay().should('exist');
+    overlay().find('.js-code-highlight').should('exist');
+    overlay().find('pre.highlight').should('contain.text', 'puts');
+  });
+
+  it('reveals an exit control that is visible without hover', () => {
+    // Regression for #23535: the panel only un-hid on `:hover`, so the exit
+    // affordance was invisible on touch/non-hover devices.
+    enterFullscreen();
+
+    exitControl().should('be.visible');
+  });
+
+  it('places the exit control above the header so it is not occluded', () => {
+    // The overlay sits under the fixed header by default (z-index 500 vs 10000),
+    // burying the exit control. A real (non-forced) click only succeeds if the
+    // control is both visible AND on top — Cypress fails the click if it is
+    // covered by another element, so this is the z-index regression test.
+    enterFullscreen();
+    overlay().should('exist');
+
+    exitControl().click();
+    cy.get('.fullscreen-code.is-open').should('not.exist');
+  });
+
+  it('exits fullscreen on the Escape key', () => {
+    enterFullscreen();
+    overlay().should('exist');
+
+    cy.get('body').trigger('keyup', { key: 'Escape' });
+    cy.get('.fullscreen-code.is-open').should('not.exist');
+  });
+
+  it('re-opens after exiting, with state always in sync', () => {
+    // Exit then re-enter: a stale flag used to desync here and no-op the reopen.
+    enterFullscreen();
+    exitControl().click();
+    cy.get('.fullscreen-code.is-open').should('not.exist');
+
+    enterFullscreen();
+    overlay().should('exist');
+    exitControl().should('be.visible');
+  });
+
+  it('keeps working after a back/forward navigation', () => {
+    enterFullscreen();
+    overlay().should('exist');
+
+    // A browser back/forward fires popstate while the container may be swapped
+    // out. Dispatch it directly so the assertion does not depend on the history
+    // stack, while still exercising the same handler the back button triggers.
+    cy.window().then((win) => {
+      win.dispatchEvent(new PopStateEvent('popstate'));
+    });
+    cy.get('.fullscreen-code.is-open').should('not.exist');
+
+    // The interrupted session must not leave state stuck: re-enter, and confirm
+    // both the exit control and Escape still tear it down.
+    enterFullscreen();
+    overlay().should('exist');
+    exitControl().should('be.visible');
+
+    cy.get('body').trigger('keyup', { key: 'Escape' });
+    cy.get('.fullscreen-code.is-open').should('not.exist');
+  });
+});

--- a/lib/cypress-rails/manages_transactions.rb
+++ b/lib/cypress-rails/manages_transactions.rb
@@ -1,0 +1,50 @@
+require "cypress-rails/manages_transactions"
+
+# Rails 8 removed ConnectionPool#connection and #lock_thread=, which
+# cypress-rails 0.7 still uses to wrap the test server in a transaction
+# (testdouble/cypress-rails#165 is unmerged). Replaces the connection-based
+# strategy with the pool pinning Rails 8's own transactional fixtures use.
+module CypressRails
+  class ManagesTransactions
+    def begin_transaction
+      setup_shared_connection_pool
+
+      @connection_pools = ActiveRecord::Base.connection_handler.connection_pool_list(:writing)
+      @connection_pools.each do |pool|
+        pool.pin_connection!(true)
+        pool.lease_connection
+      end
+
+      # When connections are established in the future, begin a transaction too
+      @connection_subscriber = ActiveSupport::Notifications.subscribe("!connection.active_record") do |*, payload|
+        connection_name = payload[:connection_name] if payload.key?(:connection_name)
+        shard = payload[:shard] if payload.key?(:shard)
+        next unless connection_name
+
+        pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(connection_name, shard: shard)
+        next unless pool
+
+        setup_shared_connection_pool
+
+        unless @connection_pools.include?(pool)
+          pool.pin_connection!(true)
+          pool.lease_connection
+          @connection_pools << pool
+        end
+      end
+
+      @initializer_hooks.run(:after_transaction_start)
+    end
+
+    def rollback_transaction
+      return if @connection_pools.blank?
+
+      ActiveSupport::Notifications.unsubscribe(@connection_subscriber) if @connection_subscriber
+
+      @connection_pools.each(&:unpin_connection!)
+      @connection_pools.clear
+
+      ActiveRecord::Base.connection_handler.clear_active_connections!
+    end
+  end
+end

--- a/lib/cypress-rails/manages_transactions.rb
+++ b/lib/cypress-rails/manages_transactions.rb
@@ -37,9 +37,12 @@ module CypressRails
     end
 
     def rollback_transaction
-      return if @connection_pools.blank?
+      if @connection_subscriber
+        ActiveSupport::Notifications.unsubscribe(@connection_subscriber)
+        @connection_subscriber = nil
+      end
 
-      ActiveSupport::Notifications.unsubscribe(@connection_subscriber) if @connection_subscriber
+      return if @connection_pools.blank?
 
       @connection_pools.each(&:unpin_connection!)
       @connection_pools.clear

--- a/spec/requests/api/v1/pages_spec.rb
+++ b/spec/requests/api/v1/pages_spec.rb
@@ -68,7 +68,9 @@ RSpec.describe "Api::V1::Pages" do
     include_context "when user is authorized"
 
     let(:post_params) do
-      attributes_for(:page)
+      # Fixed title so find_by(title:) can never collide with the let!(:page)
+      # record — Faker::Book.title draws from a small pool and duplicates.
+      attributes_for(:page, title: "Api V1 Pages Spec Page")
     end
     let(:body_html) { "<div>hi, folks</div>" }
     let(:body_css) { "h1 {font-size: 120px}" }

--- a/spec/support/seeds/seeds_e2e.rb
+++ b/spec/support/seeds/seeds_e2e.rb
@@ -909,37 +909,6 @@ end
 
 ##############################################################################
 
-seeder.create_if_none(ListingCategory) do
-  ListingCategory.create!(
-    slug: "cfp",
-    cost: 1,
-    name: "Conference CFP",
-    rules: "Currently open for proposals, with link to form.",
-  )
-end
-
-##############################################################################
-
-seeder.create_if_none(Listing) do
-  Credit.add_to(admin_user, rand(1..100))
-  Credit.add_to(admin_user.organizations.first, rand(1..100))
-
-  Listing.create!(
-    user: admin_user,
-    title: "Listing title",
-    body_markdown: Faker::Markdown.random.lines.take(10).join,
-    location: Faker::Address.city,
-    organization_id: admin_user.organizations.first&.id,
-    listing_category_id: ListingCategory.first.id,
-    published: true,
-    originally_published_at: Time.current,
-    bumped_at: Time.current,
-    tag_list: Tag.order(Arel.sql("RANDOM()")).first(2).pluck(:name),
-  )
-end
-
-##############################################################################
-
 seeder.create_if_none(Tag) do
   10.times do |i|
     tag = Tag.create!(


### PR DESCRIPTION
> [!IMPORTANT]
> This PR was written by Claude (Claude Code, Fable 5 model), directed and reviewed by @anchildress1.
> I told Claude to write "Welcome back Fable!" It replied with
> <img width="413" height="38" alt="image" src="https://github.com/user-attachments/assets/d110d5e3-5024-4a42-aad6-449d35273bfb" />


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The fullscreen code block overlay had no reachable exit on touch/non-hover devices: the exit panel was only revealed on `:hover`, and the overlay rendered *under* the fixed header (`--z-modal: 500` vs `#topbar` at 10000), occluding the control even when visible.

- Exit panel is now always visible in fullscreen; overlay sits above the header (10001, matching the image-lightbox close control)
- Fullscreen state is derived from the DOM (`is-open` class) instead of a module-level boolean, so an interrupted soft navigation can no longer desync clicks from the overlay
- An interrupted session (back navigation while fullscreen) now releases the `overflow: hidden` scroll lock and its listeners

Two small e2e-infra fixes ride along so the new Cypress spec can run: removal of seeds referencing the deleted `ListingCategory` model (crashed all seeded runs with a `NameError`), and a Rails 8 compatibility patch for cypress-rails 0.7 transactions (upstream fix testdouble/cypress-rails#165 is unmerged).

## Related Tickets & Documents

- Closes #23535

## QA Instructions, Screenshots, Recordings

1. Open an article containing a fenced code block
2. Expand the code block to fullscreen (on a touch device or with DevTools touch emulation)
3. The exit control should be visible without hovering and clickable (not buried under the header)
4. Escape key and browser back both exit fullscreen; the page scrolls normally afterward and fullscreen can be re-entered

Tested on macOS: Chrome (Cypress) and jsdom (Jest).

### UI accessibility checklist
- [x] Semantic HTML implemented?
- [x] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

**Before:**
<img width="1728" height="258" alt="image" src="https://github.com/user-attachments/assets/39b2e47a-d57c-4900-a9a2-a867e7bd56a4" />

**After :**
<img width="1728" height="206" alt="image" src="https://github.com/user-attachments/assets/a9717742-a01c-4a68-80cc-1a5552477d79" />

## Added/updated tests?

- [x] Yes (Jest edge cases + a new seeded Cypress flow covering visibility, occlusion, Escape, and back/forward)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785547014&installation_id=139885019&pr_number=23543&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23543&signature=e26e7f54a177775cdc300e4d60f58485960218a9e97a51b8f29592714d93b246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->