### PR TITLE
Deliver user_gdpr_deleted despite the destroyed user row

### DIFF
--- a/app/services/trackers/customerio_cdp.rb
+++ b/app/services/trackers/customerio_cdp.rb
@@ -10,6 +10,12 @@ module Trackers
     # Customer.io CDP does not implement analytics-ruby's default /v1/import
     # path (404); its Segment-compatible batch endpoint is /v1/batch.
     BATCH_PATH = "/v1/batch".freeze
+    # Events that fire after the user row is destroyed — the only ones allowed
+    # to fall back to the payload's own email. Everything else must resolve a
+    # live row, so a straggler event for a just-deleted user is dropped rather
+    # than delivered via a stale address (which could resurrect state after a
+    # GDPR erasure).
+    DESTRUCTIVE_EVENTS = ["user_gdpr_deleted"].freeze
 
     def enabled?
       # Resolve the setting via the default subforem (like mailers do): the admin
@@ -18,13 +24,6 @@ module Trackers
       ApplicationConfig["CUSTOMERIO_CDP_WRITE_KEY"].present? &&
         Settings::General.customerio_cdp_enabled(subforem_id: Subforem.cached_default_id)
     end
-
-    # Events that fire after the user row is destroyed — the only ones allowed
-    # to fall back to the payload's own email. Everything else must resolve a
-    # live row, so a straggler event for a just-deleted user is dropped rather
-    # than delivered via a stale address (which could resurrect state after a
-    # GDPR erasure).
-    DESTRUCTIVE_EVENTS = ["user_gdpr_deleted"].freeze
 
     # People are identified by email rather than DEV user id: ids are not synced
     # to the Core consumer yet. Emails are resolved at send time so they are

--- a/app/services/trackers/customerio_cdp.rb
+++ b/app/services/trackers/customerio_cdp.rb
@@ -21,10 +21,13 @@ module Trackers
 
     # People are identified by email rather than DEV user id: ids are not synced
     # to the Core consumer yet. Emails are resolved at send time so they are
-    # current; ids without a matching user (deleted in the interim) are skipped.
-    # The properties payload still carries the DEV id for future linking.
+    # current — but destructive events (user_gdpr_deleted) fire after the row
+    # is destroyed, so when no row matches we fall back to the payload's own
+    # email rather than silently dropping the one event whose point is that
+    # the user no longer exists.
     def track(event_name:, user_ids:, properties:, timestamp: nil)
       emails = User.where(id: Array.wrap(user_ids)).pluck(:email)
+      emails = [properties["email"]] if emails.empty?
       emails.each do |email|
         next if email.blank?
 

--- a/app/services/trackers/customerio_cdp.rb
+++ b/app/services/trackers/customerio_cdp.rb
@@ -19,15 +19,19 @@ module Trackers
         Settings::General.customerio_cdp_enabled(subforem_id: Subforem.cached_default_id)
     end
 
+    # Events that fire after the user row is destroyed — the only ones allowed
+    # to fall back to the payload's own email. Everything else must resolve a
+    # live row, so a straggler event for a just-deleted user is dropped rather
+    # than delivered via a stale address (which could resurrect state after a
+    # GDPR erasure).
+    DESTRUCTIVE_EVENTS = ["user_gdpr_deleted"].freeze
+
     # People are identified by email rather than DEV user id: ids are not synced
     # to the Core consumer yet. Emails are resolved at send time so they are
-    # current — but destructive events (user_gdpr_deleted) fire after the row
-    # is destroyed, so when no row matches we fall back to the payload's own
-    # email rather than silently dropping the one event whose point is that
-    # the user no longer exists.
+    # current; see DESTRUCTIVE_EVENTS for the deleted-row exception.
     def track(event_name:, user_ids:, properties:, timestamp: nil)
       emails = User.where(id: Array.wrap(user_ids)).pluck(:email)
-      emails = [properties["email"]] if emails.empty?
+      emails = [properties["email"]] if emails.empty? && DESTRUCTIVE_EVENTS.include?(event_name)
       emails.each do |email|
         next if email.blank?
 

--- a/spec/services/trackers/customerio_cdp_spec.rb
+++ b/spec/services/trackers/customerio_cdp_spec.rb
@@ -106,6 +106,19 @@ RSpec.describe Trackers::CustomerioCdp do
       )
     end
 
+    # Only destructive events may use the payload email: a straggler
+    # user_updated for a just-deleted user must NOT deliver via a stale
+    # payload address (it could resurrect state after a GDPR erasure).
+    it "does not fall back for non-destructive events when the user row is gone" do
+      deleted_id = user.id
+      payload = { "id" => deleted_id, "email" => user.email }
+      user.destroy!
+
+      adapter.track(event_name: "user_updated", user_ids: [deleted_id], properties: payload)
+
+      expect(client).not_to have_received(:track)
+    end
+
     it "skips entirely when the user is gone and the payload has no email" do
       deleted_id = user.id
       user.destroy!

--- a/spec/services/trackers/customerio_cdp_spec.rb
+++ b/spec/services/trackers/customerio_cdp_spec.rb
@@ -91,6 +91,30 @@ RSpec.describe Trackers::CustomerioCdp do
       )
     end
 
+    # user_gdpr_deleted fires after the row is destroyed; resolving the email
+    # by DB lookup alone would silently drop exactly the event whose point is
+    # that the user no longer exists.
+    it "falls back to the payload email when the user row is already gone" do
+      deleted_id = user.id
+      payload = { "id" => deleted_id, "email" => user.email }
+      user.destroy!
+
+      adapter.track(event_name: "user_gdpr_deleted", user_ids: [deleted_id], properties: payload)
+
+      expect(client).to have_received(:track).with(
+        user_id: payload["email"], event: "user_gdpr_deleted", properties: payload, timestamp: nil,
+      )
+    end
+
+    it "skips entirely when the user is gone and the payload has no email" do
+      deleted_id = user.id
+      user.destroy!
+
+      adapter.track(event_name: "user_gdpr_deleted", user_ids: [deleted_id], properties: { "id" => deleted_id })
+
+      expect(client).not_to have_received(:track)
+    end
+
     # DEV ids are not synced to Core yet, so people are identified by email.
     it "identifies users by their current email, not their DEV id" do
       adapter.track(event_name: "user_updated", user_ids: [user.id], properties: { "id" => user.id })


### PR DESCRIPTION
## What

The Customer.io CDP adapter resolves recipient emails by querying the users table at send time (`User.where(id:).pluck(:email)`). `user_gdpr_deleted` (#23574) fires **after** the row is destroyed, so by the time the async dispatch ran the query resolved zero emails and the event was silently skipped — the one event whose entire point is that the user no longer exists never reached MLH Core.

When no row matches, the adapter now falls back to the payload's own email (`Users::DeleteWorker` already builds the payload from the in-memory attributes before destruction). If neither exists, the event is skipped as before.

## Why a standalone PR

The bug shipped with #23574, which is already merged — this is a fix to main, independent of the open #23579 feature work (originally pushed there; moved here so it isn't coupled to that PR's review timeline). No behavior change for any other event: live users still resolve by current DB email.

## Tests

`spec/services/trackers/customerio_cdp_spec.rb` — destroyed-row fallback delivers with the payload email; skipped entirely when the payload has no email either.

https://claude.ai/code/session_01BbriEeFARfLvUDKbH3WYAt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786200732&installation_id=139885019&pr_number=23587&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23587&signature=0b09d473cfcf6a80d1e19629d792d363bc23f5885d1a1194c1641245c18e5184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->