### PR TITLE
Fix HTML leakage in event liquid embed button

### DIFF
--- a/app/views/liquids/_event.html.erb
+++ b/app/views/liquids/_event.html.erb
@@ -7,20 +7,13 @@
   </div>
   <p class="ltag__event__description"><%= event.description %></p>
   <div class="ltag__event__actions">
-    <button data-event-signup-button="true"
-            data-event-name-slug="<%= event.event_name_slug %>"
-            data-event-variation-slug="<%= event.event_variation_slug %>"
-            data-signed-up-class="crayons-btn--outlined"
-            data-unsigned-up-class="crayons-btn--primary"
-            class="crayons-btn event-signup-btn crayons-btn--primary"
-            data-signed-up="false">
+    <button data-event-signup-button="true" data-event-name-slug="<%= event.event_name_slug %>" data-event-variation-slug="<%= event.event_variation_slug %>" data-signed-up-class="crayons-btn--outlined" data-unsigned-up-class="crayons-btn--primary" class="crayons-btn event-signup-btn crayons-btn--primary" data-signed-up="false">
       <template data-signed-up-html>
         <%= event.signup_button_text(signed_up: true) %>
       </template>
       <template data-unsigned-up-html>
         <%= event.signup_button_text(signed_up: false) %>
       </template>
-
       <%= event.signup_button_text(signed_up: false) %>
     </button>
   </div>

--- a/app/views/liquids/_org_lead_form.html.erb
+++ b/app/views/liquids/_org_lead_form.html.erb
@@ -6,10 +6,7 @@
 
   <div class="lead-form-signed-in" style="display:none;">
     <div class="lead-form-actions">
-      <button type="button"
-              class="crayons-btn lead-form-submit-btn"
-              data-form-id="<%= form.id %>"
-              onclick="submitLeadForm(this)">
+      <button type="button" class="crayons-btn lead-form-submit-btn" data-form-id="<%= form.id %>" onclick="submitLeadForm(this)">
         <%= form.button_text %>
       </button>
       <span class="lead-form-status fs-s color-base-60 ml-2" style="display:none;"></span>
@@ -35,10 +32,7 @@
       <input type="text" id="lead_form_job_title_<%= form.id %>" name="job_title" class="crayons-textfield">
     </div>
     <div class="lead-form-actions">
-      <button type="button"
-              class="crayons-btn lead-form-submit-btn"
-              data-form-id="<%= form.id %>"
-              onclick="submitLeadFormAnonymous(this)">
+      <button type="button" class="crayons-btn lead-form-submit-btn" data-form-id="<%= form.id %>" onclick="submitLeadFormAnonymous(this)">
         <%= form.button_text %>
       </button>
       <span class="lead-form-status fs-s color-base-60 ml-2" style="display:none;"></span>


### PR DESCRIPTION
This PR fixes a bug where the Markdown parser treated deeply indented attributes of the inline `<button>` tag inside liquid embed views as markdown code blocks. We collapse these attributes onto a single line to prevent this side-effect.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786196913&installation_id=139885019&pr_number=23584&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23584&signature=ede306cb7a3c45815dfe52efd60b9a6648d02b544a12b55f8463617cb1b96a03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->