### PR TITLE
Suppress CDP newsletter events for admin-API notification settings writes

### DIFF
--- a/app/controllers/concerns/api/admin/users_controller.rb
+++ b/app/controllers/concerns/api/admin/users_controller.rb
@@ -121,7 +121,13 @@ module Api
         end
 
         setting = @user_record.notification_setting
-        setting.update!(updates)
+        # This endpoint carries MLH Core's OWN consent state (its dev
+        # newsletter opt-outs/opt-ins). Emitting the CDP newsletter events
+        # here would make Core consume its own push as a user consent
+        # change — destroying the layered global-unsubscribe vs
+        # list-preference distinction. Model callbacks that aren't CDP
+        # emission (Mailchimp sync, base_email_eligible) still run.
+        User.skip_trackable_events { setting.update!(updates) }
 
         audit!(slug: "update_notification_settings",
                data: {

--- a/spec/requests/api/v1/admin/users_spec.rb
+++ b/spec/requests/api/v1/admin/users_spec.rb
@@ -383,6 +383,28 @@ RSpec.describe "/api/admin/users" do
       expect(audit.data["changes"]).to eq("email_newsletter" => [true, false])
     end
 
+    # Core pushes ITS OWN consent state through this endpoint; if the write
+    # emitted the CDP newsletter events, Core would consume its own push as
+    # a user consent change (destroying the layered global-unsubscribe /
+    # list-preference distinction).
+    it "does not emit CDP newsletter events for admin-API writes" do
+      allow(Trackable::Registry).to receive(:active_names).and_return([:any])
+      allow(Trackable::DispatchWorker).to receive(:perform_async)
+      Settings::General.customerio_cdp_enabled = true
+      FeatureFlag.enable(:dev_core_user_sync, FeatureFlag::Actor[target])
+      target.notification_setting.update!(email_newsletter: true)
+
+      with_trackable_events do
+        put_settings({ notification_setting: { email_newsletter: false } })
+      end
+
+      expect(target.notification_setting.reload.email_newsletter).to be(false)
+      expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+        .with(anything, /user_newsletter/, anything, anything, anything)
+    ensure
+      FeatureFlag.remove(:dev_core_user_sync)
+    end
+
     it "rejects a body missing the notification_setting wrapper with the admin error_code" do
       put_settings({ email_newsletter: false })
 


### PR DESCRIPTION
## What

Wraps the `PUT /api/admin/users/:id/notification_settings` write in `User.skip_trackable_events`, so admin-API writes no longer emit `user_newsletter_subscribed`/`user_newsletter_unsubscribed` to the CDP. Genuine user toggles (settings page, one-click unsubscribe links, onboarding, Mailchimp webhook) still emit; Mailchimp list sync and `base_email_eligible` still run for admin writes.

## Why

Review finding on the Core ↔ DEV consent sync: this endpoint carries **MLH Core's own consent state** (its dev-newsletter opt-outs/opt-ins pushed onto DEV's local flag). With the emission in place, Core consumed its own push back as a *user* consent change — concretely, a Core-side **global unsubscribe** pushed `email_newsletter=false`, the echo flipped Core's `dev` list preference to false, and **lifting the global unsubscribe could then never restore the user's underlying DEV preference**. Each side should only broadcast consent changes it authored.

## Tests

`spec/requests/api/v1/admin/users_spec.rb` — admin write updates the flag but emits no `user_newsletter_*` events (gates enabled, trackable active); existing user-toggle emission specs in `spec/models/users/notification_setting_spec.rb` unchanged and green.

https://claude.ai/code/session_01BbriEeFARfLvUDKbH3WYAt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786226486&installation_id=139885019&pr_number=23589&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23589&signature=c16271e5bc74505b1c758f07bc54e6436bcda3b0d56019fd0183330f3de3ecfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->