### PR TITLE
Emit user_merged instead of user_gdpr_deleted when admins merge users

### DIFF
--- a/app/services/moderator/merge_user.rb
+++ b/app/services/moderator/merge_user.rb
@@ -21,8 +21,11 @@ module Moderator
       merge_mentions
       merge_profile
       update_social
-      Users::DeleteWorker.new.perform(@delete_user.id, true)
+      # The merged-away row is deleted, but this is a merge, not a GDPR
+      # erasure — MLH Core merges the two accounts instead of erasing one.
+      Users::DeleteWorker.new.perform(@delete_user.id, true, "merge")
       @keep_user.touch(:profile_updated_at)
+      @keep_user.track!("user_merged", { "merged_forem_user_id" => @delete_user.id })
       Users::MergeSyncWorker.perform_async(@keep_user.id)
 
       EdgeCache::Bust.call("/#{@keep_user.username}")

--- a/app/workers/users/delete_worker.rb
+++ b/app/workers/users/delete_worker.rb
@@ -4,16 +4,21 @@ module Users
 
     sidekiq_options queue: :high_priority, retry: 10
 
-    def perform(user_id, admin_delete = false) # rubocop:disable Style/OptionalBooleanParameter
+    # reason distinguishes true GDPR erasures (the default) from deletions
+    # that only remove the row, like merges — those must not leave a
+    # gdpr-delete reminder or tell MLH Core to erase the person's data.
+    def perform(user_id, admin_delete = false, reason = "gdpr") # rubocop:disable Style/OptionalBooleanParameter
       user = User.find_by(id: user_id)
       return unless user
 
       Users::Delete.call(user)
-      # notify admins internally that they need to delete gdpr data
-      GDPRDeleteRequest.create(user_id: user.id, email: user.email, username: user.username)
-      # tell MLH Core so it can erase the DEV-derived data it holds (the user
-      # object is destroyed, but its in-memory attributes still feed the payload)
-      user.track!("user_gdpr_deleted")
+      if reason == "gdpr"
+        # notify admins internally that they need to delete gdpr data
+        GDPRDeleteRequest.create(user_id: user.id, email: user.email, username: user.username)
+        # tell MLH Core so it can erase the DEV-derived data it holds (the user
+        # object is destroyed, but its in-memory attributes still feed the payload)
+        user.track!("user_gdpr_deleted")
+      end
 
       return if admin_delete || user.email.blank?
 

--- a/spec/services/moderator/merge_user_spec.rb
+++ b/spec/services/moderator/merge_user_spec.rb
@@ -32,5 +32,36 @@ RSpec.describe Moderator::MergeUser, type: :service do
 
       expect(keep_user.reload.badge_achievements_count).to eq(2)
     end
+
+    describe "DEV → Core sync events" do
+      before do
+        allow(Trackable::Registry).to receive(:active_names).and_return([:any])
+        allow(Trackable::DispatchWorker).to receive(:perform_async)
+        Settings::General.customerio_cdp_enabled = true
+        FeatureFlag.enable(:dev_core_user_sync)
+      end
+
+      after { FeatureFlag.remove(:dev_core_user_sync) }
+
+      around { |ex| with_trackable_events { ex.run } }
+
+      it "emits user_merged for the kept user carrying the merged-away forem user id" do
+        described_class.call(admin: admin, keep_user: keep_user, delete_user_id: delete_user.id)
+
+        expect(Trackable::DispatchWorker).to have_received(:perform_async)
+          .with(anything, "user_merged", [keep_user.id],
+                hash_including("merged_forem_user_id" => delete_user_id), anything)
+      end
+
+      # A merge deletes the merged-away row via Users::DeleteWorker, but it is
+      # not a GDPR erasure — the person's content now lives on keep_user, and
+      # Core must merge rather than erase.
+      it "does not emit user_gdpr_deleted for the merged-away account" do
+        described_class.call(admin: admin, keep_user: keep_user, delete_user_id: delete_user.id)
+
+        expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+          .with(anything, "user_gdpr_deleted", anything, anything, anything)
+      end
+    end
   end
 end

--- a/spec/workers/users/delete_worker_spec.rb
+++ b/spec/workers/users/delete_worker_spec.rb
@@ -72,6 +72,34 @@ RSpec.describe Users::DeleteWorker, type: :worker do
           worker.perform(user.id, true)
         end.to change(GDPRDeleteRequest, :count).by(1)
       end
+
+      # Merges delete the merged-away row through this worker, but nobody
+      # requested erasure - the person's content moved to the kept account.
+      it "does not create a gdpr-delete record for non-GDPR (merge) deletions" do
+        expect do
+          worker.perform(user.id, true, "merge")
+        end.not_to change(GDPRDeleteRequest, :count)
+      end
+
+      it "does not emit user_gdpr_deleted for non-GDPR (merge) deletions" do
+        allow(Trackable::Registry).to receive(:active_names).and_return([:any])
+        allow(Trackable::DispatchWorker).to receive(:perform_async)
+        Settings::General.customerio_cdp_enabled = true
+        FeatureFlag.enable(:dev_core_user_sync)
+
+        with_trackable_events { worker.perform(user.id, true, "merge") }
+
+        expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+          .with(anything, "user_gdpr_deleted", anything, anything, anything)
+      ensure
+        FeatureFlag.remove(:dev_core_user_sync)
+      end
+
+      it "still deletes the user on non-GDPR (merge) deletions" do
+        worker.perform(user.id, true, "merge")
+
+        expect(User.exists?(id: user.id)).to be(false)
+      end
     end
 
     context "when user is not found" do


### PR DESCRIPTION
## What

`Users::DeleteWorker` assumed every deletion is a GDPR erasure: it created a `GDPRDeleteRequest` and emitted `user_gdpr_deleted` to the Customer.io CDP even when `Moderator::MergeUser` deleted the merged-away row. That made MLH Core treat an admin merge as an erasure — destroying Core-side data that actually just moved to the kept account — and left admins a bogus external-systems purge reminder for someone who never requested deletion.

- `DeleteWorker#perform` now takes an explicit deletion `reason` (default `"gdpr"`, so all existing call sites keep today's behavior). Only real erasures create the `GDPRDeleteRequest` and emit `user_gdpr_deleted`.
- `Moderator::MergeUser` passes `"merge"` and emits `user_merged` from the kept user with a `merged_forem_user_id` property, so Core can merge its two user records (mirroring the DEV-side merge) instead of erasing one.

The kept user's existing `profile_updated_at` touch still emits `user_updated`, keeping its profile fresh in Core.

Note: this also stops merges from creating `GDPRDeleteRequest` rows — those reminders tell admins to purge the person from external systems, which is wrong for a merge where the person keeps their account.

## Tests

- `spec/workers/users/delete_worker_spec.rb` — merge-reason deletions skip the GDPR record and event but still delete; default reason unchanged
- `spec/services/moderator/merge_user_spec.rb` — `user_merged` emission with the merged id; no `user_gdpr_deleted` during a merge

https://claude.ai/code/session_01BbriEeFARfLvUDKbH3WYAt