### PR TITLE
Widen DEV → Core CDP sync coverage: newsletter, email, confirmation, engagement

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -144,6 +144,9 @@ new_email = user_params[:email].to_s.strip.presence
         # Bypassing validations/callbacks is intentional here to match the behavior of updating
         # user emails via the admin UI directly and immediately without sending confirmation emails.
         if @user.update_columns(email: downcased_email, unconfirmed_email: nil)
+          # update_columns bypasses the Trackable after_commit, so tell the
+          # DEV -> Core sync about the new address explicitly.
+          @user.track!("user_updated")
           Note.create(
             author_id: current_user.id,
             noteable_id: @user.id,
@@ -582,6 +585,9 @@ new_email = user_params[:email].to_s.strip.presence
       new_email = @user.unconfirmed_email
 
       if new_email.present? && @user.update_columns(email: new_email, unconfirmed_email: nil, confirmed_at: Time.current)
+        # update_columns bypasses the Trackable after_commit, so tell the
+        # DEV -> Core sync about the swapped address explicitly.
+        @user.track!("user_updated")
         Note.create(
           author_id: current_user.id,
           noteable_id: @user.id,

--- a/app/controllers/concerns/api/admin/users_controller.rb
+++ b/app/controllers/concerns/api/admin/users_controller.rb
@@ -68,6 +68,9 @@ module Api
         # but explicitly bust the user cache that the after_commit hook would
         # otherwise refresh.
         @user_record.update_columns(email: new_email, unconfirmed_email: nil)
+        # ...and the Trackable after_commit, so tell the DEV -> Core sync
+        # about the new address explicitly.
+        @user_record.track!("user_updated")
         Users::BustCacheWorker.perform_async(@user_record.id)
         audit!(slug: "update_user_email",
                data: { "target_user_id" => @user_record.id, "old_email" => old_email, "new_email" => new_email })

--- a/app/controllers/magic_links_controller.rb
+++ b/app/controllers/magic_links_controller.rb
@@ -2,7 +2,12 @@ class MagicLinksController < ApplicationController
   def show
     user = User.find_by(sign_in_token: params[:id])
     if user && user.sign_in_token_sent_at > 20.minutes.ago
-      user.update_column(:confirmed_at, Time.current) if user.confirmed_at.blank?
+      if user.confirmed_at.blank?
+        user.update_column(:confirmed_at, Time.current)
+        # update_column bypasses the Trackable after_commit, so tell the
+        # DEV -> Core sync the email is now verified.
+        user.track!("user_updated")
+      end
       sign_in(user)
       redirect_to root_path
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -929,6 +929,9 @@ class User < ApplicationRecord
   # The setting is resolved via the default subforem (like mailers do) because the
   # admin panel saves it subforem-scoped and callbacks may run without request context.
   def trackable_events_skipped?
+    # Bots (community_bot / member_bot) are not people; the Core backfill
+    # excluded them and the live sync must too.
+    return true unless member?
     return true unless Settings::General.customerio_cdp_enabled(subforem_id: Subforem.cached_default_id)
     return true unless FeatureFlag.enabled_for_user?(:dev_core_user_sync, self)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,6 +44,18 @@ class User < ApplicationRecord
     removed: { "suspended" => "user_unsuspended", "spam" => "user_spam_unflagged" }
   }.freeze
 
+  # Column changes that must reach MLH Core: deliberate profile edits, the
+  # actual email swap (Devise reconfirmable lands it outside any profile
+  # edit), email confirmation, and invited accounts completing registration.
+  SYNC_TRIGGER_KEYS = %w[profile_updated_at email confirmed_at registered].freeze
+
+  # Activity timestamps that mean "this person used DEV" — advancing any of
+  # them emits a throttled user_engaged so Core keeps engaged_at fresh for
+  # accounts that never edit their profile.
+  ACTIVITY_TIMESTAMP_KEYS = %w[current_sign_in_at last_sign_in_at last_presence_at last_reacted_at
+                               last_followed_at last_comment_at last_article_at].freeze
+  ENGAGEMENT_EMIT_INTERVAL = 1.week
+
   enum :type_of, { member: 0, community_bot: 1, member_bot: 2 }
   enum :current_subscriber_status, { not_subscribed: 0, free_subscription: 1, trial_subscription: 2,
                                      paying_subscription: 3 }
@@ -843,17 +855,62 @@ class User < ApplicationRecord
 
   # Curated payload — do NOT ship the full users row across the boundary.
   # String keys keep the job arguments JSON-safe for Sidekiq.strict_args!.
+  # mlh_user_id is the Core user id from the mlh OAuth identity, letting Core
+  # resolve deterministically instead of by email match.
   def trackable_payload
-    { "id" => id, "username" => username, "email" => email, "name" => name }
+    {
+      "id" => id, "username" => username, "email" => email, "name" => name,
+      "confirmed_at" => confirmed_at&.iso8601,
+      "email_newsletter" => notification_setting&.email_newsletter,
+      "mlh_user_id" => identities.where(provider: "mlh").pick(:uid)
+    }
   end
 
-  # Emit user_updated only on deliberate profile edits. Forem touches
-  # profile_updated_at on every profile-edit path (Users::Update, users#update),
-  # so unrelated row churn (sign-ins, counters, score recalcs) does not emit.
-  def enqueue_trackable_event_updated
-    return unless previous_changes.key?("profile_updated_at")
+  # Invited accounts (registered: false) have not consented to anything yet,
+  # so their creation stays out of the sync; user_created fires from the
+  # update path when registration completes.
+  def enqueue_trackable_event_created
+    return unless registered?
 
-    enqueue_trackable_event("user_updated")
+    enqueue_trackable_event("user_created")
+  end
+
+  # Emit only for changes Core consumes (SYNC_TRIGGER_KEYS): profile edits
+  # touch profile_updated_at on every edit path (Users::Update, users#update),
+  # so unrelated row churn (counters, score recalcs) does not emit. Activity
+  # timestamp changes emit a throttled user_engaged instead.
+  def enqueue_trackable_event_updated
+    track_engagement
+    return unless previous_changes.keys.intersect?(SYNC_TRIGGER_KEYS)
+
+    if previous_changes.key?("registered")
+      enqueue_trackable_event("user_created") if registered?
+    else
+      enqueue_trackable_event("user_updated")
+    end
+  end
+
+  # At most one user_engaged per user per ENGAGEMENT_EMIT_INTERVAL — the
+  # cache key throttles the frequent writers (presence pings, sign-ins) down
+  # to what Core actually needs to keep engaged_at inside its activity
+  # window. Moderated accounts stay silent so a pruned Customer.io profile
+  # is not resurrected by their activity.
+  def track_engagement
+    changed_activity = previous_changes.slice(*ACTIVITY_TIMESTAMP_KEYS)
+    return if changed_activity.empty?
+    return unless engagement_emission_due?
+    return if spam_or_suspended?
+
+    engaged_at = changed_activity.filter_map { |_key, (_old, new_value)| new_value }.max || Time.current
+    track!("user_engaged", { "engaged_at" => engaged_at.iso8601 })
+  end
+
+  def engagement_emission_due?
+    cache_key = "user_engaged_throttle:#{id}"
+    return false if Rails.cache.exist?(cache_key)
+
+    Rails.cache.write(cache_key, true, expires_in: ENGAGEMENT_EMIT_INTERVAL)
+    true
   end
 
   # Two gates: the admin master switch, then the per-account rollout flag.
@@ -895,8 +952,8 @@ class User < ApplicationRecord
 
     MODERATION_ROLE_EVENTS[direction][role_name.to_s]
   end
-  private :enqueue_trackable_event_updated, :trackable_events_skipped?, :enqueue_trackable_event_destroyed,
-          :moderation_role_event
+  private :enqueue_trackable_event_created, :enqueue_trackable_event_updated, :trackable_events_skipped?,
+          :enqueue_trackable_event_destroyed, :moderation_role_event, :track_engagement, :engagement_emission_due?
 
   protected
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -818,6 +818,9 @@ class User < ApplicationRecord
     return if last_presence_at.present? && last_presence_at > 1.hour.ago
 
     update_column(:last_presence_at, Time.current)
+    # update_column bypasses callbacks, so the throttled engagement event that
+    # enqueue_trackable_event_updated would fire has to be emitted explicitly.
+    track_engagement!(last_presence_at)
   end
 
   def sync_base_email_eligible!
@@ -898,19 +901,28 @@ class User < ApplicationRecord
   def track_engagement
     changed_activity = previous_changes.slice(*ACTIVITY_TIMESTAMP_KEYS)
     return if changed_activity.empty?
+
+    engaged_at = changed_activity.filter_map { |_key, (_old, new_value)| new_value }.max || Time.current
+    track_engagement!(engaged_at)
+  end
+
+  # Emit a throttled user_engaged for a known activity timestamp. Callable from
+  # paths that skip callbacks (e.g. update_presence!'s update_column write). The
+  # throttle slot is claimed before the spam/suspended role query so hot presence
+  # pings stay a single cache read.
+  def track_engagement!(engaged_at)
     return unless engagement_emission_due?
     return if spam_or_suspended?
 
-    engaged_at = changed_activity.filter_map { |_key, (_old, new_value)| new_value }.max || Time.current
     track!("user_engaged", { "engaged_at" => engaged_at.iso8601 })
   end
 
+  # Atomically claim the per-user throttle slot; the write only succeeds when no
+  # unexpired key exists, so its truthy return doubles as the "due" signal and
+  # concurrent writers cannot both emit inside the interval.
   def engagement_emission_due?
-    cache_key = "user_engaged_throttle:#{id}"
-    return false if Rails.cache.exist?(cache_key)
-
-    Rails.cache.write(cache_key, true, expires_in: ENGAGEMENT_EMIT_INTERVAL)
-    true
+    Rails.cache.write("user_engaged_throttle:#{id}", true,
+                      expires_in: ENGAGEMENT_EMIT_INTERVAL, unless_exist: true)
   end
 
   # Two gates: the admin master switch, then the per-account rollout flag.
@@ -953,7 +965,8 @@ class User < ApplicationRecord
     MODERATION_ROLE_EVENTS[direction][role_name.to_s]
   end
   private :enqueue_trackable_event_created, :enqueue_trackable_event_updated, :trackable_events_skipped?,
-          :enqueue_trackable_event_destroyed, :moderation_role_event, :track_engagement, :engagement_emission_due?
+          :enqueue_trackable_event_destroyed, :moderation_role_event, :track_engagement, :track_engagement!,
+          :engagement_emission_due?
 
   protected
 

--- a/app/models/users/notification_setting.rb
+++ b/app/models/users/notification_setting.rb
@@ -13,6 +13,7 @@ module Users
     alias_attribute :subscribed_to_email_follower_notifications, :email_follower_notifications
 
     after_commit :subscribe_to_mailchimp_newsletter
+    after_commit :track_newsletter_change, on: :update
     after_save if: :saved_change_to_email_newsletter? do
       user&.sync_base_email_eligible!
     end
@@ -23,6 +24,19 @@ module Users
       return if user.email.blank?
 
       Users::SubscribeToMailchimpNewsletterWorker.perform_async(user.id)
+    end
+
+    private
+
+    # Newsletter consent changes must reach MLH Core (source of truth for
+    # email subscriptions), which cannot see this table otherwise. Fires on
+    # every toggle path: settings page, one-click unsubscribe links,
+    # onboarding, and the Mailchimp unsubscribe webhook.
+    def track_newsletter_change
+      return unless saved_change_to_email_newsletter?
+
+      event = email_newsletter? ? "user_newsletter_subscribed" : "user_newsletter_unsubscribed"
+      user&.track!(event)
     end
   end
 end

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -62,6 +62,11 @@ module Authentication
 
         flag_spam_user(user) if account_less_than_a_week_old?(user, identity)
 
+        # A newly linked mlh identity puts the MLH Core user id (its uid) into
+        # User#trackable_payload, so surface a user_updated to the DEV → Core
+        # sync — which keys off profile_updated_at.
+        user.profile_updated_at = Time.current if new_identity && identity.provider == "mlh"
+
         user.save!
         authed_user = user
       end

--- a/app/workers/trackable/dispatch_worker.rb
+++ b/app/workers/trackable/dispatch_worker.rb
@@ -6,6 +6,15 @@ module Trackable
 
     sidekiq_options queue: :low_priority, retry: 5
 
+    # A dead-lettered event is silent DEV -> Core drift: the event is gone
+    # and nothing downstream will notice. Page instead of dropping quietly.
+    sidekiq_retries_exhausted do |job, exception|
+      Honeybadger.notify(
+        exception,
+        context: { adapter: job["args"]&.first, event: job["args"]&.second, trackable_dead_letter: true },
+      )
+    end
+
     def perform(adapter_name, event_name, user_ids, properties, timestamp_iso)
       adapter = Trackable::Registry.instance_for(adapter_name)
       return if adapter.nil? || !adapter.enabled?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -67,9 +67,33 @@ RSpec.describe User do
       expect(user.trackable_user_ids).to eq([user.id])
     end
 
-    it "ships a curated payload of id, username, email, name" do
+    it "ships a curated payload of identity, confirmation, newsletter, and Core-link state" do
       user = create(:user)
-      expect(user.trackable_payload.keys).to contain_exactly("id", "username", "email", "name")
+      expect(user.trackable_payload.keys).to contain_exactly(
+        "id", "username", "email", "name", "confirmed_at", "email_newsletter", "mlh_user_id"
+      )
+    end
+
+    it "reflects confirmation and newsletter state in the payload" do
+      user = create(:user)
+      user.notification_setting.update!(email_newsletter: true)
+      payload = user.reload.trackable_payload
+
+      expect(payload["confirmed_at"]).to eq(user.confirmed_at.iso8601)
+      expect(payload["email_newsletter"]).to be(true)
+    end
+
+    it "includes the Core user id from the mlh identity in the payload" do
+      omniauth_mock_mlh_payload
+      user = create(:user)
+      create(:identity, user: user, provider: "mlh", uid: "424242")
+
+      expect(user.trackable_payload["mlh_user_id"]).to eq("424242")
+    end
+
+    it "leaves mlh_user_id nil when the user has no mlh identity" do
+      user = create(:user)
+      expect(user.trackable_payload["mlh_user_id"]).to be_nil
     end
 
     # Sidekiq.strict_args! (raise-mode outside production) rejects symbol keys in
@@ -113,6 +137,98 @@ RSpec.describe User do
       user.update!(last_comment_at: 1.day.ago)
       expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
         .with(anything, "user_updated", anything, anything, anything)
+    end
+
+    it "emits user_updated when the email column actually changes" do
+      user = create(:user)
+      enable_sync(actor: user)
+      user.skip_reconfirmation!
+      user.update!(email: "new-address@example.com")
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_updated", [user.id], hash_including("email" => "new-address@example.com"), anything)
+    end
+
+    # Devise reconfirmable parks the new address in unconfirmed_email; the
+    # users.email swap only lands when the user confirms, and that save does
+    # not touch profile_updated_at — so the email/confirmed_at keys must
+    # trigger user_updated on their own.
+    it "emits user_updated with the new email when a pending email change is confirmed" do
+      user = create(:user)
+      enable_sync(actor: user)
+      user.update!(email: "pending-address@example.com")
+      expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+        .with(anything, "user_updated", anything, hash_including("email" => "pending-address@example.com"), anything)
+
+      user.confirm
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_updated", [user.id], hash_including("email" => "pending-address@example.com"),
+              anything)
+    end
+
+    it "emits user_updated when an unconfirmed user confirms their email" do
+      user = create(:user, confirmed_at: nil)
+      enable_sync(actor: user)
+      user.confirm
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_updated", [user.id], hash_including("confirmed_at" => user.confirmed_at.iso8601),
+              anything)
+    end
+
+    describe "engagement events" do
+      # The throttle needs a real cache; the suite default is :null_store.
+      before do
+        allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+      end
+
+      it "emits user_engaged when an activity timestamp advances" do
+        user = create(:user)
+        enable_sync(actor: user)
+        user.touch(:last_comment_at)
+        expect(Trackable::DispatchWorker).to have_received(:perform_async)
+          .with(anything, "user_engaged", [user.id],
+                hash_including("engaged_at" => user.reload.last_comment_at.iso8601), anything)
+      end
+
+      it "throttles repeat activity inside the emit interval" do
+        user = create(:user)
+        enable_sync(actor: user)
+        user.touch(:last_comment_at)
+        user.touch(:last_comment_at)
+        user.update!(current_sign_in_at: Time.current)
+        expect(Trackable::DispatchWorker).to have_received(:perform_async)
+          .with(anything, "user_engaged", anything, anything, anything).once
+      end
+
+      it "does not emit user_engaged for spam or suspended users" do
+        user = create(:user)
+        enable_sync(actor: user)
+        described_class.skip_trackable_events { user.add_role(:spam) }
+        user.touch(:last_comment_at)
+        expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+          .with(anything, "user_engaged", anything, anything, anything)
+      end
+
+      it "does not emit user_engaged for non-activity changes" do
+        user = create(:user)
+        enable_sync(actor: user)
+        user.touch(:profile_updated_at)
+        expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+          .with(anything, "user_engaged", anything, anything, anything)
+      end
+    end
+
+    it "does not emit user_created for unregistered invited users" do
+      enable_sync
+      create(:user, registered: false, registered_at: nil)
+      expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+    end
+
+    it "emits user_created when an invited user completes registration" do
+      user = create(:user, registered: false, registered_at: nil)
+      enable_sync(actor: user)
+      user.update!(registered: true, registered_at: Time.current)
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_created", [user.id], anything, anything)
     end
 
     it "does not emit user_destroyed when a synced user is deleted (deletes are out of scope)" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -246,6 +246,12 @@ RSpec.describe User do
       end
     end
 
+    it "does not emit any sync events for bot accounts" do
+      enable_sync
+      create(:user, type_of: :community_bot)
+      expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+    end
+
     it "does not emit user_created for unregistered invited users" do
       enable_sync
       create(:user, registered: false, registered_at: nil)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -215,6 +215,35 @@ RSpec.describe User do
         expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
           .with(anything, "user_engaged", anything, anything, anything)
       end
+
+      # update_presence! writes via update_column, which bypasses callbacks, so
+      # the engagement event has to be emitted explicitly from that path.
+      it "emits user_engaged from a presence ping" do
+        user = create(:user)
+        enable_sync(actor: user)
+        user.update_presence!
+        expect(Trackable::DispatchWorker).to have_received(:perform_async)
+          .with(anything, "user_engaged", [user.id],
+                hash_including("engaged_at" => user.reload.last_presence_at.iso8601), anything)
+      end
+
+      it "throttles repeat presence pings inside the emit interval" do
+        user = create(:user)
+        enable_sync(actor: user)
+        user.update_presence!
+        Timecop.travel(2.hours.from_now) { user.update_presence! }
+        expect(Trackable::DispatchWorker).to have_received(:perform_async)
+          .with(anything, "user_engaged", anything, anything, anything).once
+      end
+
+      it "does not emit user_engaged from a presence ping for spam or suspended users" do
+        user = create(:user)
+        enable_sync(actor: user)
+        described_class.skip_trackable_events { user.add_role(:spam) }
+        user.update_presence!
+        expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+          .with(anything, "user_engaged", anything, anything, anything)
+      end
     end
 
     it "does not emit user_created for unregistered invited users" do

--- a/spec/models/users/notification_setting_spec.rb
+++ b/spec/models/users/notification_setting_spec.rb
@@ -40,4 +40,42 @@ RSpec.describe Users::NotificationSetting do
       end
     end
   end
+
+  describe "newsletter events for the DEV → Core sync" do
+    before do
+      allow(Trackable::Registry).to receive(:active_names).and_return([:any])
+      allow(Trackable::DispatchWorker).to receive(:perform_async)
+      Settings::General.customerio_cdp_enabled = true
+      FeatureFlag.enable(:dev_core_user_sync, FeatureFlag::Actor[user])
+    end
+
+    after { FeatureFlag.remove(:dev_core_user_sync) }
+
+    around { |ex| with_trackable_events { ex.run } }
+
+    it "emits user_newsletter_subscribed when email_newsletter flips on" do
+      notification_setting.update!(email_newsletter: true)
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_newsletter_subscribed", [user.id], anything, anything)
+    end
+
+    it "emits user_newsletter_unsubscribed when email_newsletter flips off" do
+      notification_setting.update!(email_newsletter: true)
+      notification_setting.update!(email_newsletter: false)
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_newsletter_unsubscribed", [user.id], anything, anything)
+    end
+
+    it "does not emit for other notification setting changes" do
+      notification_setting.update!(email_badge_notifications: !notification_setting.email_badge_notifications)
+      expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+        .with(anything, /user_newsletter/, anything, anything, anything)
+    end
+
+    it "does not emit when the sync gates are off" do
+      Settings::General.customerio_cdp_enabled = false
+      notification_setting.update!(email_newsletter: true)
+      expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+    end
+  end
 end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -590,6 +590,24 @@ RSpec.describe "/admin/member_manager/users" do
       expect(user.email).to eq("updated@example.com")
       expect(user.unconfirmed_email).to be_nil
     end
+
+    # update_columns bypasses the Trackable after_commit, so the controller
+    # must emit explicitly or Core never learns the new address.
+    it "emits user_updated to the DEV -> Core sync" do
+      allow(Trackable::Registry).to receive(:active_names).and_return([:any])
+      allow(Trackable::DispatchWorker).to receive(:perform_async)
+      Settings::General.customerio_cdp_enabled = true
+      FeatureFlag.enable(:dev_core_user_sync, FeatureFlag::Actor[user])
+
+      with_trackable_events do
+        patch update_email_admin_user_path(user), params: { user: { email: "updated@example.com" } }
+      end
+
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_updated", [user.id], hash_including("email" => "updated@example.com"), anything)
+    ensure
+      FeatureFlag.remove(:dev_core_user_sync)
+    end
   end
 
   describe "DELETE /admin/member_manager/users/:id/remove_identity" do
@@ -737,6 +755,25 @@ RSpec.describe "/admin/member_manager/users" do
         expect(user_with_pending_email.confirmed_at).to be_present
         expect(response).to redirect_to(admin_user_path(user_with_pending_email))
         expect(flash[:success]).to be_present
+      end
+
+      # update_columns bypasses the Trackable after_commit, so the controller
+      # must emit explicitly or Core never learns the swapped address.
+      it "emits user_updated to the DEV -> Core sync" do
+        allow(Trackable::Registry).to receive(:active_names).and_return([:any])
+        allow(Trackable::DispatchWorker).to receive(:perform_async)
+        Settings::General.customerio_cdp_enabled = true
+        FeatureFlag.enable(:dev_core_user_sync, FeatureFlag::Actor[user_with_pending_email])
+
+        with_trackable_events do
+          post confirm_pending_email_admin_user_path(user_with_pending_email)
+        end
+
+        expect(Trackable::DispatchWorker).to have_received(:perform_async)
+          .with(anything, "user_updated", [user_with_pending_email.id],
+                hash_including("email" => "newemail@example.com"), anything)
+      ensure
+        FeatureFlag.remove(:dev_core_user_sync)
       end
 
       it "creates an audit note recording the email change" do

--- a/spec/requests/api/v1/admin/users_spec.rb
+++ b/spec/requests/api/v1/admin/users_spec.rb
@@ -268,6 +268,26 @@ RSpec.describe "/api/admin/users" do
       expect(ActionMailer::Base.deliveries).to be_empty
     end
 
+    # update_columns bypasses the Trackable after_commit, so the endpoint
+    # must emit explicitly or Core never learns the new address.
+    it "emits user_updated to the DEV -> Core sync" do
+      allow(Trackable::Registry).to receive(:active_names).and_return([:any])
+      allow(Trackable::DispatchWorker).to receive(:perform_async)
+      Settings::General.customerio_cdp_enabled = true
+      FeatureFlag.enable(:dev_core_user_sync, FeatureFlag::Actor[target])
+
+      with_trackable_events do
+        put "/api/admin/users/#{target.id}/email",
+            params: { email: "new@example.com" },
+            headers: admin_api_headers
+      end
+
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_updated", [target.id], hash_including("email" => "new@example.com"), anything)
+    ensure
+      FeatureFlag.remove(:dev_core_user_sync)
+    end
+
     it "returns 409 email_taken on conflict" do
       create(:user, email: "taken@example.com")
 

--- a/spec/requests/magic_links_spec.rb
+++ b/spec/requests/magic_links_spec.rb
@@ -159,6 +159,44 @@ RSpec.describe "MagicLinks", type: :request do
   describe "GET /magic_links/:id" do
     let(:token) { "valid_token" }
 
+    # The magic-link sign-in confirms the email via update_column, which
+    # bypasses the Trackable after_commit - it must emit explicitly so Core
+    # learns the address is verified.
+    it "emits user_updated to the DEV -> Core sync when it confirms the email" do
+      user = create(:user, confirmed_at: nil)
+      user.update_columns(sign_in_token: "tok-sync-123", sign_in_token_sent_at: Time.current)
+      allow(Trackable::Registry).to receive(:active_names).and_return([:any])
+      allow(Trackable::DispatchWorker).to receive(:perform_async)
+      Settings::General.customerio_cdp_enabled = true
+      FeatureFlag.enable(:dev_core_user_sync, FeatureFlag::Actor[user])
+
+      with_trackable_events { get "/magic_links/tok-sync-123" }
+
+      expect(user.reload.confirmed_at).to be_present
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_updated", [user.id],
+              hash_including("confirmed_at" => user.confirmed_at.iso8601), anything)
+    ensure
+      FeatureFlag.remove(:dev_core_user_sync)
+    end
+
+    it "does not emit user_updated when the email was already confirmed" do
+      user = create(:user, confirmed_at: 1.week.ago)
+      user.update_columns(sign_in_token: "tok-sync-456", sign_in_token_sent_at: Time.current)
+      allow(Trackable::Registry).to receive(:active_names).and_return([:any])
+      allow(Trackable::DispatchWorker).to receive(:perform_async)
+      Settings::General.customerio_cdp_enabled = true
+      FeatureFlag.enable(:dev_core_user_sync, FeatureFlag::Actor[user])
+
+      with_trackable_events { get "/magic_links/tok-sync-456" }
+
+      # (the sign-in itself legitimately emits a throttled user_engaged)
+      expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+        .with(anything, "user_updated", anything, anything, anything)
+    ensure
+      FeatureFlag.remove(:dev_core_user_sync)
+    end
+
     context "when the token matches a user and is not expired" do
       it "confirms the user and redirects to root_path" do
         freeze_time do

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -952,4 +952,29 @@ RSpec.describe Authentication::Authenticator, type: :service do
       end
     end
   end
+
+  context "when authenticating through MLH" do
+    let!(:auth_payload) { omniauth_mock_mlh_payload }
+
+    # The mlh identity carries the Core user id (uid), which rides along in
+    # User#trackable_payload — so linking it must surface a user_updated to the
+    # DEV → Core sync, which keys off profile_updated_at.
+    it "touches profile_updated_at when linking a new mlh identity to an existing account" do
+      user = create(:user, email: auth_payload.info.email, profile_updated_at: 2.years.ago)
+
+      described_class.call(auth_payload, current_user: user)
+
+      expect(user.reload.profile_updated_at).to be > 1.minute.ago
+    end
+
+    it "does not touch profile_updated_at when the mlh identity already exists" do
+      user = create(:user, email: auth_payload.info.email)
+      described_class.call(auth_payload, current_user: user)
+      user.update_column(:profile_updated_at, 2.years.ago)
+
+      described_class.call(auth_payload, current_user: user)
+
+      expect(user.reload.profile_updated_at).to be < 1.year.ago
+    end
+  end
 end

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -964,7 +964,7 @@ RSpec.describe Authentication::Authenticator, type: :service do
 
       described_class.call(auth_payload, current_user: user)
 
-      expect(user.reload.profile_updated_at).to be > 1.minute.ago
+      expect(user.reload.profile_updated_at).to be_within(5.seconds).of(Time.current)
     end
 
     it "does not touch profile_updated_at when the mlh identity already exists" do

--- a/spec/workers/trackable/dispatch_worker_spec.rb
+++ b/spec/workers/trackable/dispatch_worker_spec.rb
@@ -68,4 +68,16 @@ RSpec.describe Trackable::DispatchWorker, type: :worker do
       expect(Rails.logger).to have_received(:error).with(a_string_including("dummy")).at_least(:once)
     end
   end
+
+  describe ".sidekiq_retries_exhausted" do
+    # A dead-lettered event is silent DEV -> Core drift; make it page.
+    it "notifies Honeybadger when an event exhausts its retries" do
+      allow(Honeybadger).to receive(:notify)
+      job = { "args" => ["customerio_cdp", "user_updated", [1], {}, nil], "error_message" => "boom" }
+
+      described_class.sidekiq_retries_exhausted_block.call(job, StandardError.new("boom"))
+
+      expect(Honeybadger).to have_received(:notify)
+    end
+  end
 end


### PR DESCRIPTION
## What

Extends the DEV → MLH Core user sync (Trackable → Customer.io CDP) beyond create + profile edits, closing the gaps where Core (source of truth for emails and subscriptions) silently drifted from DEV:

- **Newsletter consent**: `Users::NotificationSetting#email_newsletter` changes now emit `user_newsletter_subscribed` / `user_newsletter_unsubscribed`. This covers every toggle path — settings page, one-click unsubscribe links in emails, onboarding, and the Mailchimp unsubscribe webhook — none of which previously reached the CDP.
- **Email changes**: Devise `reconfirmable` lands the actual `users.email` swap outside any profile edit, so Core never learned new addresses. `user_updated` now also fires when `email` or `confirmed_at` change, and the payload carries `confirmed_at` so Core can mark verified identifiers.
- **Core-link id**: the payload now carries `mlh_user_id` (the mlh identity's uid), letting Core resolve users deterministically instead of by email match. Linking a new mlh identity via OAuth touches `profile_updated_at` so the link surfaces immediately.
- **Engagement**: activity-timestamp changes (sign-ins, comments, articles, reactions, follows, presence) emit a throttled `user_engaged` — at most one per user per week via a cache key — so Core's `engaged_at` stays fresh for users who never edit their profile. Event-driven; no scheduled batch scan. Moderated (spam/suspended) accounts stay silent so pruned Customer.io profiles aren't resurrected.
- **Invited accounts**: `user_created` no longer fires for `registered: false` invite placeholders; it fires when registration completes.

## Why

MLH Core consumes these events to keep user emails, newsletter subscriptions, and engagement windows accurate. Without them, a DEV unsubscribe kept receiving Core-driven email (compliance issue), email changes never propagated, and active users aged out of Core's 24-month engagement window.

Everything stays behind the existing gates: `Settings::General.customerio_cdp_enabled` + the `:dev_core_user_sync` feature flag.

## Tests

- `spec/models/user_spec.rb` — payload shape, email/confirmed_at emission, reconfirmable swap, invite gating, engagement throttling
- `spec/models/users/notification_setting_spec.rb` — newsletter event emission + gating
- `spec/services/authentication/authenticator_spec.rb` — mlh identity link touch

https://claude.ai/code/session_01BbriEeFARfLvUDKbH3WYAt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786113084&installation_id=139885019&pr_number=23579&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23579&signature=c8c91b06ce68f591f42a7effbf0ff18ac8e565517a8635968aa914a6011ed757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->