### PR TITLE
Use spec-compliant identity fields on CDP calls

### DIFF
--- a/app/services/trackers/customerio_cdp.rb
+++ b/app/services/trackers/customerio_cdp.rb
@@ -47,7 +47,7 @@ module Trackers
         }
         mlh_uid = linked_uids[id] || (properties["mlh_user_id"].presence if destructive)
         attributes[:user_id] = mlh_uid if mlh_uid
-        client.track(**attributes)
+        client.track(attributes)
       end
     end
 

--- a/app/services/trackers/customerio_cdp.rb
+++ b/app/services/trackers/customerio_cdp.rb
@@ -10,11 +10,11 @@ module Trackers
     # Customer.io CDP does not implement analytics-ruby's default /v1/import
     # path (404); its Segment-compatible batch endpoint is /v1/batch.
     BATCH_PATH = "/v1/batch".freeze
-    # Events that fire after the user row is destroyed — the only ones allowed
-    # to fall back to the payload's own email. Everything else must resolve a
-    # live row, so a straggler event for a just-deleted user is dropped rather
-    # than delivered via a stale address (which could resurrect state after a
-    # GDPR erasure).
+    # Events that fire after the user row is destroyed. Straggler events for
+    # deleted users are otherwise dropped (they could resurrect state after a
+    # GDPR erasure), so these are the only ones that deliver without a live
+    # row — possible because identity comes from the stable anonymous id and
+    # the payload's own mlh_user_id, both knowable post-destruction.
     DESTRUCTIVE_EVENTS = ["user_gdpr_deleted"].freeze
 
     def enabled?
@@ -25,25 +25,39 @@ module Trackers
         Settings::General.customerio_cdp_enabled(subforem_id: Subforem.cached_default_id)
     end
 
-    # People are identified by email rather than DEV user id: ids are not synced
-    # to the Core consumer yet. Emails are resolved at send time so they are
-    # current; see DESTRUCTIVE_EVENTS for the deleted-row exception.
+    # Identity follows the Segment spec: every call carries a stable
+    # anonymous_id ("dev:<DEV user id>"), plus user_id set to the canonical
+    # MLH (Core) user id once the account is linked — sending both stitches
+    # the pre-link anonymous history onto the person downstream. Email is
+    # never an identity field; it travels in properties only.
     def track(event_name:, user_ids:, properties:, timestamp: nil)
-      emails = User.where(id: Array.wrap(user_ids)).pluck(:email)
-      emails = [properties["email"]] if emails.empty? && DESTRUCTIVE_EVENTS.include?(event_name)
-      emails.each do |email|
-        next if email.blank?
+      destructive = DESTRUCTIVE_EVENTS.include?(event_name)
+      ids = deliverable_ids(Array.wrap(user_ids), destructive)
+      # Send-time lookup so the link is current; for destructive events the
+      # identity row died with the user, so the payload's pre-destruction
+      # capture is the fallback.
+      linked_uids = Identity.where(provider: "mlh", user_id: ids).pluck(:user_id, :uid).to_h
 
-        client.track(
-          user_id: email,
+      ids.each do |id|
+        attributes = {
+          anonymous_id: "dev:#{id}",
           event: event_name,
           properties: properties,
-          timestamp: timestamp,
-        )
+          timestamp: timestamp
+        }
+        mlh_uid = linked_uids[id] || (properties["mlh_user_id"].presence if destructive)
+        attributes[:user_id] = mlh_uid if mlh_uid
+        client.track(**attributes)
       end
     end
 
     private
+
+    def deliverable_ids(ids, destructive)
+      return ids if destructive
+
+      User.where(id: ids).ids
+    end
 
     def client
       @client ||= Segment::Analytics.new(

--- a/spec/services/trackers/customerio_cdp_spec.rb
+++ b/spec/services/trackers/customerio_cdp_spec.rb
@@ -91,25 +91,61 @@ RSpec.describe Trackers::CustomerioCdp do
       )
     end
 
-    # user_gdpr_deleted fires after the row is destroyed; resolving the email
-    # by DB lookup alone would silently drop exactly the event whose point is
-    # that the user no longer exists.
-    it "falls back to the payload email when the user row is already gone" do
+    # Identity follows the Segment spec: a stable dev-scoped anonymous_id on
+    # every call; email is never an identity field (it travels in properties).
+    it "identifies users by a stable dev-scoped anonymous id, never email" do
+      adapter.track(event_name: "user_updated", user_ids: [user.id], properties: { "id" => user.id })
+
+      expect(client).to have_received(:track).with(
+        anonymous_id: "dev:#{user.id}", event: "user_updated",
+        properties: { "id" => user.id }, timestamp: nil
+      )
+    end
+
+    it "adds the canonical MLH user id as user_id once the account is linked" do
+      # The identity factory reads OmniAuth.config.mock_auth for auth_data_dump.
+      omniauth_mock_mlh_payload
+      create(:identity, user: user, provider: "mlh", uid: "01JZFAKEULID0000000000USER")
+
+      adapter.track(event_name: "user_updated", user_ids: [user.id], properties: { "id" => user.id })
+
+      expect(client).to have_received(:track).with(
+        hash_including(anonymous_id: "dev:#{user.id}", user_id: "01JZFAKEULID0000000000USER"),
+      )
+    end
+
+    # user_gdpr_deleted fires after the row is destroyed; the stable anonymous
+    # id keeps it deliverable without any DB row, and the payload's
+    # mlh_user_id (captured before destruction) preserves the person link.
+    it "delivers destructive events for a destroyed user via the anonymous id" do
       deleted_id = user.id
-      payload = { "id" => deleted_id, "email" => user.email }
+      payload = { "id" => deleted_id, "email" => user.email, "mlh_user_id" => "01JZFAKEULID0000000000USER" }
       user.destroy!
 
       adapter.track(event_name: "user_gdpr_deleted", user_ids: [deleted_id], properties: payload)
 
       expect(client).to have_received(:track).with(
-        user_id: payload["email"], event: "user_gdpr_deleted", properties: payload, timestamp: nil,
+        anonymous_id: "dev:#{deleted_id}", user_id: "01JZFAKEULID0000000000USER",
+        event: "user_gdpr_deleted", properties: payload, timestamp: nil
       )
     end
 
-    # Only destructive events may use the payload email: a straggler
-    # user_updated for a just-deleted user must NOT deliver via a stale
-    # payload address (it could resurrect state after a GDPR erasure).
-    it "does not fall back for non-destructive events when the user row is gone" do
+    it "delivers destructive events anonymously when the payload has no mlh_user_id" do
+      deleted_id = user.id
+      user.destroy!
+
+      adapter.track(event_name: "user_gdpr_deleted", user_ids: [deleted_id], properties: { "id" => deleted_id })
+
+      expect(client).to have_received(:track).with(
+        anonymous_id: "dev:#{deleted_id}", event: "user_gdpr_deleted",
+        properties: { "id" => deleted_id }, timestamp: nil
+      )
+    end
+
+    # A straggler user_updated for a just-deleted user must NOT deliver — it
+    # could resurrect state after a GDPR erasure. Only destructive events may
+    # deliver without a live row.
+    it "drops non-destructive events when the user row is gone" do
       deleted_id = user.id
       payload = { "id" => deleted_id, "email" => user.email }
       user.destroy!
@@ -119,31 +155,13 @@ RSpec.describe Trackers::CustomerioCdp do
       expect(client).not_to have_received(:track)
     end
 
-    it "skips entirely when the user is gone and the payload has no email" do
-      deleted_id = user.id
-      user.destroy!
-
-      adapter.track(event_name: "user_gdpr_deleted", user_ids: [deleted_id], properties: { "id" => deleted_id })
-
-      expect(client).not_to have_received(:track)
-    end
-
-    # DEV ids are not synced to Core yet, so people are identified by email.
-    it "identifies users by their current email, not their DEV id" do
-      adapter.track(event_name: "user_updated", user_ids: [user.id], properties: { "id" => user.id })
-
-      expect(client).to have_received(:track).with(
-        user_id: user.email, event: "user_updated", properties: { "id" => user.id }, timestamp: nil,
-      )
-    end
-
     it "calls client.track once per user" do
       other_user = create(:user)
       adapter.track(event_name: "article_created", user_ids: [user.id, other_user.id],
                     properties: { "title" => "t" })
 
-      expect(client).to have_received(:track).with(hash_including(user_id: user.email))
-      expect(client).to have_received(:track).with(hash_including(user_id: other_user.email))
+      expect(client).to have_received(:track).with(hash_including(anonymous_id: "dev:#{user.id}"))
+      expect(client).to have_received(:track).with(hash_including(anonymous_id: "dev:#{other_user.id}"))
     end
 
     it "passes timestamp through" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Bug Fix

## Description

The CDP tracker was using the user's **email as the transport `userId`**, and dropping GDPR-deletion events for accounts with no payload email. Per the Segment spec (which Customer.io Data Pipelines implements), a `userId` must be a stable database id — never an email — and every call must carry a `userId` or an `anonymousId`.

This PR makes identity on every call spec-shaped:

- **`anonymous_id: "dev:<user id>"` on every call** — deterministic and stable, derived from the immutable DEV user id, so events are identifiable even pre-link and post-destruction.
- **`user_id` = the canonical MLH (Core) user id once linked** — resolved from the `mlh` identity at send time so it's current. Sending both ids on one call is the spec's mechanism for stitching the pre-link anonymous history onto the person downstream.
- **Email is no longer an identity field** — it travels in `properties` only.

Behavioral notes:

- The straggler guard is unchanged: non-destructive events for destroyed users are still dropped (they could resurrect state after a GDPR erasure).
- `user_gdpr_deleted` now **always delivers**: identity comes from the anonymous id (constructible without a DB row) plus the payload's pre-destruction `mlh_user_id` when present. The previous email-fallback machinery — which silently dropped GDPR deletions for email-less accounts — is gone.
- The downstream consumer (MLH Core) resolves people from `properties` and explicitly ignores the transport `userId`, so this is transparent to it.

## Added tests?

- [x] Yes — the `#track` spec block is rewritten around the new identity contract (anonymous id always; linked `user_id`; destructive-event delivery with and without `mlh_user_id`; straggler drop preserved). 18 examples, 0 failures; adjacent trackable/delete-worker suites green (40 examples).

_This PR was written by an agent (Claude Code) on behalf of @jonmarkgo._

https://claude.ai/code/session_01BbriEeFARfLvUDKbH3WYAt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786291283&installation_id=139885019&pr_number=23594&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23594&signature=5527b9d01b5a7ddb578d05cc6ae5d836a33aa5768a98c93fb915ff1d5e5bcbff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->