### PR TITLE
fix(spec): wait for body[data-loaded] in editor system specs to avoid flakes

### DIFF
--- a/spec/system/articles/user_creates_an_article_spec.rb
+++ b/spec/system/articles/user_creates_an_article_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe "Creating an article with the editor" do
 
   it "creates a new article", :flaky, js: true do
     visit new_path
+    expect(page).to have_selector("body[data-loaded='true']")
     fill_in "article_body_markdown", with: template
     click_button "Save changes"
     expect(page).to have_selector("header h1", text: "Sample Article")
@@ -91,6 +92,7 @@ RSpec.describe "Creating an article with the editor" do
 
     it "displays a rate limit warning", :flaky, js: true do
       visit new_path
+      expect(page).to have_selector("body[data-loaded='true']")
       fill_in "article_body_markdown", with: template
       click_button "Save changes"
       expect(page).to have_text("Rate limit reached")

--- a/spec/system/articles/user_edits_an_article_spec.rb
+++ b/spec/system/articles/user_edits_an_article_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Editing with an editor", js: true do
 
   it "user previews their changes" do
     visit "/#{user.username}/#{article.slug}/edit"
+    expect(page).to have_selector("body[data-loaded='true']")
     fill_in "article_body_markdown", with: template.gsub("Suspendisse", "Yooo")
     click_button("Preview")
     expect(page).to have_text("Yooo")
@@ -23,6 +24,7 @@ RSpec.describe "Editing with an editor", js: true do
 
   it "user updates their post" do
     visit "/#{user.username}/#{article.slug}/edit"
+    expect(page).to have_selector("body[data-loaded='true']")
     fill_in "article_body_markdown", with: template.gsub("Suspendisse", "Yooo")
     click_button("Save changes")
     expect(page).to have_text("Yooo")
@@ -30,6 +32,7 @@ RSpec.describe "Editing with an editor", js: true do
 
   it "user unpublishes their post" do
     visit "/#{user.username}/#{article.slug}/edit"
+    expect(page).to have_selector("body[data-loaded='true']")
     fill_in("article_body_markdown", with: template.gsub("true", "false"), fill_options: { clear: :backspace })
     click_button("Save changes")
     expect(page).to have_text("Unpublished Post.")
@@ -49,6 +52,7 @@ RSpec.describe "Editing with an editor", js: true do
 
     it "displays a rate limit warning", :flaky, js: true do
       visit "/#{user.username}/#{article.slug}/edit"
+      expect(page).to have_selector("body[data-loaded='true']")
       fill_in "article_body_markdown", with: template.gsub("Suspendisse", "Yooo")
       click_button "Save changes"
       expect(page).to have_text("Rate limit reached")

--- a/spec/system/user_uses_the_editor_spec.rb
+++ b/spec/system/user_uses_the_editor_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe "Using the editor" do
 
   def fill_markdown_with(content)
     visit "/new"
-    expect(page).to have_selector("body[data-loaded='true']", wait: 30)
+    expect(page).to have_selector("body[data-loaded='true']")
     within("#article-form") { fill_in "article_body_markdown", with: content }
   end
 
   describe "Viewing the editor", :js do
     it "renders the logo or Community name as expected" do
       visit "/new"
-      expect(page).to have_selector("body[data-loaded='true']", wait: 30)
+      expect(page).to have_selector("body[data-loaded='true']")
       expect(page).to have_css(".site-logo")
       within(".truncate-at-2") do
         expect(page).to have_text("DEV(local)")
@@ -36,7 +36,7 @@ RSpec.describe "Using the editor" do
     it "renders the AI Editor Buddy conditionally with dynamic community nomenclature" do
       stub_const("AI_AVAILABLE", true)
       visit "/new"
-      expect(page).to have_selector("body[data-loaded='true']", wait: 30)
+      expect(page).to have_selector("body[data-loaded='true']")
       
       expect(page).to have_css("#editor-ai-toggle-btn")
       find("#editor-ai-toggle-btn").click
@@ -114,6 +114,7 @@ RSpec.describe "Using the editor" do
   describe "using v2 editor", :js do
     it "fill out form with rich content and click publish" do
       visit "/new"
+      expect(page).to have_selector("body[data-loaded='true']")
       within "form#article-form" do
         fill_in "article-form-title", with: "This is a <span> test"
         find_by_id("tag-input").native.send_keys("what", :return)


### PR DESCRIPTION
This PR fixes flaky editor system specs by ensuring we wait for `body[data-loaded='true']` after navigating to the editor pages, guaranteeing that base data/Preact editor components are hydrated and loaded before interacting with the form.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786297227&installation_id=139885019&pr_number=23596&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23596&signature=c056bfb2bbeb2cc7e70898212c986b03406e1afde92b3e715ab9abd3738be87e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->