### PR TITLE
Fix bulk identities handling of same-batch duplicate users

### DIFF
--- a/app/controllers/concerns/api/admin/user_identities_controller.rb
+++ b/app/controllers/concerns/api/admin/user_identities_controller.rb
@@ -110,9 +110,9 @@ module Api
 
       # Three queries for the whole batch instead of three per row — at 1,000
       # rows per request and ~2M links total, per-row lookups would hammer
-      # the DB. The taken-uid set is mutated as rows link so same-batch
-      # duplicates conflict like pre-existing ones; the RecordNotUnique
-      # rescue still covers races with concurrent writers.
+      # the DB. Both preloaded indexes are mutated as rows link so same-batch
+      # duplicates (by uid or by user) resolve like pre-existing ones; the
+      # RecordNotUnique rescue still covers races with concurrent writers.
       def bulk_preload(provider, entries)
         objects = entries.select { |entry| bulk_entry_object?(entry) }
         user_ids = objects.filter_map { |entry| entry[:user_id].presence }
@@ -158,6 +158,7 @@ module Api
 
         identity = Identity.create!(user: target, provider: provider, uid: uid)
         preload[:taken_uids] << uid
+        preload[:identities_by_user][target.id] = identity
         { "user_id" => target.id, "identity_id" => identity.id, "status" => "created" }
       rescue ActiveRecord::RecordNotUnique
         { "user_id" => target.id, "status" => "conflict", "error_code" => "identity_uid_taken" }

--- a/spec/requests/api/v1/admin/user_identities_spec.rb
+++ b/spec/requests/api/v1/admin/user_identities_spec.rb
@@ -242,6 +242,29 @@ RSpec.describe "Api::V1::Admin::UserIdentities" do
       expect(results[second.id]["error_code"]).to eq("identity_uid_taken")
     end
 
+    it "reports a same-batch repeat of the same user and uid as already_linked" do
+      repeated = create(:user)
+
+      bulk_post([{ user_id: repeated.id, uid: "888" }, { user_id: repeated.id, uid: "888" }])
+
+      expect(response).to have_http_status(:ok)
+      statuses = response.parsed_body["results"].pluck("status")
+      expect(statuses).to eq(%w[created already_linked])
+      expect(repeated.identities.where(provider: "mlh").count).to eq(1)
+    end
+
+    it "reports a same-batch same user with a different uid as a per-item conflict" do
+      repeated = create(:user)
+
+      bulk_post([{ user_id: repeated.id, uid: "888" }, { user_id: repeated.id, uid: "999" }])
+
+      expect(response).to have_http_status(:ok)
+      results = response.parsed_body["results"]
+      expect(results.pluck("status")).to eq(%w[created conflict])
+      expect(results.last["error_code"]).to eq("user_already_has_identity_for_provider")
+      expect(repeated.identities.where(provider: "mlh").pluck(:uid)).to eq(["888"])
+    end
+
     it "reports not_found and invalid entries without failing the batch" do
       bulk_post([{ user_id: 999_999, uid: "1" }, { user_id: user.id, uid: "" }])
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Follow-up to #23583. The bulk identities endpoint's per-user identity preload (`identities_by_user`) was never updated after a successful create, so a batch containing the same `user_id` twice broke the endpoint's documented per-item isolation:

- **Same user, same uid twice** → `created, conflict` instead of `created, already_linked`.
- **Same user, two different uids** → the first identity was created, then the second entry hit the model's per-user uniqueness validation and failed the **whole request** with a 422 (after the first identity had already been persisted).

Both were confirmed with live request probes. The fix records each created identity in the preloaded `identities_by_user` map (mirroring how `taken_uids` is already maintained), so same-batch repeats resolve through the same branches as pre-existing rows: `already_linked` for an identical uid, a per-item `user_already_has_identity_for_provider` conflict for a different one.

Note: MLH Core's backfill seed derives entries from unique DEV profile ids, so this bug did not block the planned import — it's an API-contract fix.

## Added tests?

- [x] Yes — two request specs covering both same-batch duplicate-user shapes (`spec/requests/api/v1/admin/user_identities_spec.rb`), red before the fix, green after. Full file: 28 examples, 0 failures.

_This PR was written by an agent (Claude Code) on behalf of @jonmarkgo._

https://claude.ai/code/session_01BbriEeFARfLvUDKbH3WYAt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786281063&installation_id=139885019&pr_number=23592&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23592&signature=15d5247ce01a56d83ce5fc4e723b4b4fc9844eb285305044d861b0744b7e6429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->