### PR TITLE
Strip trailing whitespace from event descriptions in liquid embed

### DIFF
--- a/app/views/liquids/_event.html.erb
+++ b/app/views/liquids/_event.html.erb
@@ -5,7 +5,7 @@
     </h3>
     <span class="ltag__event__date"><%= event.start_time.strftime("%B %d, %Y") %></span>
   </div>
-  <p class="ltag__event__description"><%= event.description %></p>
+  <p class="ltag__event__description"><%= event.description&.rstrip %></p>
   <div class="ltag__event__actions">
     <button data-event-signup-button="true" data-event-name-slug="<%= event.event_name_slug %>" data-event-variation-slug="<%= event.event_variation_slug %>" data-signed-up-class="crayons-btn--outlined" data-unsigned-up-class="crayons-btn--primary" class="crayons-btn event-signup-btn crayons-btn--primary" data-signed-up="false">
       <template data-signed-up-html>


### PR DESCRIPTION
This PR updates the event liquid embed template to strip trailing whitespace from the event description via `&.rstrip`. This prevents trailing newlines in the description from generating blank lines in the HTML, which breaks the Markdown parser's HTML block detection and causes extra `<br>` tags and space.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786203537&installation_id=139885019&pr_number=23588&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23588&signature=1afc49fd796a1e3ee7d00a2b4b8c780cdbd2eea629d8df7a4b3f96684df7c074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->