### PR TITLE
Explicitly enable JSON metadata serializer in framework configuration

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -53,6 +53,9 @@ module PracticalDeveloper
     # TODO: Revert to :json after legacy links (valid for 31 days) have expired.
     config.active_support.message_serializer = :json_allow_marshal
 
+    # Enable JSON message serializer for metadata to avoid legacy Marshal format dependency.
+    config.active_support.use_message_serializer_for_metadata = true
+
 
     # Enable validating only parent-related columns for presence when the parent is mandatory.
     config.active_record.belongs_to_required_validates_foreign_key = true


### PR DESCRIPTION
Explicitly configure use_message_serializer_for_metadata = true in config/application.rb alongside config.active_support.message_serializer = :json_allow_marshal. This resolves serialization conflicts on self-hosted Forem contexts running older defaults or having legacy database settings with Marshal envelopes, while ensuring new envelopes are stored in JSON format.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785720295&installation_id=139885019&pr_number=23554&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23554&signature=898ce7808063c65d689ad277f65ddf8d8ed976ccac76a53418f47b129c59c653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->