### PR TITLE
feat: Add contributor organization role and draft-only publishing restriction

### DIFF
--- a/app/assets/stylesheets/views.scss
+++ b/app/assets/stylesheets/views.scss
@@ -13,4 +13,5 @@
 @import 'views/signup-modal';
 @import 'views/events';
 @import 'views/trends';
+@import 'views/tags';
 

--- a/app/assets/stylesheets/views/tags.scss
+++ b/app/assets/stylesheets/views/tags.scss
@@ -1,0 +1,168 @@
+// Tag Landing Page Styles
+@import 'config/import';
+@import 'variables';
+@import '_mixins';
+
+.tag-header-wrapper {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  margin-bottom: var(--su-4);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.tag-header-cover {
+  height: 24px;
+  background-color: var(--tag-bg-color, var(--accent-brand));
+  background-image: linear-gradient(180deg, rgba(0, 0, 0, 0.08) 0%, transparent 100%);
+  transition: background-color 0.2s ease;
+
+  @media (min-width: 768px) {
+    height: 48px;
+  }
+}
+
+.tag-header-main {
+  display: flex;
+  flex-direction: column;
+  padding: var(--su-4);
+  gap: var(--su-4);
+  position: relative;
+
+  @media (min-width: 768px) {
+    flex-direction: row;
+    align-items: flex-start;
+    padding: var(--su-4) var(--su-6) var(--su-5);
+    gap: var(--su-5);
+  }
+}
+
+.tag-header-logo {
+  width: 64px;
+  height: 64px;
+  border-radius: var(--radius);
+  background-color: var(--card-bg);
+  border: 1px solid var(--card-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-top: -24px; // Overlap cover banner
+  z-index: 2;
+  box-shadow: var(--shadow-sm);
+  padding: var(--su-2);
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+
+  @media (min-width: 768px) {
+    width: 80px;
+    height: 80px;
+    margin-top: -48px;
+    padding: var(--su-3);
+  }
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+    
+    &:hover {
+      transform: rotate(0deg) scale(1.1) !important;
+    }
+  }
+}
+
+.tag-header-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--su-1);
+
+  h1 {
+    font-size: var(--fs-xl);
+    font-weight: var(--fw-bold);
+    line-height: 1.2;
+    color: var(--card-color, inherit);
+    margin: 0;
+
+    @media (min-width: 768px) {
+      font-size: var(--fs-2xl);
+    }
+  }
+
+  p {
+    font-size: var(--fs-base);
+    color: var(--card-color-secondary, var(--color-base-70));
+    line-height: 1.5;
+    margin: 0;
+    max-width: 800px;
+  }
+}
+
+.tag-header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--su-2);
+  flex-shrink: 0;
+
+  @media (max-width: 767px) {
+    width: 100%;
+    justify-content: flex-start;
+  }
+  
+  // Custom button styling using the tag's color
+  .js-follow-tag-button {
+    background-color: var(--tag-bg-color, var(--accent-brand));
+    border-color: var(--tag-bg-color, var(--accent-brand));
+    color: var(--tag-text-color, #ffffff);
+    font-weight: var(--fw-medium);
+    
+    &:hover {
+      filter: brightness(0.9);
+    }
+  }
+}
+
+// Tag feed pills navigation
+.tag-feed-nav-capsule {
+  display: flex;
+  gap: var(--su-1);
+  padding: var(--su-1);
+  background: var(--body-bg);
+  border-radius: 9999px;
+  box-shadow: 0 0 0 1px var(--base-20), 0 2px 5px rgba(0, 0, 0, 0.05);
+  margin: 6px 0 3px;
+  list-style: none;
+
+  .crayons-navigation__item {
+    border-radius: 9999px;
+    padding: var(--su-1) var(--su-3);
+    font-size: var(--fs-sm);
+    display: flex;
+    align-items: center;
+    gap: var(--su-2);
+    transition: all 0.2s ease;
+    color: var(--base-70);
+    border-bottom: none;
+
+    @media (min-width: 640px) {
+      padding: var(--su-1) var(--su-4);
+      font-size: var(--fs-base);
+    }
+
+    &:hover {
+      color: var(--base-90);
+      background: var(--base-5);
+    }
+
+    &.crayons-navigation__item--current {
+      background: var(--accent-brand, #3b49df) !important;
+      color: #ffffff !important;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15) !important;
+      font-weight: var(--fw-bold);
+    }
+  }
+}

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -230,25 +230,37 @@ class StoriesController < ApplicationController
     end
 
     unless is_readme
-      # Get active users ordered by badge achievements
-      # For find_each_respecting_scope compatibility, we get ordered IDs first (with order column in select)
-      # then create a relation that preserves that order when .ids is called
-      # This avoids the DISTINCT/ORDER BY conflict when find_each_respecting_scope calls .ids
+      # Get active users (excluding contributors) ordered by badge achievements
       ordered_user_data = @organization.active_users
+                                       .where.not(organization_memberships: { type_of_user: "contributor" })
                                        .select("users.id, users.badge_achievements_count")
                                        .order(Arel.sql("users.badge_achievements_count DESC NULLS LAST, users.id ASC"))
                                        .pluck(:id, :badge_achievements_count)
       ordered_user_ids = ordered_user_data.map(&:first)
 
-      # Create a relation that preserves the order when .ids is called by find_each_respecting_scope
-      # The limit applied in the view will be respected by checking the relation's limit_value
       @organization_users = User.where(id: ordered_user_ids).extending(Module.new do
-        ids_array = ordered_user_ids.dup # Capture in closure
+        ids_array = ordered_user_ids.dup
         define_method :ids do
-          # Return IDs in the order they were provided, preserving the badge_achievements_count ordering
-          # This is called by in_batches_respecting_scope to get all IDs before batching
-          # Check if a limit was applied to this relation and respect it
-          # limit_value is available on ActiveRecord::Relation
+          limit = limit_value
+          if limit
+            ids_array.take(limit)
+          else
+            ids_array
+          end
+        end
+      end)
+
+      # Get active contributors ordered by badge achievements
+      ordered_contributor_data = @organization.active_users
+                                              .where(organization_memberships: { type_of_user: "contributor" })
+                                              .select("users.id, users.badge_achievements_count")
+                                              .order(Arel.sql("users.badge_achievements_count DESC NULLS LAST, users.id ASC"))
+                                              .pluck(:id, :badge_achievements_count)
+      ordered_contributor_ids = ordered_contributor_data.map(&:first)
+
+      @organization_contributors = User.where(id: ordered_contributor_ids).extending(Module.new do
+        ids_array = ordered_contributor_ids.dup
+        define_method :ids do
           limit = limit_value
           if limit
             ids_array.take(limit)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -32,7 +32,7 @@ class Article < ApplicationRecord
   # admin_update was added as a hack to bypass published_at validation when admin is updating
   # TODO: [@lightalloy] remove published_at validation from the model and
   # move it to the services where the create/update takes place to avoid using hacks
-  attr_accessor :publish_under_org, :admin_update
+  attr_accessor :publish_under_org, :admin_update, :editing_user
   attr_writer :series, :labels
   attr_accessor :body_url
 
@@ -281,6 +281,7 @@ class Article < ApplicationRecord
   validate :title_unique_for_user_past_five_minutes
   validate :restrict_attributes_with_status_types
   validate :restrict_type_based_on_role
+  validate :restrict_contributor_publishing
   validate :canonical_url_must_not_have_spaces
   validate :validate_collection_permission
   validate :validate_tag
@@ -1855,6 +1856,20 @@ class Article < ApplicationRecord
        saved_change_to_published_at? ||
        saved_change_to_main_image?
       Articles::UpdateDependentEmbedsWorker.perform_async(id)
+    end
+  end
+
+  def restrict_contributor_publishing
+    return unless organization_id
+    return unless user
+
+    if user.org_contributor?(organization)
+      if published?
+        editor = editing_user || user
+        unless editor.org_admin?(organization) || editor.any_admin?
+          errors.add(:published, I18n.t("models.article.contributor_cannot_publish"))
+        end
+      end
     end
   end
 end

--- a/app/models/organization_membership.rb
+++ b/app/models/organization_membership.rb
@@ -5,7 +5,7 @@ class OrganizationMembership < ApplicationRecord
   belongs_to :user
   belongs_to :organization
 
-  USER_TYPES = %w[admin member guest pending].freeze
+  USER_TYPES = %w[admin member guest pending contributor].freeze
 
   validates :type_of_user, presence: true
   validates :user_id, uniqueness: { scope: :organization_id }
@@ -21,7 +21,8 @@ class OrganizationMembership < ApplicationRecord
   after_commit :recompile_organization_pages
 
   scope :admin, -> { where(type_of_user: "admin") }
-  scope :member, -> { where(type_of_user: %w[admin member]) }
+  scope :member, -> { where(type_of_user: %w[admin member contributor]) }
+  scope :contributor, -> { where(type_of_user: "contributor") }
   scope :pending, -> { where(type_of_user: "pending") }
   scope :active, -> { where.not(type_of_user: "pending") }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -657,6 +657,10 @@ class User < ApplicationRecord
     organization_memberships.admin.exists?(organization: organization)
   end
 
+  def org_contributor?(organization)
+    organization_memberships.contributor.exists?(organization: organization)
+  end
+
   def block; end
 
   def all_blocked_by

--- a/app/services/articles/creator.rb
+++ b/app/services/articles/creator.rb
@@ -70,12 +70,14 @@ module Articles
       begin
         @article = Article.new(article_params) do |article|
           article.user_id = user.id
+          article.editing_user = user
           article.show_comments = true
         end
       rescue ArgumentError => e
         if e.message.include?("is not a valid type_of")
           @article = Article.new(article_params.except(:type_of)) do |article|
             article.user_id = user.id
+            article.editing_user = user
           end
           @article.errors.add(:type_of, :invalid)
           return @article

--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -14,6 +14,7 @@ module Articles
 
     def call
       user.rate_limiter.check_limit!(:article_update)
+      article.editing_user = user
       success = article.update(article_params)
 
       if success

--- a/app/views/admin/users/modals/_add_organization_modal.html.erb
+++ b/app/views/admin/users/modals/_add_organization_modal.html.erb
@@ -8,7 +8,7 @@
     <div class="crayons-field">
       <%= f.label :type_of_user, t("views.admin.users.actions.add_org.role"), class: "crayons-field__label" %>
           <p id="add-org-permission-description" class="crayons-field__description"><%= t("views.admin.users.actions.add_org.role_desc_html", user: tag.span(class: "js-user-name")) %></p>
-      <%= f.select(:type_of_user, options_for_select({ t("views.admin.users.actions.add_org.member") => "member", t("views.admin.users.actions.add_org.admin") => "admin" }), {}, class: "crayons-select", aria: { describedby: "add-org-permission-description" }) %>
+      <%= f.select(:type_of_user, options_for_select({ t("views.admin.users.actions.add_org.member") => "member", t("views.admin.users.actions.add_org.admin") => "admin", t("views.admin.users.actions.add_org.contributor") => "contributor" }), {}, class: "crayons-select", aria: { describedby: "add-org-permission-description" }) %>
     </div>
     <div>
       <%= f.submit t("views.admin.users.actions.add_org.submit"), class: "c-btn c-btn--primary" %>

--- a/app/views/admin/users/show/overview/_organizations.html.erb
+++ b/app/views/admin/users/show/overview/_organizations.html.erb
@@ -50,7 +50,7 @@
           <p class="crayons-field__description"><%= t("views.admin.users.actions.add_org.role_desc_html", user: @user.name) %></p>
           <%= f.select(:type_of_user,
                        options_for_select(
-                         { t("views.admin.users.actions.add_org.member") => "member", t("views.admin.users.actions.add_org.admin") => "admin" },
+                         { t("views.admin.users.actions.add_org.member") => "member", t("views.admin.users.actions.add_org.admin") => "admin", t("views.admin.users.actions.add_org.contributor") => "contributor" },
                          selected: org_membership.type_of_user,
                        ),
                        {},

--- a/app/views/organization_settings/edit.html.erb
+++ b/app/views/organization_settings/edit.html.erb
@@ -569,6 +569,8 @@
                   <% end %>
                   <% if org_membership.type_of_user == "admin" %>
                     <span class="c-indicator c-indicator--danger"><%= t("views.settings.org.admin.admin") %></span>
+                  <% elsif org_membership.type_of_user == "contributor" %>
+                    <span class="c-indicator c-indicator--info"><%= t("views.settings.org.admin.contributor") %></span>
                   <% end %>
                 </p>
 

--- a/app/views/organizations/_sidebar.html.erb
+++ b/app/views/organizations/_sidebar.html.erb
@@ -25,6 +25,24 @@
       <% end %>
     </div>
   <% end %>
+  <% if @organization_contributors.present? && @organization_contributors.any? %>
+    <div class="crayons-card crayons-card--secondary org-sidebar-widget">
+      <header class="crayons-card__header">
+        <h3 class="crayons-subtitle-3">
+          <%= t("views.organizations.contributors") %>
+        </h3>
+      </header>
+      <div class="org-sidebar-widget-body">
+        <% @organization_contributors.limit(@user_limit).find_each_respecting_scope do |user| %>
+          <div class="org-sidebar-widget-user-pic">
+            <a href="/<%= user.username %>">
+              <img src="<%= user.profile_image_url_for(length: 90) %>" alt="<%= user.username %> profile image" loading="lazy" />
+            </a>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
   <% if @organization.story.present? %>
     <div class="crayons-card crayons-card--secondary">
       <header class="crayons-card__header">

--- a/app/views/stories/tagged_articles/_sidebar.html.erb
+++ b/app/views/stories/tagged_articles/_sidebar.html.erb
@@ -1,5 +1,5 @@
 <% cache "tag-sidebar-#{@tag.name}-#{@tag&.updated_at}-#{user_signed_in?}-#{@page}", expires_in: 72.hours do %>
-  <div id="sidebar-wrapper-left" class="sidebar-wrapper sidebar-wrapper-left">
+  <div id="sidebar-wrapper-left" class="sidebar-wrapper sidebar-wrapper-left crayons-layout__sidebar-left crayons-layout__content">
     <div class="sidebar-bg" id="sidebar-bg-left"></div>
     <aside class="side-bar fs-s">
       <% if @tag %>

--- a/app/views/stories/tagged_articles/_sidebar_additional.html.erb
+++ b/app/views/stories/tagged_articles/_sidebar_additional.html.erb
@@ -1,5 +1,5 @@
 <% if @page == 1 %>
-  <div id="sidebar-wrapper-right" class="sidebar-wrapper sidebar-wrapper-right">
+  <div id="sidebar-wrapper-right" class="sidebar-wrapper sidebar-wrapper-right crayons-layout__sidebar-right crayons-layout__content">
     <div class="sidebar-bg" id="sidebar-bg-right"></div>
     <aside class="side-bar sidebar-additional showing fs-s" id="sidebar-additional">
       <% active_threads = active_threads(tags: [@tag.name, "discuss"], time_ago: Timeframe.datetime(params[:timeframe])) %>

--- a/app/views/stories/tagged_articles/index.html.erb
+++ b/app/views/stories/tagged_articles/index.html.erb
@@ -1,52 +1,54 @@
 <%= content_for :page_meta do %>
   <%= render "stories/tagged_articles/meta" %>
 <% end %>
-<div data-tag-id="<%= @tag.id %>" data-tag-name="<%= @tag.name %>" id="tag-<%= @tag.id %>" class="crayons-layout js-tag-card">
-  <header class="crayons-card branded-4 p-4 l:p-6 spec__tag-header" style="border-top-color: <%= @tag.bg_color_hex %> ">
-    <div class="flex">
+<div data-tag-id="<%= @tag.id %>"
+     data-tag-name="<%= @tag.name %>"
+     id="tag-<%= @tag.id %>"
+     class="js-tag-card tag-header-wrapper"
+     style="--tag-bg-color: <%= @tag.bg_color_hex %>; --tag-text-color: <%= @tag.text_color_hex %>;">
+  <div class="tag-header-cover"></div>
+  <div class="crayons-layout">
+    <div class="tag-header-main spec__tag-header">
       <% if @tag.badge_id && @tag.badge %>
-          <img src="<%= optimized_image_url(@tag.badge.badge_image_url, width: 64) %>" alt="" class="mr-4" style="transform: rotate(<%= -25 + (@tag.id.digits.first * 5) %>deg); width: 64px; height: 64px;" />
-      <% end %>
-      <div class="flex flex-col w-100 justify-center">
-        <div class="flex justify-between items-center">
-          <h1 class="crayons-title">
-            <% if @tag && @tag.pretty_name.present? %>
-              <%= @tag.pretty_name %>
-            <% else %>
-              <span class="opacity-50">#</span>
-              <%= @tag.name %>
-            <% end %>
-          </h1>
-          <% if @tag %>
-            <div id="tag-buttons-<%= @tag.id %>" class="mt-auto flex items-end justify-between">
-              <div class="flex gap-2">
-                <button
-                  class="c-btn c-btn--primary js-follow-tag-button"
-                  aria-label="<%= t("views.tags.aria_labels.follow", tag_name: @tag.name) %>">
-                  <%= t("views.tags.follow") %>
-                </button>
-                <button
-                  class="c-btn js-hide-tag-button"
-                  aria-label="<%= t("views.tags.aria_labels.hide", tag_name: @tag.name) %>">
-                  <%= t("views.tags.hide") %>
-                </button>
-              </div>
-            </div>
-          <% end %>
+        <div class="tag-header-logo">
+          <img src="<%= optimized_image_url(@tag.badge.badge_image_url, width: 90) %>" alt="" style="transform: rotate(<%= -25 + (@tag.id.digits.first * 5) %>deg);" />
         </div>
+      <% end %>
+      <div class="tag-header-text">
+        <h1 class="crayons-title fw-heavy">
+          <% if @tag && @tag.pretty_name.present? %>
+            <%= @tag.pretty_name %>
+          <% else %>
+            <span class="opacity-50">#</span><%= @tag.name %>
+          <% end %>
+        </h1>
         <% if @tag && @tag.short_summary.present? %>
-          <p class="max-w-100 m:max-w-75 pt-2 s:pt-4">
+          <p class="fs-base color-base-70 mt-1">
             <%= strip_tags(@tag.short_summary) %>
           </p>
         <% end %>
       </div>
+      <% if @tag %>
+        <div id="tag-buttons-<%= @tag.id %>" class="tag-header-actions">
+          <div class="flex gap-2">
+            <button
+              class="c-btn c-btn--primary js-follow-tag-button"
+              aria-label="<%= t("views.tags.aria_labels.follow", tag_name: @tag.name) %>">
+              <%= t("views.tags.follow") %>
+            </button>
+            <button
+              class="c-btn js-hide-tag-button"
+              aria-label="<%= t("views.tags.aria_labels.hide", tag_name: @tag.name) %>">
+              <%= t("views.tags.hide") %>
+            </button>
+          </div>
+        </div>
+      <% end %>
     </div>
-    <% if @tag && @tag.short_summary.present? %>
-    <% end %>
-  </header>
+  </div>
 </div>
 
-<div class="home sub-home" id="index-container"
+<div class="crayons-layout crayons-layout--3-cols crayons-layout--3-cols--drop-right-left" id="index-container"
     data-params="<%= params.merge(sort_by: "hotness_score", sort_direction: "desc").to_json(only: %i[tag username sort_by sort_direction]) %>" data-which=""
     data-tag="<%= @tag.name %>"
     data-feed="<%= params[:timeframe] || "base-feed" %>"
@@ -54,7 +56,7 @@
     data-requires-approval="<%= @tag.requires_approval %>"
     data-articles-since="<%= Timeframe.datetime_iso8601(params[:timeframe]) %>">
   <%= render "stories/tagged_articles/sidebar" %>
-  <main class="articles-list" id="main-content" data-follow-button-container="true">
+  <main class="articles-list crayons-layout__content" id="main-content" data-follow-button-container="true">
     <header class="flex items-center p-2 m:p-0 m:pb-2" id="on-page-nav-controls">
       <h1 class="screen-reader-only"><%= t("views.stories.heading") %></h1>
       <button type="button" class="crayons-btn crayons-btn--ghost crayons-btn--icon mr-2 inline-block m:hidden mb-auto" id="on-page-nav-butt-left" aria-label="<%= t("views.stories.menu.aria_left") %>">
@@ -65,21 +67,35 @@
       <% if user_signed_in? %>
         <div class="flex-1 flex items-center justify-between">
           <nav class="-mx-3 m:mx-0 s:flex items-center justify-between w-100" aria-label="<%= t("views.stories.sort.aria_tagged") %>">
-            <ul class="crayons-navigation crayons-navigation--horizontal">
+            <ul class="tag-feed-nav-capsule">
               <li>
                 <a data-text="<%= t("views.stories.sort.relevant") %>" href="<%= list_path %>" class="crayons-navigation__item <%= "crayons-navigation__item--current" if %w[week month year infinity latest].exclude?(params[:timeframe]) %>"
-                  <%= %w[week month year infinity latest].exclude?(params[:timeframe]) ? ' aria-current="page"'.html_safe : "" %>><%= t("views.stories.sort.relevant") %></a>
+                  <%= %w[week month year infinity latest].exclude?(params[:timeframe]) ? ' aria-current="page"'.html_safe : "" %> style="border-radius: 9999px; transition: all 0.2s ease;">
+                  <%= crayons_icon_tag("discover", width: 18, height: 18, class: "hidden s:block") %>
+                  <span style="display: grid; place-items: center start;">
+                    <span aria-hidden="true" style="grid-area: 1/1; visibility: hidden; font-weight: bold;"><%= t("views.stories.sort.relevant") %></span>
+                    <span style="grid-area: 1/1;"><%= t("views.stories.sort.relevant") %></span>
+                  </span>
+                </a>
               </li>
               <li>
-                <a data-text="<%= t("views.stories.sort.latest") %>" href="<%= list_path %>/latest" class="crayons-navigation__item <%= "crayons-navigation__item--current" if timeframe_check("latest") %>"<%= timeframe_check("latest") ? ' aria-current="page"'.html_safe : "" %>>
-                  <%= t("views.stories.sort.latest") %>
+                <a data-text="<%= t("views.stories.sort.latest") %>" href="<%= list_path %>/latest" class="crayons-navigation__item <%= "crayons-navigation__item--current" if timeframe_check("latest") %>"<%= timeframe_check("latest") ? ' aria-current="page"'.html_safe : "" %> style="border-radius: 9999px; transition: all 0.2s ease;">
+                  <%= crayons_icon_tag("latest", width: 18, height: 18, class: "hidden s:block") %>
+                  <span style="display: grid; place-items: center start;">
+                    <span aria-hidden="true" style="grid-area: 1/1; visibility: hidden; font-weight: bold;"><%= t("views.stories.sort.latest") %></span>
+                    <span style="grid-area: 1/1;"><%= t("views.stories.sort.latest") %></span>
+                  </span>
                 </a>
               </li>
               <li>
                 <a data-text="<%= t("views.stories.sort.top") %>" href="<%= list_path %>/top/week"
                   class="crayons-navigation__item <%= "crayons-navigation__item--current" if timeframe_check("week") || timeframe_check("month") || timeframe_check("year") || timeframe_check("infinity") %>"
-                  <%= timeframe_check("week") || timeframe_check("month") || timeframe_check("year") || timeframe_check("infinity") ? ' aria-current="page"'.html_safe : "" %>>
-                    <%= t("views.stories.sort.top") %>
+                  <%= timeframe_check("week") || timeframe_check("month") || timeframe_check("year") || timeframe_check("infinity") ? ' aria-current="page"'.html_safe : "" %> style="border-radius: 9999px; transition: all 0.2s ease;">
+                  <%= crayons_icon_tag("fire", width: 18, height: 18, class: "hidden s:block") %>
+                  <span style="display: grid; place-items: center start;">
+                    <span aria-hidden="true" style="grid-area: 1/1; visibility: hidden; font-weight: bold;"><%= t("views.stories.sort.top") %></span>
+                    <span style="grid-area: 1/1;"><%= t("views.stories.sort.top") %></span>
+                  </span>
                 </a>
               </li>
             </ul>

--- a/app/views/stories/tagged_articles/index.html.erb
+++ b/app/views/stories/tagged_articles/index.html.erb
@@ -8,7 +8,7 @@
      style="--tag-bg-color: <%= @tag.bg_color_hex %>; --tag-text-color: <%= @tag.text_color_hex %>;">
   <div class="tag-header-cover"></div>
   <div class="crayons-layout">
-    <div class="tag-header-main spec__tag-header">
+    <header class="tag-header-main spec__tag-header">
       <% if @tag.badge_id && @tag.badge %>
         <div class="tag-header-logo">
           <img src="<%= optimized_image_url(@tag.badge.badge_image_url, width: 90) %>" alt="" style="transform: rotate(<%= -25 + (@tag.id.digits.first * 5) %>deg);" />
@@ -44,7 +44,7 @@
           </div>
         </div>
       <% end %>
-    </div>
+    </header>
   </div>
 </div>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,6 +53,9 @@ module PracticalDeveloper
     # TODO: Revert to :json after legacy links (valid for 31 days) have expired.
     config.active_support.message_serializer = :json_allow_marshal
 
+    # Enable JSON message serializer for metadata to avoid legacy Marshal format dependency.
+    config.active_support.use_message_serializer_for_metadata = true
+
 
     # Enable validating only parent-related columns for presence when the parent is mandatory.
     config.active_record.belongs_to_required_validates_foreign_key = true

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -22,6 +22,7 @@ en:
       published: Published
       unique_url: has already been taken. Email %{email} for further details.
       future_or_current_published_at: only future or current published_at allowed
+      contributor_cannot_publish: only organization admins can publish contributor posts
 
       immutable_published_at: updating published_at for articles that have already been published is not allowed
       mention_too_many:

--- a/config/locales/models/fr.yml
+++ b/config/locales/models/fr.yml
@@ -22,6 +22,7 @@ fr:
       published: Publié
       unique_url: a déjà été pris. Envoyez un e-mail à %{email} pour plus de détails.
       future_or_current_published_at: seulement le futur ou le présent published_at autorisé lors de la publication d'un article
+      contributor_cannot_publish: seuls les administrateurs de l'organisation peuvent publier les articles des contributeurs
       immutable_published_at: la mise à jour de published_at pour les articles qui ont déjà été publiés n'est pas autorisée
       mention_too_many:
         one: Vous ne pouvez pas mentionner plus de %{count} utilisateurs dans un article !

--- a/config/locales/models/pt.yml
+++ b/config/locales/models/pt.yml
@@ -22,6 +22,7 @@ pt:
       published: Publicado
       unique_url: já foi usado. Envie um e-mail para %{email} para mais detalhes.
       future_or_current_published_at: apenas published_at futuro ou atual permitido
+      contributor_cannot_publish: apenas administradores da organização podem publicar posts de colaboradores
       immutable_published_at: atualizar published_at para artigos que já foram publicados não é permitido
       mention_too_many:
         one: Você não pode mencionar mais de %{count} usuários em um post!

--- a/config/locales/views/admin/en.yml
+++ b/config/locales/views/admin/en.yml
@@ -129,9 +129,10 @@ en:
             edit: Edit %{user}'s role at an organization
             id: Organization ID
             role: Role
-            role_desc_html: You can assign %{user} to be an Admin or a regular member.
+            role_desc_html: You can assign %{user} to be an Admin, a regular member, or a contributor.
             admin: admin
             member: member
+            contributor: contributor
             submit: Add organization
           adjust_credit:
             text: Adjust credit balance
@@ -292,6 +293,7 @@ en:
               admin: Admin
               member: Member
               guest: Guest
+              contributor: Contributor
             revoke_confirm: Are your sure you want to remove %{user} from %{org}?
             submit: Submit
           roles:

--- a/config/locales/views/admin/fr.yml
+++ b/config/locales/views/admin/fr.yml
@@ -129,9 +129,10 @@ fr:
             edit: Edit %{user}'s role at an organization
             id: Organization ID
             role: Role
-            role_desc_html: You can assign %{user} to be an Admin or a regular member.
+            role_desc_html: You can assign %{user} to be an Admin, a regular member, or a contributor.
             admin: admin
             member: member
+            contributor: contributeur
             submit: Add organization
           adjust_credit:
             text: Adjust credit balance
@@ -284,6 +285,7 @@ fr:
               admin: Admin
               member: Member
               guest: Guest
+              contributor: Contributeur
             revoke_confirm: Are your sure you want to remove %{user} from %{org}?
             submit: Submit
           roles:

--- a/config/locales/views/organizations/en.yml
+++ b/config/locales/views/organizations/en.yml
@@ -156,6 +156,7 @@ en:
             other: "%{count} members"
       support: Support email
       team: Meet the team
+      contributors: Contributors
       all_members: See All Members
       twitter:
         icon: Twitter logo

--- a/config/locales/views/organizations/fr.yml
+++ b/config/locales/views/organizations/fr.yml
@@ -155,6 +155,7 @@ fr:
             other: "%{count} members"
       support: Support email
       team: Meet the team
+      contributors: Contributeurs
       all_members: See All Members
       twitter:
         icon: Twitter logo

--- a/config/locales/views/organizations/pt.yml
+++ b/config/locales/views/organizations/pt.yml
@@ -156,6 +156,7 @@ pt:
             other: "%{count} members"
       support: Support email
       team: Meet the team
+      contributors: Colaboradores
       all_members: See All Members
       twitter:
         icon: Twitter logo

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -165,6 +165,7 @@ en:
       org:
         admin:
           admin: Admin
+          contributor: Contributor
           copy:
             button:
               aria_label: Copy organization secret code to clipboard

--- a/config/locales/views/settings/fr.yml
+++ b/config/locales/views/settings/fr.yml
@@ -165,6 +165,7 @@ fr:
       org:
         admin:
           admin: Admin
+          contributor: Contributeur
           copy:
             button:
               aria_label: Copy organization secret code to clipboard

--- a/config/locales/views/settings/pt.yml
+++ b/config/locales/views/settings/pt.yml
@@ -118,6 +118,8 @@ pt:
         confirm: Confirmar
       org:
         admin:
+          admin: Admin
+          contributor: Colaborador
           members: Membros da Organização
           active_members: Membros Ativos
           pending_members: Convites Pendentes

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -3986,4 +3986,66 @@ RSpec.describe Article do
       expect(Organizations::RecompilePagesWorker).to have_received(:perform_async).with(organization.id)
     end
   end
+
+  describe "contributor publishing restriction" do
+    let(:organization) { create(:organization) }
+    let(:contributor) { create(:user) }
+    let(:org_admin) { create(:user) }
+    let(:other_user) { create(:user) }
+
+    before do
+      create(:organization_membership, user: contributor, organization: organization, type_of_user: "contributor")
+      create(:organization_membership, user: org_admin, organization: organization, type_of_user: "admin")
+    end
+
+    context "when creating an article" do
+      it "allows contributor to save a draft under the organization" do
+        article = build(:article, user: contributor, organization: organization, published: false)
+        article.editing_user = contributor
+        expect(article.valid?).to be true
+      end
+
+      it "does not allow contributor to publish directly under the organization" do
+        article = build(:article, user: contributor, organization: organization, published: true)
+        article.editing_user = contributor
+        expect(article.valid?).to be false
+        expect(article.errors[:published]).to include("only organization admins can publish contributor posts")
+      end
+
+      it "allows organization admin to publish the article" do
+        article = build(:article, user: contributor, organization: organization, published: true)
+        article.editing_user = org_admin
+        expect(article.valid?).to be true
+      end
+
+      it "does not allow other users to publish the article" do
+        article = build(:article, user: contributor, organization: organization, published: true)
+        article.editing_user = other_user
+        expect(article.valid?).to be false
+      end
+    end
+
+    context "when updating an existing draft article" do
+      let!(:article) { create(:article, user: contributor, organization: organization, published: false) }
+
+      it "allows contributor to update draft details while remaining a draft" do
+        article.title = "Updated Title"
+        article.editing_user = contributor
+        expect(article.valid?).to be true
+      end
+
+      it "does not allow contributor to change published to true" do
+        article.published = true
+        article.editing_user = contributor
+        expect(article.valid?).to be false
+        expect(article.errors[:published]).to include("only organization admins can publish contributor posts")
+      end
+
+      it "allows organization admin to change published to true" do
+        article.published = true
+        article.editing_user = org_admin
+        expect(article.valid?).to be true
+      end
+    end
+  end
 end

--- a/spec/models/organization_membership_spec.rb
+++ b/spec/models/organization_membership_spec.rb
@@ -17,10 +17,13 @@ RSpec.describe OrganizationMembership do
     let(:user2) { create(:user) }
     let(:user3) { create(:user) }
 
+    let(:user4) { create(:user) }
+
     before do
       create(:organization_membership, organization: organization, user: user1, type_of_user: "admin")
       create(:organization_membership, organization: organization, user: user2, type_of_user: "member")
       create(:organization_membership, organization: organization, user: user3, type_of_user: "pending")
+      create(:organization_membership, organization: organization, user: user4, type_of_user: "contributor")
     end
 
     describe ".pending" do
@@ -32,8 +35,22 @@ RSpec.describe OrganizationMembership do
 
     describe ".active" do
       it "returns only non-pending memberships" do
-        expect(organization.organization_memberships.active.count).to eq(2)
-        expect(organization.organization_memberships.active.pluck(:user_id)).to contain_exactly(user1.id, user2.id)
+        expect(organization.organization_memberships.active.count).to eq(3)
+        expect(organization.organization_memberships.active.pluck(:user_id)).to contain_exactly(user1.id, user2.id, user4.id)
+      end
+    end
+
+    describe ".member" do
+      it "returns admins, members, and contributors" do
+        expect(organization.organization_memberships.member.count).to eq(3)
+        expect(organization.organization_memberships.member.pluck(:user_id)).to contain_exactly(user1.id, user2.id, user4.id)
+      end
+    end
+
+    describe ".contributor" do
+      it "returns only contributor memberships" do
+        expect(organization.organization_memberships.contributor.count).to eq(1)
+        expect(organization.organization_memberships.contributor.first.user).to eq(user4)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -996,6 +996,24 @@ RSpec.describe User do
     end
   end
 
+  describe "#org_contributor?" do
+    it "recognizes an org contributor" do
+      create(:organization_membership, user: user, organization: org, type_of_user: "contributor")
+      expect(user.org_contributor?(org)).to be(true)
+    end
+
+    it "forbids an incorrect org contributor" do
+      other_org = create(:organization)
+      create(:organization_membership, user: user, organization: org, type_of_user: "contributor")
+      expect(user.org_contributor?(other_org)).to be(false)
+      expect(other_user.org_contributor?(org)).to be(false)
+    end
+
+    it "returns false if nil is given" do
+      expect(user.org_contributor?(nil)).to be(false)
+    end
+  end
+
   describe "#enough_credits?" do
     it "returns false if the user has less unspent credits than neeed" do
       expect(user.enough_credits?(1)).to be(false)

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -525,5 +525,20 @@ RSpec.describe "StoriesIndex" do
         expect(response.body).to include("sidebar-left")
       end
     end
+
+    context "when organization has contributors" do
+      let(:contributor) { create(:user) }
+
+      before do
+        create(:organization_membership, organization: organization, user: contributor, type_of_user: "contributor")
+      end
+
+      it "renders the contributor under Contributors" do
+        get "/#{organization.slug}"
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Contributors")
+        expect(response.body).to include(contributor.username)
+      end
+    end
   end
 end


### PR DESCRIPTION
This pull request implements the new "Contributor" organization membership role, including:

1. **Role and Scopes**: Adds `contributor` to the accepted `type_of_user` list in `OrganizationMembership`, includes contributors in the `member` scope, and defines a `contributor` scope.
2. **User Helper**: Implements `org_contributor?(organization)` on the `User` model.
3. **Draft-only Restriction**: Adds the `restrict_contributor_publishing` model validation on `Article` (utilizing the `editing_user` accessor). Contributors can only save drafts under the organization. Only organization/site admins are permitted to publish contributor-authored organization posts.
4. **UI & Templates**:
   - Organization profiles render a separate "Contributors" widget on the sidebar for active contributors.
   - Admin panels support selecting the "Contributor" role for new/existing organization memberships.
   - Organization settings render a "Contributor" badge for member roles.
5. **Locales**: Locales updated for English, French, and Portuguese.
6. **Tests**: Comprehensive model validation and request integration tests implemented and verified.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785619546&installation_id=139885019&pr_number=23550&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23550&signature=647f7d10f4f9d080d8baf7008b9efdf77ca4940d3afff35a4c1e22e20908a993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->