### PR TITLE
Add a bulk admin API endpoint for linking mlh identities

### DIFF
--- a/app/controllers/concerns/api/admin/user_identities_controller.rb
+++ b/app/controllers/concerns/api/admin/user_identities_controller.rb
@@ -75,7 +75,8 @@ module Api
         ensure_enabled_provider!(provider)
 
         entries = bulk_entries!
-        @results = entries.map { |entry| bulk_link_result(provider, entry) }
+        preload = bulk_preload(provider, entries)
+        @results = entries.map { |entry| bulk_link_result(provider, entry, preload) }
 
         audit!(slug: "bulk_link_identities",
                data: {
@@ -107,19 +108,59 @@ module Api
         )
       end
 
-      def bulk_link_result(provider, entry)
+      # Three queries for the whole batch instead of three per row — at 1,000
+      # rows per request and ~2M links total, per-row lookups would hammer
+      # the DB. The taken-uid set is mutated as rows link so same-batch
+      # duplicates conflict like pre-existing ones; the RecordNotUnique
+      # rescue still covers races with concurrent writers.
+      def bulk_preload(provider, entries)
+        objects = entries.select { |entry| bulk_entry_object?(entry) }
+        user_ids = objects.filter_map { |entry| entry[:user_id].presence }
+        uids = objects.filter_map { |entry| entry[:uid].presence&.to_s }
+        {
+          users: User.where(id: user_ids).index_by(&:id),
+          identities_by_user: Identity.where(provider: provider, user_id: user_ids).index_by(&:user_id),
+          taken_uids: Identity.where(provider: provider, uid: uids).pluck(:uid).to_set
+        }
+      end
+
+      # Strings also respond to #[], so require an actual object entry.
+      def bulk_entry_object?(entry)
+        entry.is_a?(ActionController::Parameters) || entry.is_a?(Hash)
+      end
+
+      def bulk_link_result(provider, entry, preload)
+        return { "user_id" => nil, "status" => "invalid" } unless bulk_entry_object?(entry)
+
         user_id = entry[:user_id]
         uid = entry[:uid].to_s
         return { "user_id" => user_id, "status" => "invalid" } if user_id.blank? || uid.blank?
 
-        target = User.find_by(id: user_id)
+        target = preload[:users][user_id.to_i]
         return { "user_id" => user_id.to_i, "status" => "not_found" } unless target
 
-        identity, already_linked = resolve_identity_for_link(target, provider, uid)
-        { "user_id" => target.id, "identity_id" => identity.id,
-          "status" => already_linked ? "already_linked" : "created" }
-      rescue Api::Admin::ApiError => e
-        { "user_id" => target.id, "status" => "conflict", "error_code" => e.error_code.to_s }
+        link_preloaded_identity(provider, target, uid, preload)
+      end
+
+      def link_preloaded_identity(provider, target, uid, preload)
+        existing = preload[:identities_by_user][target.id]
+        if existing
+          return { "user_id" => target.id, "identity_id" => existing.id, "status" => "already_linked" } if
+            existing.uid == uid
+
+          return { "user_id" => target.id, "status" => "conflict",
+                   "error_code" => "user_already_has_identity_for_provider" }
+        end
+
+        if preload[:taken_uids].include?(uid)
+          return { "user_id" => target.id, "status" => "conflict", "error_code" => "identity_uid_taken" }
+        end
+
+        identity = Identity.create!(user: target, provider: provider, uid: uid)
+        preload[:taken_uids] << uid
+        { "user_id" => target.id, "identity_id" => identity.id, "status" => "created" }
+      rescue ActiveRecord::RecordNotUnique
+        { "user_id" => target.id, "status" => "conflict", "error_code" => "identity_uid_taken" }
       end
 
       # Returns [identity, already_linked]. Raises Api::Admin::ApiError for the

--- a/app/controllers/concerns/api/admin/user_identities_controller.rb
+++ b/app/controllers/concerns/api/admin/user_identities_controller.rb
@@ -8,16 +8,14 @@ module Api
         @identities = target.identities.order(created_at: :asc)
       end
 
+      BULK_IDENTITY_LIMIT = 1_000
+
       def create
         target = User.find(params[:user_id])
         provider = params.require(:provider)
         uid = params.require(:uid).to_s
 
-        unless Authentication::Providers.enabled?(provider)
-          raise Api::Admin::ApiError.new(:unknown_provider,
-                                         I18n.t("admin_api.errors.unknown_provider", provider: provider),
-                                         status: 422)
-        end
+        ensure_enabled_provider!(provider)
 
         already_linked = false
         ActiveRecord::Base.transaction do
@@ -67,7 +65,62 @@ module Api
         head :no_content
       end
 
+      # Links a batch of identities in one request (the Core -> DEV reverse-link
+      # seed is millions of accounts; one HTTP call per identity would take
+      # days against the API rate limits). Every entry gets a per-item result
+      # - created / already_linked / conflict / not_found / invalid - so one
+      # bad row never fails the batch, and the whole batch is audited once.
+      def bulk_create
+        provider = params.require(:provider)
+        ensure_enabled_provider!(provider)
+
+        entries = bulk_entries!
+        @results = entries.map { |entry| bulk_link_result(provider, entry) }
+
+        audit!(slug: "bulk_link_identities",
+               data: {
+                 "provider" => provider,
+                 "count" => entries.size,
+                 "statuses" => @results.pluck("status").tally
+               })
+        render :bulk_create, status: :ok
+      end
+
       private
+
+      def ensure_enabled_provider!(provider)
+        return if Authentication::Providers.enabled?(provider)
+
+        raise Api::Admin::ApiError.new(:unknown_provider,
+                                       I18n.t("admin_api.errors.unknown_provider", provider: provider),
+                                       status: 422)
+      end
+
+      def bulk_entries!
+        entries = params[:identities]
+        return entries if entries.is_a?(Array) && entries.size.between?(1, BULK_IDENTITY_LIMIT)
+
+        raise Api::Admin::ApiError.new(
+          :invalid_identities,
+          I18n.t("admin_api.errors.invalid_identities", limit: BULK_IDENTITY_LIMIT),
+          status: 422,
+        )
+      end
+
+      def bulk_link_result(provider, entry)
+        user_id = entry[:user_id]
+        uid = entry[:uid].to_s
+        return { "user_id" => user_id, "status" => "invalid" } if user_id.blank? || uid.blank?
+
+        target = User.find_by(id: user_id)
+        return { "user_id" => user_id.to_i, "status" => "not_found" } unless target
+
+        identity, already_linked = resolve_identity_for_link(target, provider, uid)
+        { "user_id" => target.id, "identity_id" => identity.id,
+          "status" => already_linked ? "already_linked" : "created" }
+      rescue Api::Admin::ApiError => e
+        { "user_id" => target.id, "status" => "conflict", "error_code" => e.error_code.to_s }
+      end
 
       # Returns [identity, already_linked]. Raises Api::Admin::ApiError for the
       # strict-fail-closed conflict states (user has different uid for provider,

--- a/app/views/api/v1/admin/user_identities/bulk_create.json.jbuilder
+++ b/app/views/api/v1/admin/user_identities/bulk_create.json.jbuilder
@@ -1,0 +1,1 @@
+json.results @results

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -201,6 +201,7 @@ en:
       identity_not_found: "Identity not found for user"
       user_already_has_identity_for_provider: "User already has an identity for provider '%{provider}'"
       identity_uid_taken: "Identity uid %{uid} (%{provider}) is already linked to another user"
+      invalid_identities: "identities must be an array of 1 to %{limit} entries"
       cannot_merge_user_into_itself: "Cannot merge a user into itself"
       merge_identity_conflict: "Merge could not complete: %{reason}"
       unknown_provider: "Provider '%{provider}' is not configured"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -232,6 +232,7 @@ fr:
       identity_not_found: "Identité introuvable pour cet utilisateur"
       user_already_has_identity_for_provider: "L'utilisateur a déjà une identité pour le fournisseur « %{provider} »"
       identity_uid_taken: "L'uid %{uid} (%{provider}) est déjà lié à un autre utilisateur"
+      invalid_identities: "identities doit être un tableau de 1 à %{limit} entrées"
       cannot_merge_user_into_itself: "Impossible de fusionner un utilisateur avec lui-même"
       merge_identity_conflict: "La fusion n'a pas pu être effectuée : %{reason}"
       unknown_provider: "Le fournisseur « %{provider} » n'est pas configuré"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -232,6 +232,7 @@ pt:
       identity_not_found: "Identidade não encontrada para o usuário"
       user_already_has_identity_for_provider: "O usuário já possui uma identidade para o provedor '%{provider}'"
       identity_uid_taken: "O uid %{uid} (%{provider}) já está vinculado a outro usuário"
+      invalid_identities: "identities deve ser uma lista de 1 a %{limit} itens"
       cannot_merge_user_into_itself: "Não é possível mesclar um usuário consigo mesmo"
       merge_identity_conflict: "A mesclagem não pôde ser concluída: %{reason}"
       unknown_provider: "O provedor '%{provider}' não está configurado"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,13 +38,13 @@ Rails.application.routes.draw do
     get "/:org_slug/:slug",
         to: "stories#custom_domain_show",
         constraints: {
-          org_slug: /(?!(?:api|assets|packs|rails|r|ahoy|enter|users)\z)[^\/.]+/,
-          slug: /[^\/.]+/
+          org_slug: %r{(?!(?:api|assets|packs|rails|r|ahoy|enter|users)\z)[^/.]+},
+          slug: %r{[^/.]+}
         }
     get "/:slug",
         to: "stories#custom_domain_show",
         constraints: {
-          slug: /(?!(?:api|assets|packs|rails|r|ahoy|enter|users)\z)[^\/.]+/
+          slug: %r{(?!(?:api|assets|packs|rails|r|ahoy|enter|users)\z)[^/.]+}
         }
   end
 
@@ -127,6 +127,10 @@ Rails.application.routes.draw do
 
         namespace :admin do
           resources :users, only: %i[index show update] do
+            collection do
+              post "identities/bulk", to: "user_identities#bulk_create"
+            end
+
             member do
               put :email, action: :update_email
               put :status, action: :update_status
@@ -175,7 +179,8 @@ Rails.application.routes.draw do
     resources :events, only: %i[index]
     get "/calendar", to: "calendar#index"
     get "events/:event_name_slug/:event_variation_slug", to: "events#show", as: :event
-    get "events/:event_name_slug/:event_variation_slug/signup_status", to: "event_signups#status", as: :event_signup_status
+    get "events/:event_name_slug/:event_variation_slug/signup_status", to: "event_signups#status",
+                                                                       as: :event_signup_status
     post "events/:event_name_slug/:event_variation_slug/signup", to: "event_signups#create", as: :event_signup
     delete "events/:event_name_slug/:event_variation_slug/signup", to: "event_signups#destroy"
     resources :article_mutes, only: %i[update]
@@ -234,11 +239,11 @@ Rails.application.routes.draw do
       end
     end
     resources :trending, param: :slug, only: %i[index show], controller: :trends
-    get "/trends", to: redirect { |path_params, req|
+    get "/trends", to: redirect { |path_params, _req|
       locale = path_params[:locale]
       locale ? "/locale/#{locale}/trending" : "/trending"
     }
-    get "/trends/:slug", to: redirect { |path_params, req|
+    get "/trends/:slug", to: redirect { |path_params, _req|
       locale = path_params[:locale]
       slug = path_params[:slug]
       locale ? "/locale/#{locale}/trending/#{slug}" : "/trending/#{slug}"
@@ -419,15 +424,18 @@ Rails.application.routes.draw do
     get "/:slug/members", to: "organizations#members", as: :organization_members
     get "/:slug/settings", to: "organization_settings#edit", as: :organization_settings
     patch "/:slug/settings", to: "organization_settings#update"
-    post "/:slug/settings/verify", to: "organization_settings#request_verification", as: :organization_request_verification
+    post "/:slug/settings/verify", to: "organization_settings#request_verification",
+                                   as: :organization_request_verification
     post "/:slug/settings/preview", to: "organization_settings#preview", as: :organization_settings_preview
     get "/:slug/settings/lead_forms", to: "organization_lead_forms#index", as: :organization_lead_forms
     post "/:slug/settings/lead_forms", to: "organization_lead_forms#create"
     get "/:slug/settings/lead_forms/:id/edit", to: "organization_lead_forms#edit", as: :edit_organization_lead_form
     patch "/:slug/settings/lead_forms/:id", to: "organization_lead_forms#update", as: :update_organization_lead_form
     delete "/:slug/settings/lead_forms/:id", to: "organization_lead_forms#destroy", as: :organization_lead_form
-    patch "/:slug/settings/lead_forms/:id/toggle", to: "organization_lead_forms#toggle", as: :organization_lead_form_toggle
-    get "/:slug/settings/lead_forms/:id/submissions", to: "organization_lead_forms#submissions", as: :organization_lead_form_submissions
+    patch "/:slug/settings/lead_forms/:id/toggle", to: "organization_lead_forms#toggle",
+                                                   as: :organization_lead_form_toggle
+    get "/:slug/settings/lead_forms/:id/submissions", to: "organization_lead_forms#submissions",
+                                                      as: :organization_lead_form_submissions
     post "/lead_submissions", to: "lead_submissions#create"
     get "/lead_submissions/check", to: "lead_submissions#check"
     post "articles/preview", to: "articles#preview"
@@ -534,7 +542,8 @@ Rails.application.routes.draw do
 
     get "/top/:timeframe", to: "stories#index"
 
-    get "/:feed_type/:timeframe", to: "stories#index", constraints: { feed_type: /following/, timeframe: /latest|latest_less_filtered/ }
+    get "/:feed_type/:timeframe", to: "stories#index",
+                                  constraints: { feed_type: /following/, timeframe: /latest|latest_less_filtered/ }
 
     get "/:timeframe", to: "stories#index", constraints: { timeframe: /latest|latest_less_filtered/ }
     get "/:feed_type", to: "stories#index", constraints: { feed_type: /discover|following/ }

--- a/spec/requests/api/v1/admin/user_identities_spec.rb
+++ b/spec/requests/api/v1/admin/user_identities_spec.rb
@@ -169,4 +169,104 @@ RSpec.describe "Api::V1::Admin::UserIdentities" do
       expect(audit.data).to include("provider" => "mlh", "uid" => "core-1", "identity_id" => identity.id)
     end
   end
+
+  describe "POST /api/admin/users/identities/bulk" do
+    def bulk_post(identities, provider: "mlh", headers: admin_api_headers)
+      post "/api/admin/users/identities/bulk",
+           params: { provider: provider, identities: identities }.to_json,
+           headers: headers.merge("Content-Type" => "application/json")
+    end
+
+    it "links every entry and returns per-item results" do
+      users = create_list(:user, 3)
+      entries = users.each_with_index.map { |u, i| { user_id: u.id, uid: (1000 + i).to_s } }
+
+      expect { bulk_post(entries) }.to change(Identity, :count).by(3)
+
+      expect(response).to have_http_status(:ok)
+      results = response.parsed_body["results"]
+      expect(results.pluck("status")).to all(eq("created"))
+      expect(results.pluck("user_id")).to match_array(users.map(&:id))
+      expect(users.first.identities.find_by(provider: "mlh").uid).to eq("1000")
+    end
+
+    it "reports already_linked for idempotent repeats" do
+      create(:identity, user: user, provider: "mlh", uid: "424242")
+
+      expect { bulk_post([{ user_id: user.id, uid: "424242" }]) }.not_to change(Identity, :count)
+
+      expect(response.parsed_body["results"].first["status"]).to eq("already_linked")
+    end
+
+    it "reports conflicts per item without failing the rest of the batch" do
+      conflicted = create(:user)
+      create(:identity, user: conflicted, provider: "mlh", uid: "111")
+      taken = create(:user)
+      create(:identity, user: create(:user), provider: "mlh", uid: "999")
+      fine = create(:user)
+
+      bulk_post([
+                  { user_id: conflicted.id, uid: "222" },
+                  { user_id: taken.id, uid: "999" },
+                  { user_id: fine.id, uid: "333" },
+                ])
+
+      expect(response).to have_http_status(:ok)
+      results = response.parsed_body["results"].index_by { |r| r["user_id"] }
+      expect(results[conflicted.id]["status"]).to eq("conflict")
+      expect(results[conflicted.id]["error_code"]).to eq("user_already_has_identity_for_provider")
+      expect(results[taken.id]["status"]).to eq("conflict")
+      expect(results[taken.id]["error_code"]).to eq("identity_uid_taken")
+      expect(results[fine.id]["status"]).to eq("created")
+    end
+
+    it "reports not_found and invalid entries without failing the batch" do
+      bulk_post([{ user_id: 999_999, uid: "1" }, { user_id: user.id, uid: "" }])
+
+      statuses = response.parsed_body["results"].pluck("status")
+      expect(statuses).to contain_exactly("not_found", "invalid")
+    end
+
+    it "rejects unknown providers" do
+      bulk_post([{ user_id: user.id, uid: "1" }], provider: "carrier_pigeon")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["error_code"]).to eq("unknown_provider")
+    end
+
+    it "rejects an empty identities array" do
+      bulk_post([])
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["error_code"]).to eq("invalid_identities")
+    end
+
+    it "rejects batches over the cap" do
+      entries = Array.new(1001) { |i| { user_id: i + 1, uid: i.to_s } }
+
+      bulk_post(entries)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["error_code"]).to eq("invalid_identities")
+    end
+
+    it "logs one audit entry for the batch" do
+      expect do
+        bulk_post([{ user_id: user.id, uid: "77" }])
+      end.to change(AuditLog, :count).by(1)
+
+      audit = AuditLog.last
+      expect(audit.slug).to eq("bulk_link_identities")
+      expect(audit.data["count"]).to eq(1)
+    end
+
+    it "requires an admin api key" do
+      post "/api/admin/users/identities/bulk",
+           params: { provider: "mlh", identities: [{ user_id: user.id, uid: "1" }] }.to_json,
+           headers: { "Content-Type" => "application/json",
+                      "Accept" => "application/vnd.forem.api-v1+json" }
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
 end

--- a/spec/requests/api/v1/admin/user_identities_spec.rb
+++ b/spec/requests/api/v1/admin/user_identities_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe "Api::V1::Admin::UserIdentities" do
     # the providers exercised below.
     allow(Settings::Authentication).to receive(:providers)
       .and_return(Authentication::Providers.available)
+    # The identity factory reads OmniAuth.config.mock_auth for its
+    # auth_data_dump — set it here so examples don't depend on spec order.
+    omniauth_mock_mlh_payload
   end
 
   after { Audit::Subscribe.forget :admin_api }
@@ -218,6 +221,25 @@ RSpec.describe "Api::V1::Admin::UserIdentities" do
       expect(results[taken.id]["status"]).to eq("conflict")
       expect(results[taken.id]["error_code"]).to eq("identity_uid_taken")
       expect(results[fine.id]["status"]).to eq("created")
+    end
+
+    it "reports non-object entries as invalid without failing the batch" do
+      bulk_post(["not-a-hash", { user_id: user.id, uid: "55" }])
+
+      statuses = response.parsed_body["results"].pluck("status")
+      expect(statuses).to contain_exactly("invalid", "created")
+    end
+
+    it "reports a same-batch duplicate uid as a conflict" do
+      first = create(:user)
+      second = create(:user)
+
+      bulk_post([{ user_id: first.id, uid: "777" }, { user_id: second.id, uid: "777" }])
+
+      results = response.parsed_body["results"].index_by { |r| r["user_id"] }
+      expect(results[first.id]["status"]).to eq("created")
+      expect(results[second.id]["status"]).to eq("conflict")
+      expect(results[second.id]["error_code"]).to eq("identity_uid_taken")
     end
 
     it "reports not_found and invalid entries without failing the batch" do


### PR DESCRIPTION
## What

`POST /api/admin/users/identities/bulk` — links up to 1,000 identities per request:

```json
{ "provider": "mlh", "identities": [{ "user_id": 123, "uid": "45678" }, ...] }
```

Every entry gets a per-item result — `created` / `already_linked` / `conflict` (with the same fail-closed `error_code`s as the single endpoint) / `not_found` / `invalid` — so one bad row never fails the batch. One audit entry per batch with a status tally. The single-identity endpoint's provider check is shared, and its conflict semantics (`user_already_has_identity_for_provider`, `identity_uid_taken`) are reused per item.

## Why

MLH Core seeds its user ids onto DEV accounts as `mlh` identities (the reverse link for the DEV → Core user sync). The backfill covers ~2M accounts; one HTTP call per identity would take days against API rate limits, while 1,000-per-request brings the seed to ~2K calls. Companion Core change updates `import:push_dev_core_links` to batch through this endpoint.

## Tests

`spec/requests/api/v1/admin/user_identities_spec.rb` — happy path, idempotent repeats, per-item conflicts (both codes), not_found/invalid entries, provider and size validation, batch audit, auth.

https://claude.ai/code/session_01BbriEeFARfLvUDKbH3WYAt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786196475&installation_id=139885019&pr_number=23583&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23583&signature=8b6336c1a9c19fc5e7abd306638a2ab5fda7b8afecdd4c063ee794051825f7c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->