### PR TITLE
Mask page views under 25 on /manage to match the dashboard

### DIFF
--- a/app/views/articles/manage.html.erb
+++ b/app/views/articles/manage.html.erb
@@ -97,7 +97,13 @@
         <div class="grid gap-4" style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));">
           <div class="crayons-card p-4" style="background: var(--card-secondary-bg);">
             <div class="color-base-60 fs-s mb-1">Page Views</div>
-            <div class="fs-3xl fw-bold"><%= number_with_delimiter(@article.page_views_count) %></div>
+            <div class="fs-3xl fw-bold">
+              <% if @article.page_views_count > 25 %>
+                <%= number_with_delimiter(@article.page_views_count) %>
+              <% else %>
+                <%= t("views.dashboard.article.views.lt_25") %>
+              <% end %>
+            </div>
           </div>
           
           <div class="crayons-card p-4" style="background: var(--card-secondary-bg);">

--- a/spec/requests/articles/articles_spec.rb
+++ b/spec/requests/articles/articles_spec.rb
@@ -308,6 +308,21 @@ RSpec.describe "Articles" do
       expect(response.body).to include("Manage Your Post")
     end
 
+    it "masks page views at or below 25, matching the dashboard" do
+      article = create(:article, user: user)
+      article.update_column(:page_views_count, 25)
+      get "#{article.path}/manage"
+      expect(response.body).to include(CGI.escapeHTML(I18n.t("views.dashboard.article.views.lt_25")))
+    end
+
+    it "shows the exact page views count above 25" do
+      article = create(:article, user: user)
+      article.update_column(:page_views_count, 1234)
+      get "#{article.path}/manage"
+      expect(response.body).to include("1,234")
+      expect(response.body).not_to include(CGI.escapeHTML(I18n.t("views.dashboard.article.views.lt_25")))
+    end
+
     it "returns unauthorized for a draft" do
       draft = create(:article, published: false, user: user)
       expect { get "#{draft.path}/manage" }.to raise_error(Pundit::NotAuthorizedError)


### PR DESCRIPTION
> [!IMPORTANT]
> This PR was generated by Claude and reviewed by me, @anchildress1 

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The `/manage` page's Statistics card rendered the raw `page_views_count` column, surfacing a misleading **"Page Views: 0"** for low-traffic posts — which is what prompted the linked issue.

Counts at or below 25 are unreliable by design:

- Anonymous views are sampled client-side at 1-in-10 (weighted ×10 server-side)
- The author's own views are excluded
- The counter column syncs asynchronously via `Articles::UpdatePageViewsWorker`

This is exactly why the posts dashboard (`_dashboard_article_row.html.erb`) masks counts ≤ 25 as `< 25`. This PR applies the same convention to the manage page's Statistics card, reusing the existing `views.dashboard.article.views.lt_25` translation (already present in `en`, `fr`, and `pt`). Counts above 25 render the exact delimited number, unchanged.

## Related Tickets & Documents

- Closes Issue #23542

## QA Instructions, Screenshots, Recordings

1. Sign in as an author and publish a post.
2. Visit `/{username}/{slug}/manage` while the post has ≤ 25 recorded page views → the Page Views card shows `< 25` instead of a raw `0`.
3. Set `page_views_count` above 25 (e.g. `article.update_column(:page_views_count, 1234)` in a console) and reload → the card shows the exact count (`1,234`).
4. The posts dashboard (`/dashboard`) behavior is unchanged and now matches `/manage`.

Tested via request specs (server-rendered ERB change only, no JS involved).

<img width="1320" height="604" alt="image" src="https://github.com/user-attachments/assets/35295cdf-ba78-4b26-8ed1-3ba0a9a0574a" />

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [x] Semantic HTML implemented?
- [x] Keyboard operability supported?
- [x] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [x] Color contrast tested?

_Text-only change inside an existing card; no structural, interactive, or color changes._

## Added/updated tests?

- [x] Yes

Two request specs in `spec/requests/articles/articles_spec.rb`: masked rendering at 25 views, exact rendering above 25.

## [optional] Are there any post deployment tasks we need to perform?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785611128&installation_id=139885019&pr_number=23549&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23549&signature=8c0ec91a1334051fdf58400529648e0061d3658da92daa8bb2e09fb0f755dc0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->