### PR TITLE
Emit DEV moderation events (suspend/spam/banish) to the Customer.io CDP

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,15 @@ class User < ApplicationRecord
 
   RECENTLY_ACTIVE_LIMIT = 10_000
 
+  # Moderation role changes emit dedicated events so Core can scope the DEV
+  # newsletter and prune bot Customer.io profiles. Suspension is moderation,
+  # not consent withdrawal — Core never flips its global unsubscribe on these.
+  # See the add_role/remove_role overrides in the Trackable section below.
+  MODERATION_ROLE_EVENTS = {
+    added: { "suspended" => "user_suspended", "spam" => "user_spam_flagged" },
+    removed: { "suspended" => "user_unsuspended", "spam" => "user_spam_unflagged" }
+  }.freeze
+
   enum :type_of, { member: 0, community_bot: 1, member_bot: 2 }
   enum :current_subscriber_status, { not_subscribed: 0, free_subscription: 1, trial_subscription: 2,
                                      paying_subscription: 3 }
@@ -863,7 +872,31 @@ class User < ApplicationRecord
   def enqueue_trackable_event_destroyed(*)
     nil
   end
-  private :enqueue_trackable_event_updated, :trackable_events_skipped?, :enqueue_trackable_event_destroyed
+
+  def add_role(role_name, resource = nil)
+    event = moderation_role_event(role_name, :added, resource)
+    already_had_role = event && has_role?(role_name)
+    result = super
+    track!(event) if event && !already_had_role
+    result
+  end
+
+  def remove_role(role_name, resource = nil)
+    event = moderation_role_event(role_name, :removed, resource)
+    had_role = event && has_role?(role_name)
+    result = super
+    track!(event) if event && had_role
+    result
+  end
+
+  # Only global (non-resource-scoped) moderation roles emit.
+  def moderation_role_event(role_name, direction, resource)
+    return if resource.present? || !persisted?
+
+    MODERATION_ROLE_EVENTS[direction][role_name.to_s]
+  end
+  private :enqueue_trackable_event_updated, :trackable_events_skipped?, :enqueue_trackable_event_destroyed,
+          :moderation_role_event
 
   protected
 

--- a/app/services/moderator/banish_user.rb
+++ b/app/services/moderator/banish_user.rb
@@ -25,6 +25,10 @@ module Moderator
       delete_user_podcasts
       reassign_and_bust_username
       delete_vomit_reactions
+      # Banish destroys the account's content and identity, so Core treats it
+      # like spam (prunes the Customer.io profile). The pre-banish username
+      # rides along because trackable_payload now carries the spam_ rename.
+      user.track!("user_banished", { "old_username" => user.old_username })
     end
 
     private

--- a/app/services/moderator/banish_user.rb
+++ b/app/services/moderator/banish_user.rb
@@ -17,7 +17,13 @@ module Moderator
       BanishedUser.create(username: user.username, banished_by: admin)
       user.remove_from_mailchimp_newsletters if user.email?
       remove_profile_info
-      handle_user_status("Suspended", I18n.t("services.moderator.banish_user.spam_account"))
+      # The role grant inside handle_user_status would emit user_suspended;
+      # suppress it so banish reaches Core as a single user_banished event
+      # (the two would race through the CDP and could downgrade Core's
+      # moderation marker after the banish was already applied).
+      User.skip_trackable_events do
+        handle_user_status("Suspended", I18n.t("services.moderator.banish_user.spam_account"))
+      end
       delete_organization
       delete_user_activity
       delete_comments

--- a/app/workers/users/delete_worker.rb
+++ b/app/workers/users/delete_worker.rb
@@ -11,6 +11,9 @@ module Users
       Users::Delete.call(user)
       # notify admins internally that they need to delete gdpr data
       GDPRDeleteRequest.create(user_id: user.id, email: user.email, username: user.username)
+      # tell MLH Core so it can erase the DEV-derived data it holds (the user
+      # object is destroyed, but its in-memory attributes still feed the payload)
+      user.track!("user_gdpr_deleted")
 
       return if admin_delete || user.email.blank?
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -122,6 +122,65 @@ RSpec.describe User do
       expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
         .with(anything, "user_destroyed", anything, anything, anything)
     end
+
+    describe "moderation role events" do
+      let(:user) { create(:user) }
+
+      before { enable_sync(actor: user) }
+
+      it "emits user_suspended when the suspended role is added" do
+        user.add_role(:suspended)
+        expect(Trackable::DispatchWorker).to have_received(:perform_async)
+          .with(anything, "user_suspended", [user.id], anything, anything)
+      end
+
+      it "emits user_spam_flagged when the spam role is added" do
+        user.add_role(:spam)
+        expect(Trackable::DispatchWorker).to have_received(:perform_async)
+          .with(anything, "user_spam_flagged", [user.id], anything, anything)
+      end
+
+      it "emits user_unsuspended when the suspended role is removed" do
+        user.add_role(:suspended)
+        user.remove_role(:suspended)
+        expect(Trackable::DispatchWorker).to have_received(:perform_async)
+          .with(anything, "user_unsuspended", [user.id], anything, anything)
+      end
+
+      it "emits user_spam_unflagged when the spam role is removed" do
+        user.add_role(:spam)
+        user.remove_role(:spam)
+        expect(Trackable::DispatchWorker).to have_received(:perform_async)
+          .with(anything, "user_spam_unflagged", [user.id], anything, anything)
+      end
+
+      it "does not emit when adding a role the user already has" do
+        user.add_role(:suspended)
+        user.add_role(:suspended)
+        expect(Trackable::DispatchWorker).to have_received(:perform_async)
+          .with(anything, "user_suspended", anything, anything, anything).once
+      end
+
+      it "does not emit when removing a role the user does not have" do
+        user.remove_role(:suspended)
+        expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+          .with(anything, "user_unsuspended", anything, anything, anything)
+      end
+
+      it "does not emit moderation events for non-moderation roles" do
+        user.add_role(:warned)
+        user.add_role(:trusted)
+        expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+          .with(anything, /user_suspended|user_spam/, anything, anything, anything)
+      end
+
+      it "does not emit when the sync gates are off" do
+        Settings::General.customerio_cdp_enabled = false
+        user.add_role(:suspended)
+        expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+          .with(anything, "user_suspended", anything, anything, anything)
+      end
+    end
   end
 
   describe "delegations" do

--- a/spec/services/moderator/banish_user_spec.rb
+++ b/spec/services/moderator/banish_user_spec.rb
@@ -5,6 +5,31 @@ RSpec.describe Moderator::BanishUser, type: :service do
   let(:moderator) { create(:user, :trusted) }
   let(:admin) { create(:user, :super_admin) }
 
+  describe "DEV → Core moderation sync" do
+    before do
+      allow(Trackable::Registry).to receive(:active_names).and_return([:any])
+      allow(Trackable::DispatchWorker).to receive(:perform_async)
+      Settings::General.customerio_cdp_enabled = true
+      FeatureFlag.enable(:dev_core_user_sync)
+    end
+
+    after { FeatureFlag.remove(:dev_core_user_sync) }
+
+    it "emits user_banished carrying the pre-banish username" do
+      original_username = user.username
+
+      with_trackable_events do
+        sidekiq_perform_enqueued_jobs do
+          described_class.call(user: user, admin: admin)
+        end
+      end
+
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_banished", [user.id],
+              hash_including("old_username" => original_username), anything)
+    end
+  end
+
   it "updates username, clears profile, and add BanishedUser record", :aggregate_failures do
     original_username = user.username
     sidekiq_perform_enqueued_jobs do

--- a/spec/services/moderator/banish_user_spec.rb
+++ b/spec/services/moderator/banish_user_spec.rb
@@ -28,6 +28,17 @@ RSpec.describe Moderator::BanishUser, type: :service do
         .with(anything, "user_banished", [user.id],
               hash_including("old_username" => original_username), anything)
     end
+
+    it "does not also emit user_suspended for the banish-internal role grant" do
+      with_trackable_events do
+        sidekiq_perform_enqueued_jobs do
+          described_class.call(user: user, admin: admin)
+        end
+      end
+
+      expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+        .with(anything, "user_suspended", anything, anything, anything)
+    end
   end
 
   it "updates username, clears profile, and add BanishedUser record", :aggregate_failures do

--- a/spec/workers/users/delete_worker_spec.rb
+++ b/spec/workers/users/delete_worker_spec.rb
@@ -21,6 +21,22 @@ RSpec.describe Users::DeleteWorker, type: :worker do
         expect(User.exists?(id: user.id)).to be(false)
       end
 
+      it "emits user_gdpr_deleted to the DEV → Core sync" do
+        allow(Trackable::Registry).to receive(:active_names).and_return([:any])
+        allow(Trackable::DispatchWorker).to receive(:perform_async)
+        Settings::General.customerio_cdp_enabled = true
+        FeatureFlag.enable(:dev_core_user_sync)
+
+        with_trackable_events { worker.perform(user.id) }
+
+        expect(Trackable::DispatchWorker).to have_received(:perform_async)
+          .with(anything, "user_gdpr_deleted", [user.id],
+                hash_including("id" => user.id, "email" => user.email, "username" => user.username),
+                anything)
+      ensure
+        FeatureFlag.remove(:dev_core_user_sync)
+      end
+
       it "calls the service when a user is found" do
         allow(delete).to receive(:call)
         worker.perform(user.id)


### PR DESCRIPTION
## What

Emits moderation and deletion lifecycle events through the existing DEV → MLH Core Trackable pipeline:

| Action | Event |
|---|---|
| `add_role(:suspended)` | `user_suspended` |
| `add_role(:spam)` | `user_spam_flagged` |
| `Moderator::BanishUser` | `user_banished` (carries `old_username`) |
| `remove_role(:suspended)` | `user_unsuspended` |
| `remove_role(:spam)` | `user_spam_unflagged` |
| `Users::DeleteWorker` (GDPR/self-service/admin delete) | `user_gdpr_deleted` |

Role emission is implemented as `add_role`/`remove_role` overrides — the single choke point for every moderation path (admin UI, `Spam::Handler`, `Spam::BlockDomainAndSuspendUsersWorker`, banish) — and only fires on actual role transitions (no duplicate events for idempotent role grants). Resource-scoped roles never emit. GDPR deletion emits from `Users::DeleteWorker`, which both self-service and admin deletions flow through (it already records the `GDPRDeleteRequest`).

Same gates as the rest of the DEV → Core sync: `Settings::General.customerio_cdp_enabled` + the `:dev_core_user_sync` feature flag, and `User.skip_trackable_events` still suppresses everything for backfills.

## Why

MLH Core is becoming the source of truth for user emails/profiles, with DEV as a CDP input. Core needs to know when DEV moderates or deletes an account so it can unsubscribe it from the DEV newsletter, delete bot Customer.io profiles, and honor GDPR erasure for the DEV-derived data it holds. Consumer side: MLH-Engineering/core#2812.

## Tests

`spec/models/user_spec.rb` (8 new examples), `spec/services/moderator/banish_user_spec.rb` (1), `spec/workers/users/delete_worker_spec.rb` (1); role-related suites (`user_spec`, `banish_user_spec`, `manage_activity_and_roles_spec`, `authorizer_spec`) all green.