### PR TITLE
Add IP rate limit for /search/feed_content and fix Fastly client IP tracking

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -24,9 +24,9 @@ module Rack
 
     class Request < ::Rack::Request
       def track_and_return_ip
-        if ApplicationConfig["FASTLY_API_KEY"].present?
-          Honeycomb.add_field("fastly_client_ip", env["HTTP_FASTLY_CLIENT_IP"])
-          env["HTTP_FASTLY_CLIENT_IP"]
+        fastly_ip = env["HTTP_FASTLY_CLIENT_IP"]
+        if ApplicationConfig["FASTLY_API_KEY"].present? && fastly_ip.present?
+          fastly_ip
         else
           ActionDispatch::Request.new(env).remote_ip
         end
@@ -83,6 +83,12 @@ module Rack
       if ENV["SITEMAP_RATE_LIMIT_ENABLED"] == "true" && request.path.starts_with?("/sitemap-")
         ip = request.track_and_return_ip
         ip unless GooglebotVerifier.googlebot?(ip)
+      end
+    end
+
+    throttle("search_feed_content_throttle", limit: 10, period: 1.minute) do |request|
+      if request.path == "/search/feed_content"
+        request.track_and_return_ip
       end
     end
 

--- a/spec/initializers/rack_attack_spec.rb
+++ b/spec/initializers/rack_attack_spec.rb
@@ -26,8 +26,47 @@ describe Rack, ".attack", throttle: true, type: :request do
         valid_responses.each { |r| expect(r).not_to eq(429) }
         expect(throttled_response).to eq(429)
         expect(new_ip_response).not_to eq(429)
-        expect(Honeycomb).to have_received(:add_field).with("fastly_client_ip", "5.6.7.8").at_least(6).times
-        expect(Honeycomb).to have_received(:add_field).with("fastly_client_ip", "1.1.1.1").at_least(1).times
+      end
+    end
+  end
+
+  describe "search_feed_content_throttle" do
+    before do
+      allow(Homepage::FetchArticles).to receive(:call).and_return([])
+      allow(Search::Article).to receive(:search_documents).and_return([])
+    end
+
+    it "throttles /search/feed_content after 10 requests per minute" do
+      Timecop.freeze do
+        start_time = Time.current
+        valid_responses = (1..10).map do |i|
+          Timecop.travel(start_time + i.seconds)
+          get "/search/feed_content", params: { feed_params: { class_name: "Article", sort_by: "hotness_score" } }, headers: { "HTTP_FASTLY_CLIENT_IP" => "5.6.7.8" }
+        end
+        Timecop.travel(start_time + 11.seconds)
+        throttled_response = get "/search/feed_content", params: { feed_params: { class_name: "Article", sort_by: "hotness_score" } }, headers: { "HTTP_FASTLY_CLIENT_IP" => "5.6.7.8" }
+        new_ip_response = get "/search/feed_content", params: { feed_params: { class_name: "Article", sort_by: "hotness_score" } }, headers: { "HTTP_FASTLY_CLIENT_IP" => "1.1.1.1" }
+
+        valid_responses.each { |r| expect(r).not_to eq(429) }
+        expect(throttled_response).to eq(429)
+        expect(new_ip_response).not_to eq(429)
+      end
+    end
+
+    it "falls back to Rails remote_ip if HTTP_FASTLY_CLIENT_IP is blank/missing" do
+      Timecop.freeze do
+        start_time = Time.current
+        valid_responses = (1..10).map do |i|
+          Timecop.travel(start_time + i.seconds)
+          get "/search/feed_content", params: { feed_params: { class_name: "Article", sort_by: "hotness_score" } }, headers: { "REMOTE_ADDR" => "9.9.9.9" }
+        end
+        Timecop.travel(start_time + 11.seconds)
+        throttled_response = get "/search/feed_content", params: { feed_params: { class_name: "Article", sort_by: "hotness_score" } }, headers: { "REMOTE_ADDR" => "9.9.9.9" }
+        new_ip_response = get "/search/feed_content", params: { feed_params: { class_name: "Article", sort_by: "hotness_score" } }, headers: { "REMOTE_ADDR" => "1.1.1.1" }
+
+        valid_responses.each { |r| expect(r).not_to eq(429) }
+        expect(throttled_response).to eq(429)
+        expect(new_ip_response).not_to eq(429)
       end
     end
   end
@@ -44,8 +83,6 @@ describe Rack, ".attack", throttle: true, type: :request do
         valid_responses.each { |r| expect(r).not_to eq(429) }
         expect(throttled_response).to eq(429)
         expect(new_ip_response).not_to eq(429)
-        expect(Honeycomb).to have_received(:add_field).with("fastly_client_ip", "5.6.7.8").at_least(4).times
-        expect(Honeycomb).to have_received(:add_field).with("fastly_client_ip", "1.1.1.1").at_least(1).times
       end
     end
 
@@ -89,7 +126,6 @@ describe Rack, ".attack", throttle: true, type: :request do
         expect(valid_response).not_to eq(429)
         expect(throttled_response).to eq(429)
         expect(new_api_response).not_to eq(429)
-        expect(Honeycomb).to have_received(:add_field).with("fastly_client_ip", "5.6.7.8").at_least(3).times
         expect(Honeycomb).to have_received(:add_field).with("user_api_key", api_secret.secret).exactly(2).times
         expect(Honeycomb).to have_received(:add_field).with("user_api_key", another_api_secret.secret)
       end
@@ -108,8 +144,6 @@ describe Rack, ".attack", throttle: true, type: :request do
         expect(valid_response).not_to eq(429)
         expect(throttled_response).to eq(429)
         expect(new_api_response).not_to eq(429)
-        expect(Honeycomb).to have_received(:add_field).with("fastly_client_ip", "5.6.7.8").at_least(2).times
-        expect(Honeycomb).to have_received(:add_field).with("fastly_client_ip", "1.1.1.1").at_least(1).times
       end
     end
 


### PR DESCRIPTION
This PR adds a dedicated IP rate limit to the `/search/feed_content` route and fixes/improves client IP tracking.

### Proposed Changes
1. **Rate Limiting:** Added a dedicated IP rate limit of **10 requests per minute** to `/search/feed_content` under `search_feed_content_throttle`.
2. **IP Tracking:** Refactored `track_and_return_ip` to correctly prioritize the `Fastly-Client-IP` header when present, with a safe fallback to Rails' `remote_ip`.
3. **Telemetry:** Removed Honeycomb telemetry logging (`Honeycomb.add_field("fastly_client_ip")`) from `track_and_return_ip`.
4. **Validation:** Added specs and verified the new rate limiter and the fallback IP tracking work as expected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786115640&installation_id=139885019&pr_number=23582&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23582&signature=f1361604d44a1aa1675e8d1ee0c95d71c321d8abef5f332651fbafeddbd1f59b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->