### PR TITLE
Drop users.mlh_username in favor of the MLH identity link

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -150,10 +150,11 @@ class UsersController < ApplicationController
     if identity && @user.identities.size > 1
       identity.destroy
 
-      @user.update(
-        provider.user_username_field => nil,
-        :profile_updated_at => Time.current,
-      )
+      unlink_attributes = { profile_updated_at: Time.current }
+      # Providers without a users.<provider>_username column (e.g. MLH) have
+      # nothing to null out besides the identity itself.
+      unlink_attributes[provider.user_username_field] = nil if provider.user_username_field
+      @user.update(unlink_attributes)
 
       # GitHub repositories are tied with the existence of the GitHub identity
       # as we use the user's GitHub token to fetch them from the API.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,12 +48,6 @@ class User < ApplicationRecord
                 :add_credits, :remove_credits, :add_org_credits, :remove_org_credits, :ip_address,
                 :current_password, :custom_invite_subject, :custom_invite_message, :custom_invite_footnote
 
-  # Username seed for OAuth providers without a users.<provider>_username
-  # column (e.g. MLH): carries the provider nickname through signup so the
-  # generated username (and the banished-username guard) behave as if the
-  # column existed, without persisting it.
-  attr_accessor :provider_username_seed
-
   acts_as_followable
   acts_as_follower
 
@@ -916,11 +910,10 @@ class User < ApplicationRecord
   end
 
   def auth_provider_usernames
-    provider_usernames = attributes
+    attributes
       .with_indifferent_access
       .slice(*Authentication::Providers.username_fields)
-      .values
-    ([provider_username_seed] + provider_usernames).compact
+      .values.compact || []
   end
 
   def generate_username

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,11 @@ class User < ApplicationRecord
 
   RECENTLY_ACTIVE_LIMIT = 10_000
 
+  # Dropped in favor of the MLH identity row (identities.uid = Core user id);
+  # ignored so in-flight code stops referencing it before the column removal
+  # migration runs.
+  self.ignored_columns += ["mlh_username"] # rubocop:disable Rails/UnusedIgnoredColumns
+
   enum :type_of, { member: 0, community_bot: 1, member_bot: 2 }
   enum :current_subscriber_status, { not_subscribed: 0, free_subscription: 1, trial_subscription: 2,
                                      paying_subscription: 3 }
@@ -42,6 +47,12 @@ class User < ApplicationRecord
   attr_accessor :scholar_email, :new_note, :note_for_current_role, :user_status, :merge_user_id,
                 :add_credits, :remove_credits, :add_org_credits, :remove_org_credits, :ip_address,
                 :current_password, :custom_invite_subject, :custom_invite_message, :custom_invite_footnote
+
+  # Username seed for OAuth providers without a users.<provider>_username
+  # column (e.g. MLH): carries the provider nickname through signup so the
+  # generated username (and the banished-username guard) behave as if the
+  # column existed, without persisting it.
+  attr_accessor :provider_username_seed
 
   acts_as_followable
   acts_as_follower
@@ -320,7 +331,7 @@ class User < ApplicationRecord
   end
 
   def self.ransackable_attributes(auth_object = nil)
-    ["agent_sessions_count", "apple_username", "articles_count", "badge_achievements_count", "base_email_eligible", "blocked_by_count", "blocking_others_count", "checked_code_of_conduct", "checked_terms_and_conditions", "comments_count", "confirmation_sent_at", "confirmed_at", "created_at", "credits_count", "current_sign_in_at", "current_subscriber_status", "email", "export_requested", "exported_at", "facebook_username", "failed_attempts", "feed_fetched_at", "following_orgs_count", "following_tags_count", "following_users_count", "forem_username", "github_repos_updated_at", "github_username", "google_oauth2_created_at", "google_oauth2_username", "id", "id_value", "invitation_accepted_at", "invitation_created_at", "invitation_limit", "invitation_sent_at", "invitations_count", "invited_by_id", "invited_by_type", "last_article_at", "last_comment_at", "last_followed_at", "last_moderation_notification", "last_notification_activity", "last_onboarding_page", "last_presence_at", "last_reacted_at", "last_sign_in_at", "latest_article_updated_at", "locked_at", "max_score", "mlh_username", "name", "old_old_username", "old_username", "onboarding_package_requested", "onboarding_subforem_id", "organization_info_updated_at", "payment_pointer", "profile_image", "profile_updated_at", "public_reactions_count", "rating_votes_count", "reactions_count", "registered", "registered_at", "reputation_modifier", "reset_password_sent_at", "saw_onboarding", "score", "sign_in_count", "sign_in_token_sent_at", "signup_cta_variant", "spent_credits_count", "stripe_id_code", "subscribed_to_user_subscriptions_count", "twitter_username", "type_of", "unconfirmed_email", "unspent_credits_count", "updated_at", "username"]
+    ["agent_sessions_count", "apple_username", "articles_count", "badge_achievements_count", "base_email_eligible", "blocked_by_count", "blocking_others_count", "checked_code_of_conduct", "checked_terms_and_conditions", "comments_count", "confirmation_sent_at", "confirmed_at", "created_at", "credits_count", "current_sign_in_at", "current_subscriber_status", "email", "export_requested", "exported_at", "facebook_username", "failed_attempts", "feed_fetched_at", "following_orgs_count", "following_tags_count", "following_users_count", "forem_username", "github_repos_updated_at", "github_username", "google_oauth2_created_at", "google_oauth2_username", "id", "id_value", "invitation_accepted_at", "invitation_created_at", "invitation_limit", "invitation_sent_at", "invitations_count", "invited_by_id", "invited_by_type", "last_article_at", "last_comment_at", "last_followed_at", "last_moderation_notification", "last_notification_activity", "last_onboarding_page", "last_presence_at", "last_reacted_at", "last_sign_in_at", "latest_article_updated_at", "locked_at", "max_score", "name", "old_old_username", "old_username", "onboarding_package_requested", "onboarding_subforem_id", "organization_info_updated_at", "payment_pointer", "profile_image", "profile_updated_at", "public_reactions_count", "rating_votes_count", "reactions_count", "registered", "registered_at", "reputation_modifier", "reset_password_sent_at", "saw_onboarding", "score", "sign_in_count", "sign_in_token_sent_at", "signup_cta_variant", "spent_credits_count", "stripe_id_code", "subscribed_to_user_subscriptions_count", "twitter_username", "type_of", "unconfirmed_email", "unspent_credits_count", "updated_at", "username"]
   end
 
   def self.ransackable_associations(auth_object = nil)
@@ -905,10 +916,11 @@ class User < ApplicationRecord
   end
 
   def auth_provider_usernames
-    attributes
+    provider_usernames = attributes
       .with_indifferent_access
       .slice(*Authentication::Providers.username_fields)
-      .values.compact || []
+      .values
+    ([provider_username_seed] + provider_usernames).compact
   end
 
   def generate_username

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -123,10 +123,12 @@ module Authentication
       suspended_user = Users::SuspendedUsername.previously_suspended?(username)
       raise ::Authentication::Errors::PreviouslySuspended if suspended_user
 
-      existing_user = User.find_by(
-        provider.user_username_field => username,
-      )
-      return existing_user if existing_user
+      if provider.user_username_field
+        existing_user = User.find_by(
+          provider.user_username_field => username,
+        )
+        return existing_user if existing_user
+      end
 
       User.new.tap do |user|
         user.assign_attributes(provider.new_user_data)
@@ -176,6 +178,8 @@ module Authentication
     end
 
     def update_profile_updated_at(user)
+      return unless provider.user_username_field
+
       field_name = "#{provider.user_username_field}_changed?"
       user.profile_updated_at = Time.current if user.public_send(field_name)
     end

--- a/app/services/authentication/providers.rb
+++ b/app/services/authentication/providers.rb
@@ -67,7 +67,9 @@ module Authentication
     end
 
     def self.username_fields
-      Authentication::Providers::Provider.subclasses.map(&:user_username_field).sort
+      # filter_map: providers without a users.<provider>_username column
+      # (e.g. MLH, whose link is the identity uid) return nil.
+      Authentication::Providers::Provider.subclasses.filter_map(&:user_username_field).sort
     end
   end
 end

--- a/app/services/authentication/providers/mlh.rb
+++ b/app/services/authentication/providers/mlh.rb
@@ -28,8 +28,7 @@ module Authentication
       def new_user_data
         {
           email: info.email.to_s,
-          name: info.name,
-          provider_username_seed: info.nickname
+          name: info.name
         }
       end
 

--- a/app/services/authentication/providers/mlh.rb
+++ b/app/services/authentication/providers/mlh.rb
@@ -9,6 +9,12 @@ module Authentication
         OFFICIAL_NAME
       end
 
+      # MLH has no users.<provider>_username column: the link to the MLH Core
+      # account lives on the identity row, whose uid IS the Core user id.
+      def self.user_username_field
+        nil
+      end
+
       def self.settings_url
         SETTINGS_URL
       end
@@ -22,15 +28,13 @@ module Authentication
       def new_user_data
         {
           email: info.email.to_s,
-          mlh_username: info.nickname,
           name: info.name,
+          provider_username_seed: info.nickname
         }
       end
 
       def existing_user_data
-        {
-          mlh_username: info.nickname
-        }
+        {}
       end
 
       protected

--- a/db/migrate/20260707153330_remove_mlh_username_from_users.rb
+++ b/db/migrate/20260707153330_remove_mlh_username_from_users.rb
@@ -1,0 +1,14 @@
+class RemoveMlhUsernameFromUsers < ActiveRecord::Migration[7.2]
+  # The MLH ↔ Core account link lives on the identities row (provider "mlh",
+  # uid = Core user id); this column only ever held the MyMLH OAuth nickname
+  # and nothing reads it. Safe to drop directly: User.ignored_columns already
+  # excludes it, so no running code references the column when this runs.
+  def up
+    safety_assured { remove_column :users, :mlh_username }
+  end
+
+  def down
+    add_column :users, :mlh_username, :string
+    add_index :users, :mlh_username, name: :index_users_on_mlh_username
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_30_143448) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_07_153330) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -2006,7 +2006,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_30_143448) do
     t.datetime "latest_article_updated_at", precision: nil
     t.datetime "locked_at", precision: nil
     t.integer "max_score", default: 0
-    t.string "mlh_username"
     t.string "name"
     t.string "old_old_username"
     t.string "old_username"
@@ -2059,7 +2058,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_30_143448) do
     t.index ["invitations_count"], name: "index_users_on_invitations_count"
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
     t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by_type_and_invited_by_id"
-    t.index ["mlh_username"], name: "index_users_on_mlh_username"
     t.index ["old_old_username"], name: "index_users_on_old_old_username"
     t.index ["old_username"], name: "index_users_on_old_username"
     t.index ["onboarding_subforem_id"], name: "index_users_on_onboarding_subforem_id"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -612,6 +612,9 @@ RSpec.describe User do
           expect(new_user.username).to match(/valid_username_\w+/)
         when :facebook, :google_oauth2
           expect(new_user.username).to match(/fname_lname_\S*\z/)
+        when :mlh
+          # no users.mlh_username column, so the username is generator-random
+          expect(new_user.username).to match(/\A[a-z]{12}\z/)
         else
           expect(new_user.username).to eq("valid_username")
         end
@@ -631,6 +634,8 @@ RSpec.describe User do
           expect(new_user.username).to match(/invalidusername_\w+/)
         when :facebook, :google_oauth2
           expect(new_user.username).to match(/fname_lname_\S*\z/)
+        when :mlh
+          expect(new_user.username).to match(/\A[a-z]{12}\z/)
         else
           expect(new_user.username).to eq("invalidusername")
         end
@@ -648,9 +653,17 @@ RSpec.describe User do
         mock_username(provider_name, banished_name)
 
         create(:banished_user, username: provider_username(provider_name))
-        expect do
-          user_from_authorization_service(provider_name, nil, "navbar_basic")
-        end.to raise_error(ActiveRecord::RecordInvalid, /Username has been banished./)
+        if provider_name == :mlh
+          # MLH usernames are generator-random (no username column), so the
+          # banished-username guard cannot match the provider nickname
+          expect do
+            user_from_authorization_service(provider_name, nil, "navbar_basic")
+          end.not_to raise_error
+        else
+          expect do
+            user_from_authorization_service(provider_name, nil, "navbar_basic")
+          end.to raise_error(ActiveRecord::RecordInvalid, /Username has been banished./)
+        end
       end
     end
 

--- a/spec/requests/api/v1/admin/user_identities_spec.rb
+++ b/spec/requests/api/v1/admin/user_identities_spec.rb
@@ -102,12 +102,22 @@ RSpec.describe "Api::V1::Admin::UserIdentities" do
     end
 
     it "sets user.<provider>_username when 'username' param is provided" do
+      omniauth_mock_github_payload if defined?(omniauth_mock_github_payload)
+      post "/api/admin/users/#{user.id}/identities",
+           params: { provider: "github", uid: "gh-12345", username: "jane_gh" },
+           headers: admin_api_headers
+
+      expect(user.reload.github_username).to eq("jane_gh")
+    end
+
+    it "ignores the 'username' param for providers without a username column (mlh)" do
       omniauth_mock_mlh_payload if defined?(omniauth_mock_mlh_payload)
       post "/api/admin/users/#{user.id}/identities",
            params: { provider: "mlh", uid: "core-12345", username: "jane_mlh" },
            headers: admin_api_headers
 
-      expect(user.reload.mlh_username).to eq("jane_mlh")
+      expect(response).to have_http_status(:created)
+      expect(user.identities.find_by(provider: "mlh").uid).to eq("core-12345")
     end
 
     it "audits the link" do
@@ -129,15 +139,22 @@ RSpec.describe "Api::V1::Admin::UserIdentities" do
       create(:identity, user: user, provider: "mlh", uid: "core-1")
     end
 
-    before { user.update_column(:mlh_username, "jane_mlh") }
-
-    it "destroys the identity and nulls user.<provider>_username" do
+    it "destroys the identity" do
       expect do
         delete "/api/admin/users/#{user.id}/identities/#{identity.id}", headers: admin_api_headers
       end.to change(Identity, :count).by(-1)
 
       expect(response).to have_http_status(:no_content)
-      expect(user.reload.mlh_username).to be_nil
+    end
+
+    it "nulls user.<provider>_username when unlinking a provider with a username column" do
+      omniauth_mock_github_payload if defined?(omniauth_mock_github_payload)
+      gh = create(:identity, user: user, provider: "github", uid: "gh-2")
+      user.update_column(:github_username, "jane_gh")
+
+      delete "/api/admin/users/#{user.id}/identities/#{gh.id}", headers: admin_api_headers
+
+      expect(user.reload.github_username).to be_nil
     end
 
     it "destroys github_repos when unlinking github" do

--- a/spec/services/authentication/providers/mlh_spec.rb
+++ b/spec/services/authentication/providers/mlh_spec.rb
@@ -36,19 +36,22 @@ RSpec.describe Authentication::Providers::Mlh, type: :service do
     end
   end
 
+  describe ".user_username_field" do
+    it "is nil because the MLH link lives on the identity (uid = Core user id), not a users column" do
+      expect(described_class.user_username_field).to be_nil
+    end
+  end
+
   describe "#new_user_data" do
-    it "maps the correct data for a new user" do
+    it "maps the correct data for a new user, seeding the username from the nickname" do
       data = provider.new_user_data
-      expect(data[:email]).to eq("test@example.com")
-      expect(data[:mlh_username]).to eq("mlhuser")
-      expect(data[:name]).to eq("MLH User")
+      expect(data).to eq(email: "test@example.com", name: "MLH User", provider_username_seed: "mlhuser")
     end
   end
 
   describe "#existing_user_data" do
-    it "maps the correct data for an existing user" do
-      data = provider.existing_user_data
-      expect(data[:mlh_username]).to eq("mlhuser")
+    it "has no user columns to refresh" do
+      expect(provider.existing_user_data).to eq({})
     end
   end
 end

--- a/spec/services/authentication/providers/mlh_spec.rb
+++ b/spec/services/authentication/providers/mlh_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe Authentication::Providers::Mlh, type: :service do
   end
 
   describe "#new_user_data" do
-    it "maps the correct data for a new user, seeding the username from the nickname" do
+    it "maps the correct data for a new user" do
       data = provider.new_user_data
-      expect(data).to eq(email: "test@example.com", name: "MLH User", provider_username_seed: "mlhuser")
+      expect(data).to eq(email: "test@example.com", name: "MLH User")
     end
   end
 


### PR DESCRIPTION
## What

Removes the `users.mlh_username` column. The MLH ↔ Core account link lives on the `identities` row (`provider: mlh`, `uid` = MLH Core user id) — written by MyMLH OAuth and by the admin identities API — so the column was a redundant mirror that only ever held the OAuth nickname, and nothing rendered it.

A bare `remove_column` isn't possible because the shared auth machinery derives `mlh_username` from the provider name (per-save validation loop, authenticator lookup, settings unlink), so the mechanism is: `Mlh.user_username_field` returns `nil` (provider declares it has no username column) and the four call sites guard for that.

MyMLH signups now get a generator-random initial username (users pick their real one in onboarding); the banished-username guard consequently no longer matches on MLH nicknames — both documented in the updated specs.

`User.ignored_columns` ships in the same release so the deploy window (code live before the migration runs) is safe; the ignore line can be deleted in a follow-up.

## Why

MLH Core is the source of truth for the DEV ↔ Core user mapping (`SocialProfiles::Dev` on the Core side, `identities` on this side). One representation per side, no denormalized copy to drift. Core pushes links for backfilled users through the existing admin identities API.

## Tests

`mlh_spec`, `user_identities_spec`, `user_spec`, `user_settings_spec`, full `spec/services/authentication` — all green.