### PR TITLE
Add an admin API endpoint for updating user notification settings

### DIFF
--- a/app/controllers/concerns/api/admin/users_controller.rb
+++ b/app/controllers/concerns/api/admin/users_controller.rb
@@ -109,7 +109,11 @@ module Api
       # Core side.
       def update_notification_settings
         @user_record = User.find(params[:id])
-        updates = params.require(:notification_setting).permit(:email_newsletter)
+        # Handle the missing wrapper here rather than via params.require, so
+        # the caller gets the admin API error_code instead of a generic
+        # ParameterMissing 422.
+        wrapper = params[:notification_setting]
+        updates = wrapper.respond_to?(:permit) ? wrapper.permit(:email_newsletter) : {}
         if updates.blank?
           raise Api::Admin::ApiError.new(:invalid_notification_settings,
                                          I18n.t("admin_api.errors.invalid_notification_settings"),

--- a/app/controllers/concerns/api/admin/users_controller.rb
+++ b/app/controllers/concerns/api/admin/users_controller.rb
@@ -101,6 +101,33 @@ module Api
         render json: { id: @user_record.id, status: status }
       end
 
+      # Lets MLH Core push consent changes (its dev-newsletter opt-outs) back
+      # onto the DEV account's local notification settings, which DEV's own
+      # senders (digest, newsletter) key off. Writes through the model so the
+      # normal callbacks fire (Mailchimp sync, and the CDP newsletter events
+      # once enabled) - the resulting echo event is value-idempotent on the
+      # Core side.
+      def update_notification_settings
+        @user_record = User.find(params[:id])
+        updates = params.require(:notification_setting).permit(:email_newsletter)
+        if updates.blank?
+          raise Api::Admin::ApiError.new(:invalid_notification_settings,
+                                         I18n.t("admin_api.errors.invalid_notification_settings"),
+                                         status: 422)
+        end
+
+        setting = @user_record.notification_setting
+        setting.update!(updates)
+
+        audit!(slug: "update_notification_settings",
+               data: {
+                 "target_user_id" => @user_record.id,
+                 "changes" => setting.saved_changes.slice("email_newsletter")
+               })
+        render json: { id: @user_record.id,
+                       notification_setting: { email_newsletter: setting.email_newsletter } }
+      end
+
       def merge
         @user_record = User.find(params[:id])
         delete_id = params.require(:merge_user_id).to_i

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -201,6 +201,7 @@ en:
       identity_not_found: "Identity not found for user"
       user_already_has_identity_for_provider: "User already has an identity for provider '%{provider}'"
       identity_uid_taken: "Identity uid %{uid} (%{provider}) is already linked to another user"
+      invalid_notification_settings: "notification_setting must include at least one supported key (email_newsletter)"
       cannot_merge_user_into_itself: "Cannot merge a user into itself"
       merge_identity_conflict: "Merge could not complete: %{reason}"
       unknown_provider: "Provider '%{provider}' is not configured"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -232,6 +232,7 @@ fr:
       identity_not_found: "Identité introuvable pour cet utilisateur"
       user_already_has_identity_for_provider: "L'utilisateur a déjà une identité pour le fournisseur « %{provider} »"
       identity_uid_taken: "L'uid %{uid} (%{provider}) est déjà lié à un autre utilisateur"
+      invalid_notification_settings: "notification_setting doit inclure au moins une clé prise en charge (email_newsletter)"
       cannot_merge_user_into_itself: "Impossible de fusionner un utilisateur avec lui-même"
       merge_identity_conflict: "La fusion n'a pas pu être effectuée : %{reason}"
       unknown_provider: "Le fournisseur « %{provider} » n'est pas configuré"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -232,6 +232,7 @@ pt:
       identity_not_found: "Identidade não encontrada para o usuário"
       user_already_has_identity_for_provider: "O usuário já possui uma identidade para o provedor '%{provider}'"
       identity_uid_taken: "O uid %{uid} (%{provider}) já está vinculado a outro usuário"
+      invalid_notification_settings: "notification_setting deve incluir pelo menos uma chave suportada (email_newsletter)"
       cannot_merge_user_into_itself: "Não é possível mesclar um usuário consigo mesmo"
       merge_identity_conflict: "A mesclagem não pôde ser concluída: %{reason}"
       unknown_provider: "O provedor '%{provider}' não está configurado"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,13 +38,13 @@ Rails.application.routes.draw do
     get "/:org_slug/:slug",
         to: "stories#custom_domain_show",
         constraints: {
-          org_slug: /(?!(?:api|assets|packs|rails|r|ahoy|enter|users)\z)[^\/.]+/,
-          slug: /[^\/.]+/
+          org_slug: %r{(?!(?:api|assets|packs|rails|r|ahoy|enter|users)\z)[^/.]+},
+          slug: %r{[^/.]+}
         }
     get "/:slug",
         to: "stories#custom_domain_show",
         constraints: {
-          slug: /(?!(?:api|assets|packs|rails|r|ahoy|enter|users)\z)[^\/.]+/
+          slug: %r{(?!(?:api|assets|packs|rails|r|ahoy|enter|users)\z)[^/.]+}
         }
   end
 
@@ -130,6 +130,7 @@ Rails.application.routes.draw do
             member do
               put :email, action: :update_email
               put :status, action: :update_status
+              put :notification_settings, action: :update_notification_settings
               post :merge
             end
 
@@ -175,7 +176,8 @@ Rails.application.routes.draw do
     resources :events, only: %i[index]
     get "/calendar", to: "calendar#index"
     get "events/:event_name_slug/:event_variation_slug", to: "events#show", as: :event
-    get "events/:event_name_slug/:event_variation_slug/signup_status", to: "event_signups#status", as: :event_signup_status
+    get "events/:event_name_slug/:event_variation_slug/signup_status", to: "event_signups#status",
+                                                                       as: :event_signup_status
     post "events/:event_name_slug/:event_variation_slug/signup", to: "event_signups#create", as: :event_signup
     delete "events/:event_name_slug/:event_variation_slug/signup", to: "event_signups#destroy"
     resources :article_mutes, only: %i[update]
@@ -234,11 +236,11 @@ Rails.application.routes.draw do
       end
     end
     resources :trending, param: :slug, only: %i[index show], controller: :trends
-    get "/trends", to: redirect { |path_params, req|
+    get "/trends", to: redirect { |path_params, _req|
       locale = path_params[:locale]
       locale ? "/locale/#{locale}/trending" : "/trending"
     }
-    get "/trends/:slug", to: redirect { |path_params, req|
+    get "/trends/:slug", to: redirect { |path_params, _req|
       locale = path_params[:locale]
       slug = path_params[:slug]
       locale ? "/locale/#{locale}/trending/#{slug}" : "/trending/#{slug}"
@@ -419,15 +421,18 @@ Rails.application.routes.draw do
     get "/:slug/members", to: "organizations#members", as: :organization_members
     get "/:slug/settings", to: "organization_settings#edit", as: :organization_settings
     patch "/:slug/settings", to: "organization_settings#update"
-    post "/:slug/settings/verify", to: "organization_settings#request_verification", as: :organization_request_verification
+    post "/:slug/settings/verify", to: "organization_settings#request_verification",
+                                   as: :organization_request_verification
     post "/:slug/settings/preview", to: "organization_settings#preview", as: :organization_settings_preview
     get "/:slug/settings/lead_forms", to: "organization_lead_forms#index", as: :organization_lead_forms
     post "/:slug/settings/lead_forms", to: "organization_lead_forms#create"
     get "/:slug/settings/lead_forms/:id/edit", to: "organization_lead_forms#edit", as: :edit_organization_lead_form
     patch "/:slug/settings/lead_forms/:id", to: "organization_lead_forms#update", as: :update_organization_lead_form
     delete "/:slug/settings/lead_forms/:id", to: "organization_lead_forms#destroy", as: :organization_lead_form
-    patch "/:slug/settings/lead_forms/:id/toggle", to: "organization_lead_forms#toggle", as: :organization_lead_form_toggle
-    get "/:slug/settings/lead_forms/:id/submissions", to: "organization_lead_forms#submissions", as: :organization_lead_form_submissions
+    patch "/:slug/settings/lead_forms/:id/toggle", to: "organization_lead_forms#toggle",
+                                                   as: :organization_lead_form_toggle
+    get "/:slug/settings/lead_forms/:id/submissions", to: "organization_lead_forms#submissions",
+                                                      as: :organization_lead_form_submissions
     post "/lead_submissions", to: "lead_submissions#create"
     get "/lead_submissions/check", to: "lead_submissions#check"
     post "articles/preview", to: "articles#preview"
@@ -534,7 +539,8 @@ Rails.application.routes.draw do
 
     get "/top/:timeframe", to: "stories#index"
 
-    get "/:feed_type/:timeframe", to: "stories#index", constraints: { feed_type: /following/, timeframe: /latest|latest_less_filtered/ }
+    get "/:feed_type/:timeframe", to: "stories#index",
+                                  constraints: { feed_type: /following/, timeframe: /latest|latest_less_filtered/ }
 
     get "/:timeframe", to: "stories#index", constraints: { timeframe: /latest|latest_less_filtered/ }
     get "/:feed_type", to: "stories#index", constraints: { feed_type: /discover|following/ }

--- a/spec/requests/api/v1/admin/users_spec.rb
+++ b/spec/requests/api/v1/admin/users_spec.rb
@@ -342,6 +342,61 @@ RSpec.describe "/api/admin/users" do
     end
   end
 
+  describe "PUT /api/admin/users/:id/notification_settings" do
+    before { Audit::Subscribe.listen :admin_api }
+    after  { Audit::Subscribe.forget :admin_api }
+
+    let!(:target) { create(:user) }
+
+    def put_settings(body, id: target.id)
+      put "/api/admin/users/#{id}/notification_settings",
+          params: body.to_json,
+          headers: admin_api_headers.merge("Content-Type" => "application/json")
+    end
+
+    it "updates email_newsletter through the model (callbacks fire)" do
+      target.notification_setting.update!(email_newsletter: true)
+
+      put_settings({ notification_setting: { email_newsletter: false } })
+
+      expect(response).to have_http_status(:ok)
+      expect(target.notification_setting.reload.email_newsletter).to be(false)
+      expect(response.parsed_body["notification_setting"]["email_newsletter"]).to be(false)
+    end
+
+    it "can also set email_newsletter true" do
+      put_settings({ notification_setting: { email_newsletter: true } })
+
+      expect(target.notification_setting.reload.email_newsletter).to be(true)
+    end
+
+    it "logs an audit entry with the change" do
+      target.notification_setting.update!(email_newsletter: true)
+
+      expect do
+        put_settings({ notification_setting: { email_newsletter: false } })
+      end.to change(AuditLog, :count).by(1)
+
+      audit = AuditLog.last
+      expect(audit.slug).to eq("update_notification_settings")
+      expect(audit.data["target_user_id"]).to eq(target.id)
+      expect(audit.data["changes"]).to eq("email_newsletter" => [true, false])
+    end
+
+    it "rejects a body with no permitted settings" do
+      put_settings({ notification_setting: { welcome_notifications: false } })
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["error_code"]).to eq("invalid_notification_settings")
+    end
+
+    it "returns 404 for unknown users" do
+      put_settings({ notification_setting: { email_newsletter: false } }, id: 999_999)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
   describe "PUT /api/admin/users/:id/status" do
     before { Audit::Subscribe.listen :admin_api }
     after  { Audit::Subscribe.forget :admin_api }

--- a/spec/requests/api/v1/admin/users_spec.rb
+++ b/spec/requests/api/v1/admin/users_spec.rb
@@ -383,6 +383,13 @@ RSpec.describe "/api/admin/users" do
       expect(audit.data["changes"]).to eq("email_newsletter" => [true, false])
     end
 
+    it "rejects a body missing the notification_setting wrapper with the admin error_code" do
+      put_settings({ email_newsletter: false })
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["error_code"]).to eq("invalid_notification_settings")
+    end
+
     it "rejects a body with no permitted settings" do
       put_settings({ notification_setting: { welcome_notifications: false } })
 


### PR DESCRIPTION
## What

`PUT /api/admin/users/:id/notification_settings` with `{ "notification_setting": { "email_newsletter": false } }` — updates the user's local notification settings **through the model**, so the normal callbacks fire (Mailchimp list sync today; the DEV → Core CDP newsletter events once #23579 lands — that echo is value-idempotent on the Core side). Only `email_newsletter` is permitted for now; audited per change with the before/after values; 422 when no supported key is present.

## Why

MLH Core is the source of truth for email consent, and DEV is moving its sending to Customer.io — but DEV's own senders (digest, newsletter) key off the local `email_newsletter` flag. When someone unsubscribes from the DEV newsletter on the Core side, this endpoint lets Core push that opt-out back so DEV's local senders respect it too. Companion Core change enqueues that push whenever a user's `dev` newsletter key flips off or they globally unsubscribe.

## Tests

`spec/requests/api/v1/admin/users_spec.rb` — update both directions, audit entry with changes, unsupported-key 422, unknown-user 404.

https://claude.ai/code/session_01BbriEeFARfLvUDKbH3WYAt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786198284&installation_id=139885019&pr_number=23585&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23585&signature=02c50cebdd7767d83720c69255703808be1274640d45e0c032f3ede9af116753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->