### PR TITLE
Allow legacy Marshal fallback in framework defaults initializer

### DIFF
--- a/config/initializers/new_framework_defaults_8_1.rb
+++ b/config/initializers/new_framework_defaults_8_1.rb
@@ -30,3 +30,7 @@ Rails.application.config.active_record.raise_on_missing_required_finder_order_co
 # Controls whether JS line/paragraph separators (U+2028 and U+2029) are escaped in JSON.
 # If set to `false`, escaping is bypassed since modern browsers support these in JSON.
 Rails.application.config.active_support.escape_js_separators_in_json = false
+
+# Controls the serializer used for serializing signed/encrypted messages.
+# We explicitly allow Marshal fallback support to avoid breaking existing encrypted tokens.
+Rails.application.config.active_support.message_serializer = :json_allow_marshal


### PR DESCRIPTION
Configures active_support.message_serializer = :json_allow_marshal in config/initializers/new_framework_defaults_8_1.rb to prevent the framework defaults initializer from overriding the global fallback configuration and causing legacy database settings or cookie decryption failures.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785721052&installation_id=139885019&pr_number=23555&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23555&signature=977f91d7b5852e79c69323740e8e1edc0f27718179a090f97a83d5c434c4978d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->