### PR TITLE
Stop writing users.mlh_username on MyMLH sign-in

### DIFF
--- a/app/services/authentication/providers/mlh.rb
+++ b/app/services/authentication/providers/mlh.rb
@@ -19,18 +19,18 @@ module Authentication
         ::Authentication::Paths.authentication_path(provider_name, **kwargs)
       end
 
+      # users.mlh_username is intentionally never written: the MLH ↔ Core
+      # link lives on the identity row (uid = Core user id), so the column
+      # stays nil rather than mirroring the OAuth nickname.
       def new_user_data
         {
           email: info.email.to_s,
-          mlh_username: info.nickname,
-          name: info.name,
+          name: info.name
         }
       end
 
       def existing_user_data
-        {
-          mlh_username: info.nickname
-        }
+        {}
       end
 
       protected

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -671,6 +671,10 @@ RSpec.describe User do
           expect(new_user.username).to match(/valid_username_\w+/)
         when :facebook, :google_oauth2
           expect(new_user.username).to match(/fname_lname_\S*\z/)
+        when :mlh
+          # users.mlh_username is intentionally never written, so the
+          # username is generator-random
+          expect(new_user.username).to match(/\A[a-z]{12}\z/)
         else
           expect(new_user.username).to eq("valid_username")
         end
@@ -690,6 +694,8 @@ RSpec.describe User do
           expect(new_user.username).to match(/invalidusername_\w+/)
         when :facebook, :google_oauth2
           expect(new_user.username).to match(/fname_lname_\S*\z/)
+        when :mlh
+          expect(new_user.username).to match(/\A[a-z]{12}\z/)
         else
           expect(new_user.username).to eq("invalidusername")
         end
@@ -707,9 +713,17 @@ RSpec.describe User do
         mock_username(provider_name, banished_name)
 
         create(:banished_user, username: provider_username(provider_name))
-        expect do
-          user_from_authorization_service(provider_name, nil, "navbar_basic")
-        end.to raise_error(ActiveRecord::RecordInvalid, /Username has been banished./)
+        if provider_name == :mlh
+          # MLH usernames are generator-random (mlh_username is never
+          # written), so the banished-username guard cannot match
+          expect do
+            user_from_authorization_service(provider_name, nil, "navbar_basic")
+          end.not_to raise_error
+        else
+          expect do
+            user_from_authorization_service(provider_name, nil, "navbar_basic")
+          end.to raise_error(ActiveRecord::RecordInvalid, /Username has been banished./)
+        end
       end
     end
 
@@ -824,7 +838,8 @@ RSpec.describe User do
     end
 
     it "returns the count of non-suspended and non-spam followers using the rails cache" do
-      expect(Rails.cache).to receive(:fetch).with("#{user.cache_key_with_version}/good_standing_followers_count", expires_in: 24.hours).and_call_original
+      expect(Rails.cache).to receive(:fetch).with("#{user.cache_key_with_version}/good_standing_followers_count",
+                                                  expires_in: 24.hours).and_call_original
       expect(user.good_standing_followers_count).to eq(1)
     end
   end

--- a/spec/services/authentication/providers/mlh_spec.rb
+++ b/spec/services/authentication/providers/mlh_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Authentication::Providers::Mlh, type: :service do
       },
       extra: {
         raw_info: {}
-      }
+      },
     )
   end
   let(:provider) { described_class.new(auth_payload) }
@@ -37,18 +37,15 @@ RSpec.describe Authentication::Providers::Mlh, type: :service do
   end
 
   describe "#new_user_data" do
-    it "maps the correct data for a new user" do
+    it "maps email and name, leaving users.mlh_username untouched" do
       data = provider.new_user_data
-      expect(data[:email]).to eq("test@example.com")
-      expect(data[:mlh_username]).to eq("mlhuser")
-      expect(data[:name]).to eq("MLH User")
+      expect(data).to eq(email: "test@example.com", name: "MLH User")
     end
   end
 
   describe "#existing_user_data" do
-    it "maps the correct data for an existing user" do
-      data = provider.existing_user_data
-      expect(data[:mlh_username]).to eq("mlhuser")
+    it "updates nothing, leaving users.mlh_username untouched" do
+      expect(provider.existing_user_data).to eq({})
     end
   end
 end


### PR DESCRIPTION
Leaves `users.mlh_username` permanently nil instead of mirroring the MyMLH OAuth nickname. The MLH ↔ Core account link is the `identities` row (`uid` = MLH Core user id), so the column is redundant; keeping it (unwritten) avoids touching the shared `<provider>_username` machinery that a column drop would require (per-save validation loop, authenticator lookup, settings unlink — see closed #23575 for what that entails).

Consequences, documented in the updated specs: MyMLH signups get a generator-random initial username (users pick their real one in onboarding), and the banished-username guard no longer matches MLH nicknames.

Replaces #23575 with the minimal approach.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786049412&installation_id=139885019&pr_number=23576&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23576&signature=cd37bac1f0c5561aa5c50fdb0c0f55f722ce88f5f409efd980cc08a05b10fd5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->