### PR TITLE
Upgrades for Trends and Concepts

### DIFF
--- a/app/controllers/admin/concepts_controller.rb
+++ b/app/controllers/admin/concepts_controller.rb
@@ -97,7 +97,7 @@ module Admin
     end
 
     def concept_params
-      params.require(:concept).permit(:name, :description, :parent_id, :similarity_threshold)
+      params.require(:concept).permit(:name, :description, :parent_id, :similarity_threshold, :score)
     end
   end
 end

--- a/app/controllers/api/v1/admin/concepts_controller.rb
+++ b/app/controllers/api/v1/admin/concepts_controller.rb
@@ -72,6 +72,6 @@ class Api::V1::Admin::ConceptsController < Api::V1::Admin::BaseController
   end
 
   def concept_params
-    params.require(:concept).permit(:name, :description, :parent_id, :similarity_threshold)
+    params.require(:concept).permit(:name, :description, :parent_id, :similarity_threshold, :score)
   end
 end

--- a/app/controllers/api/v1/concepts_controller.rb
+++ b/app/controllers/api/v1/concepts_controller.rb
@@ -2,8 +2,8 @@ module Api
   module V1
     class ConceptsController < Api::V1::ApiController
       before_action :authenticate_with_api_key_or_current_user!
-      before_action :set_concept, only: [:show]
-      before_action :authorize_concept_access!, only: [:show]
+      before_action :set_concept, only: %i[show update articles]
+      before_action :authorize_concept_access!, only: %i[show update articles]
 
       def index
         page = [params.fetch(:page, 1).to_i, 1].max
@@ -17,7 +17,7 @@ module Api
                       current_user.accessible_concepts
                     end
 
-        @concepts = @concepts.select(:id, :name, :slug, :description, :parent_id, :created_at, :updated_at)
+        @concepts = @concepts.select(:id, :name, :slug, :description, :parent_id, :score, :similarity_threshold, :created_at, :updated_at)
                              .order(:name)
                              .page(page)
                              .per(per_page)
@@ -34,7 +34,7 @@ module Api
 
         serialized_concepts = @concepts.map do |concept|
           metrics = metrics_by_concept[concept.id] || []
-          concept.as_json(only: %i[id name slug description parent_id created_at updated_at]).merge(
+          concept.as_json(only: %i[id name slug description parent_id score similarity_threshold created_at updated_at]).merge(
             "daily_metrics" => metrics.map { |m| m.as_json(only: %i[date articles_count comments_count page_views reactions_count popularity_score]) }
           )
         end
@@ -43,24 +43,51 @@ module Api
       end
 
       def show
-        days = [params.fetch(:days, 7).to_i, 1].max
-        start_date = Date.today - days.days
+        render json: serialized_concept_response(@concept)
+      end
 
-        metrics = @concept.concept_daily_metrics
-                          .where("date >= ?", start_date)
-                          .order(date: :desc)
+      def update
+        @concept.assign_attributes(concept_update_params)
 
-        serialized_concept = @concept.as_json(only: %i[id name slug description parent_id created_at updated_at]).merge(
-          "daily_metrics" => metrics.map { |m| m.as_json(only: %i[date articles_count comments_count page_views reactions_count popularity_score]) }
-        )
+        if @concept.will_save_change_to_description?
+          Concepts::AnchorGenerator.new(@concept).call if @concept.name.present?
+        end
 
-        render json: serialized_concept
+        if @concept.save
+          if @concept.saved_change_to_description? || @concept.saved_change_to_similarity_threshold?
+            Concepts::BackfillClassifierWorker.perform_async(@concept.id)
+          end
+          render json: serialized_concept_response(@concept)
+        else
+          render json: { errors: @concept.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def articles
+        per_page = (params[:per_page] || 10).to_i
+        num = [per_page, per_page_max].min
+        page = params[:page] || 1
+
+        sort_by = params[:sort] == "score" ? "articles.score DESC" : "concept_memberships.distance ASC, articles.score DESC"
+
+        @articles = Article.published
+                           .joins(:concept_memberships)
+                           .where(concept_memberships: { concept_id: @concept.id })
+                           .select(Api::ArticlesController::INDEX_ATTRIBUTES_FOR_SERIALIZATION)
+                           .includes(user: :profile)
+                           .order(sort_by)
+                           .page(page)
+                           .per(num)
+                           .decorate
+
+        set_surrogate_key_header @concept.record_key, *@articles.map(&:record_key)
+        render "api/v0/articles/index", formats: :json
       end
 
       private
 
       def set_concept
-        @concept = Concept.select(:id, :name, :slug, :description, :parent_id, :created_at, :updated_at).find(params[:id])
+        @concept = Concept.find(params[:id])
       end
 
       def authorize_concept_access!
@@ -72,6 +99,28 @@ module Api
 
       def current_user
         @user
+      end
+
+      def concept_update_params
+        params.require(:concept).permit(:score, :description, :similarity_threshold)
+      end
+
+      def per_page_max
+        (ApplicationConfig["API_PER_PAGE_MAX"] || 1000).to_i
+      end
+
+      def serialized_concept_response(concept)
+        days = [params.fetch(:days, 7).to_i, 1].max
+        start_date = Date.today - days.days
+
+        metrics = concept.concept_daily_metrics
+                         .where("date >= ?", start_date)
+                         .order(date: :desc)
+
+        concept.as_json(only: %i[id name slug description parent_id score similarity_threshold created_at updated_at]).merge(
+          "daily_metrics" => metrics.map { |m| m.as_json(only: %i[date articles_count comments_count page_views reactions_count popularity_score]) },
+          "top_articles" => concept.top_articles(3).map { |a| a.as_json(only: %i[id title slug score published_at]) }
+        )
       end
     end
   end

--- a/app/controllers/concerns/api/trends_controller.rb
+++ b/app/controllers/concerns/api/trends_controller.rb
@@ -21,12 +21,14 @@ module Api
       num = [per_page, per_page_max].min
       page = params[:page] || 1
 
+      sort_by = params[:sort] == "score" ? "articles.score DESC" : "trend_memberships.distance ASC, articles.score DESC"
+
       @articles = Article.published
                          .joins(:trend_memberships)
                          .where(trend_memberships: { trend_id: @trend.id })
                          .select(Api::ArticlesController::INDEX_ATTRIBUTES_FOR_SERIALIZATION)
                          .includes(user: :profile)
-                         .order("trend_memberships.distance ASC, articles.score DESC")
+                         .order(sort_by)
                          .page(page)
                          .per(num)
                          .decorate

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -345,7 +345,7 @@ class Article < ApplicationRecord
   after_commit :recompile_organization_pages, on: %i[create update destroy]
 
   after_save :cleanup_memberships_if_unpublished,
-             if: -> { saved_change_to_published? && !published? }
+             if: -> { saved_change_to_published? && published_before_last_save && !published? }
 
   # The trigger `update_reading_list_document` is used to keep the `articles.reading_list_document` column updated.
   #

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -344,6 +344,9 @@ class Article < ApplicationRecord
 
   after_commit :recompile_organization_pages, on: %i[create update destroy]
 
+  after_save :cleanup_memberships_if_unpublished,
+             if: -> { saved_change_to_published? && !published? }
+
   # The trigger `update_reading_list_document` is used to keep the `articles.reading_list_document` column updated.
   #
   # Its body is inserted in a PostgreSQL trigger function and that joins the columns values
@@ -1856,5 +1859,10 @@ class Article < ApplicationRecord
        saved_change_to_main_image?
       Articles::UpdateDependentEmbedsWorker.perform_async(id)
     end
+  end
+
+  def cleanup_memberships_if_unpublished
+    concept_memberships.destroy_all
+    trend_memberships.destroy_all
   end
 end

--- a/app/models/concept.rb
+++ b/app/models/concept.rb
@@ -20,7 +20,12 @@ class Concept < ApplicationRecord
   validates :slug, presence: true, uniqueness: true
   validates :anchor_embedding, presence: true
   validates :max_lookback_days, presence: true, numericality: { greater_than_or_equal_to: 0, only_integer: true }
+  validates :score, presence: true, numericality: true
   validates :similarity_threshold, numericality: { greater_than_or_equal_to: 0.0, less_than_or_equal_to: 1.0 }, allow_nil: true
+
+  def top_articles(limit = 3)
+    articles.published.order(score: :desc).limit(limit)
+  end
 
   private
 

--- a/app/models/trend.rb
+++ b/app/models/trend.rb
@@ -33,6 +33,10 @@ class Trend < ApplicationRecord
     self.class.purge_all
   end
 
+  def top_articles(limit = 3)
+    articles.published.order(score: :desc).limit(limit)
+  end
+
   private
 
   def generate_slug

--- a/app/views/admin/concepts/_form.html.erb
+++ b/app/views/admin/concepts/_form.html.erb
@@ -24,6 +24,12 @@
     <p class="fs-xs color-base-60 mt-1"><%= t("views.admin.concepts.form.similarity_threshold_help") %></p>
   </div>
 
+  <div class="crayons-field mt-3">
+    <%= f.label :score, t("views.admin.concepts.form.score"), class: "crayons-field__label" %>
+    <%= f.number_field :score, step: :any, class: "crayons-textfield", placeholder: t("views.admin.concepts.form.score_placeholder") %>
+    <p class="fs-xs color-base-60 mt-1"><%= t("views.admin.concepts.form.score_help") %></p>
+  </div>
+
   <div class="flex items-center gap-4 mt-6">
     <%= f.submit class: "crayons-btn" %>
     <%= link_to "Cancel", admin_concepts_path, class: "crayons-btn crayons-btn--outlined" %>

--- a/app/views/api/v0/shared/_trend.json.jbuilder
+++ b/app/views/api/v0/shared/_trend.json.jbuilder
@@ -16,7 +16,3 @@ json.first_observed_at utc_iso_timestamp(trend.first_observed_at)
 json.last_observed_at  utc_iso_timestamp(trend.last_observed_at)
 json.created_at        utc_iso_timestamp(trend.created_at)
 json.updated_at        utc_iso_timestamp(trend.updated_at)
-
-json.top_articles trend.top_articles(3) do |article|
-  json.extract! article, :id, :title, :slug, :score, :published_at
-end

--- a/app/views/api/v0/shared/_trend.json.jbuilder
+++ b/app/views/api/v0/shared/_trend.json.jbuilder
@@ -16,3 +16,7 @@ json.first_observed_at utc_iso_timestamp(trend.first_observed_at)
 json.last_observed_at  utc_iso_timestamp(trend.last_observed_at)
 json.created_at        utc_iso_timestamp(trend.created_at)
 json.updated_at        utc_iso_timestamp(trend.updated_at)
+
+json.top_articles trend.top_articles(3) do |article|
+  json.extract! article, :id, :title, :slug, :score, :published_at
+end

--- a/app/views/api/v0/trends/show.json.jbuilder
+++ b/app/views/api/v0/trends/show.json.jbuilder
@@ -1,1 +1,5 @@
 json.partial! "api/v0/shared/trend", trend: @trend
+
+json.top_articles @trend.top_articles(3) do |article|
+  json.extract! article, :id, :title, :slug, :score, :published_at
+end

--- a/app/views/api/v1/shared/_trend.json.jbuilder
+++ b/app/views/api/v1/shared/_trend.json.jbuilder
@@ -16,7 +16,3 @@ json.first_observed_at utc_iso_timestamp(trend.first_observed_at)
 json.last_observed_at  utc_iso_timestamp(trend.last_observed_at)
 json.created_at        utc_iso_timestamp(trend.created_at)
 json.updated_at        utc_iso_timestamp(trend.updated_at)
-
-json.top_articles trend.top_articles(3) do |article|
-  json.extract! article, :id, :title, :slug, :score, :published_at
-end

--- a/app/views/api/v1/shared/_trend.json.jbuilder
+++ b/app/views/api/v1/shared/_trend.json.jbuilder
@@ -16,3 +16,7 @@ json.first_observed_at utc_iso_timestamp(trend.first_observed_at)
 json.last_observed_at  utc_iso_timestamp(trend.last_observed_at)
 json.created_at        utc_iso_timestamp(trend.created_at)
 json.updated_at        utc_iso_timestamp(trend.updated_at)
+
+json.top_articles trend.top_articles(3) do |article|
+  json.extract! article, :id, :title, :slug, :score, :published_at
+end

--- a/app/views/api/v1/trends/show.json.jbuilder
+++ b/app/views/api/v1/trends/show.json.jbuilder
@@ -1,1 +1,5 @@
 json.partial! "api/v1/shared/trend", trend: @trend
+
+json.top_articles @trend.top_articles(3) do |article|
+  json.extract! article, :id, :title, :slug, :score, :published_at
+end

--- a/app/workers/concepts/classify_record_worker.rb
+++ b/app/workers/concepts/classify_record_worker.rb
@@ -12,6 +12,8 @@ module Concepts
 
       # For Articles, only classify if they are published
       if record.is_a?(Article) && !record.published?
+        record.concept_memberships.destroy_all
+        record.trend_memberships.destroy_all if record.respond_to?(:trend_memberships)
         return
       end
 

--- a/config/locales/views/admin/en.yml
+++ b/config/locales/views/admin/en.yml
@@ -607,6 +607,9 @@ en:
           lookback_button: "Trigger Lookback"
           similarity_threshold: "Similarity Threshold"
         form:
+          score: "Concept Score"
+          score_placeholder: "e.g. 1.0 (optional)"
+          score_help: "Manual score/weight adjustment used for ranking."
           similarity_threshold: "Similarity Threshold"
           similarity_threshold_placeholder: "e.g. 0.25 (optional)"
           similarity_threshold_help: "Optional. Float between 0.0 and 1.0. If left blank, the system default (0.28) is used."

--- a/config/locales/views/admin/fr.yml
+++ b/config/locales/views/admin/fr.yml
@@ -596,6 +596,9 @@ fr:
           lookback_button: "Déclencher"
           similarity_threshold: "Seuil de similitude"
         form:
+          score: "Score du concept"
+          score_placeholder: "ex. 1.0 (optionnel)"
+          score_help: "Ajustement manuel du score/poids utilisé pour le classement."
           similarity_threshold: "Seuil de similitude"
           similarity_threshold_placeholder: "ex. 0.25 (optionnel)"
           similarity_threshold_help: "Optionnel. Nombre décimal entre 0,0 et 1,0. Si laissé vide, la valeur par défaut du système (0,28) est utilisée."

--- a/config/locales/views/admin/pt.yml
+++ b/config/locales/views/admin/pt.yml
@@ -493,6 +493,9 @@ pt:
           lookback_button: "Disparar Busca"
           similarity_threshold: "Limiar de Similaridade"
         form:
+          score: "Pontuação do Conceito"
+          score_placeholder: "ex. 1.0 (opcional)"
+          score_help: "Ajuste manual da pontuação/peso usado para classificação."
           similarity_threshold: "Limiar de Similaridade"
           similarity_threshold_placeholder: "ex. 0.25 (opcional)"
           similarity_threshold_help: "Opcional. Float entre 0.0 e 1.0. Se deixado em branco, o padrão do sistema (0.28) será usado."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,7 +123,9 @@ Rails.application.routes.draw do
         # shared config/routes/api.rb) because Api::V0::Admin::* controllers do
         # not implement these actions; placing the routes here scopes them to
         # callers using the application/vnd.forem.api-v1+json Accept header.
-        resources :concepts, only: %i[index show]
+        resources :concepts, only: %i[index show update] do
+          get :articles, on: :member
+        end
 
         namespace :admin do
           resources :users, only: %i[index show update] do

--- a/db/migrate/20260713121240_add_score_to_concepts.rb
+++ b/db/migrate/20260713121240_add_score_to_concepts.rb
@@ -1,4 +1,4 @@
-class AddScoreToConcepts < ActiveRecord::Migration[8.0]
+class AddScoreToConcepts < ActiveRecord::Migration[7.2]
   def change
     add_column :concepts, :score, :float, default: 0.0, null: false
   end

--- a/db/migrate/20260713121240_add_score_to_concepts.rb
+++ b/db/migrate/20260713121240_add_score_to_concepts.rb
@@ -1,0 +1,5 @@
+class AddScoreToConcepts < ActiveRecord::Migration[8.0]
+  def change
+    add_column :concepts, :score, :float, default: 0.0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_30_143448) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_13_121240) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -546,6 +546,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_30_143448) do
     t.integer "max_lookback_days", default: 0, null: false
     t.string "name", null: false
     t.bigint "parent_id"
+    t.float "score", default: 0.0, null: false
     t.float "similarity_threshold"
     t.string "slug", null: false
     t.datetime "updated_at", null: false

--- a/spec/requests/api/v0/trends_spec.rb
+++ b/spec/requests/api/v0/trends_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Api::V0::Trends" do
       trend_json = response.parsed_body.first
       expect(trend_json.keys).to match_array(%w[
         type_of id name slug description key_questions score articles_count
-        cover_image first_observed_at last_observed_at created_at updated_at
+        cover_image first_observed_at last_observed_at created_at updated_at top_articles
       ])
       expect(trend_json["type_of"]).to eq("trend")
       expect(trend_json["name"]).to eq("AI Agents")

--- a/spec/requests/api/v0/trends_spec.rb
+++ b/spec/requests/api/v0/trends_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Api::V0::Trends" do
       trend_json = response.parsed_body.first
       expect(trend_json.keys).to match_array(%w[
         type_of id name slug description key_questions score articles_count
-        cover_image first_observed_at last_observed_at created_at updated_at top_articles
+        cover_image first_observed_at last_observed_at created_at updated_at
       ])
       expect(trend_json["type_of"]).to eq("trend")
       expect(trend_json["name"]).to eq("AI Agents")
@@ -56,11 +56,12 @@ RSpec.describe "Api::V0::Trends" do
       expect(response.headers["surrogate-key"]).to eq(trend1.record_key)
     end
 
-    it "finds trend by Slug" do
+    it "finds trend by Slug and returns top_articles" do
       get "/api/trends/#{trend2.slug}"
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["name"]).to eq("AI Agents")
+      expect(response.parsed_body).to have_key("top_articles")
     end
 
     it "returns 404 for non-existent trend" do

--- a/spec/requests/api/v1/concepts_spec.rb
+++ b/spec/requests/api/v1/concepts_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Api::V1::Concepts", type: :request do
 
   describe "GET /api/concepts" do
     context "as a super admin" do
-      it "returns a list of all concepts without leaking anchor_embeddings, similarity_threshold, or max_lookback_days" do
+      it "returns a list of all concepts without leaking anchor_embeddings or max_lookback_days" do
         get api_concepts_path, headers: admin_headers
         expect(response).to be_successful
         json = JSON.parse(response.body)
@@ -46,7 +46,7 @@ RSpec.describe "Api::V1::Concepts", type: :request do
 
         concept_json = json.find { |c| c["id"] == concept_1.id }
         expect(concept_json).not_to have_key("anchor_embedding")
-        expect(concept_json).not_to have_key("similarity_threshold")
+        expect(concept_json).to have_key("similarity_threshold")
         expect(concept_json).not_to have_key("max_lookback_days")
       end
     end
@@ -94,13 +94,13 @@ RSpec.describe "Api::V1::Concepts", type: :request do
 
   describe "GET /api/concepts/:id" do
     context "as a super admin" do
-      it "allows viewing any concept without leaking anchor_embedding, similarity_threshold, or max_lookback_days" do
+      it "allows viewing any concept without leaking anchor_embedding or max_lookback_days" do
         get api_concept_path(concept_1), headers: admin_headers
         expect(response).to be_successful
         json = JSON.parse(response.body)
         expect(json["id"]).to eq(concept_1.id)
         expect(json).not_to have_key("anchor_embedding")
-        expect(json).not_to have_key("similarity_threshold")
+        expect(json).to have_key("similarity_threshold")
         expect(json).not_to have_key("max_lookback_days")
       end
     end
@@ -116,7 +116,7 @@ RSpec.describe "Api::V1::Concepts", type: :request do
         json = JSON.parse(response.body)
         expect(json["id"]).to eq(concept_1.id)
         expect(json).not_to have_key("anchor_embedding")
-        expect(json).not_to have_key("similarity_threshold")
+        expect(json).to have_key("similarity_threshold")
         expect(json).not_to have_key("max_lookback_days")
         expect(json).to have_key("daily_metrics")
 
@@ -146,6 +146,121 @@ RSpec.describe "Api::V1::Concepts", type: :request do
         get api_concept_path(concept_1), headers: user_headers
         expect(response).to have_http_status(:unauthorized)
       end
+    end
+  end
+
+  describe "PATCH /api/concepts/:id" do
+    let(:valid_params) { { concept: { score: 5.5, description: "Updated description via API", similarity_threshold: 0.45 } } }
+
+    before do
+      allow_any_instance_of(Concepts::AnchorGenerator).to receive(:call)
+      allow(Concepts::BackfillClassifierWorker).to receive(:perform_async)
+    end
+
+    context "as a super admin" do
+      it "allows updating the concept" do
+        patch api_concept_path(concept_1), params: valid_params, headers: admin_headers
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+        expect(json["score"]).to eq(5.5)
+        expect(json["description"]).to eq("Updated description via API")
+        expect(json["similarity_threshold"]).to eq(0.45)
+        expect(concept_1.reload.score).to eq(5.5)
+        expect(concept_1.reload.description).to eq("Updated description via API")
+        expect(concept_1.reload.similarity_threshold).to eq(0.45)
+        expect(Concepts::BackfillClassifierWorker).to have_received(:perform_async).with(concept_1.id)
+      end
+    end
+
+    context "as a regular user with access" do
+      before do
+        create(:concept_access, user: user, concept: concept_1)
+      end
+
+      it "allows updating score, description, and similarity_threshold" do
+        patch api_concept_path(concept_1), params: valid_params, headers: user_headers
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+        expect(json["score"]).to eq(5.5)
+        expect(json["description"]).to eq("Updated description via API")
+        expect(json["similarity_threshold"]).to eq(0.45)
+        expect(concept_1.reload.score).to eq(5.5)
+        expect(concept_1.reload.description).to eq("Updated description via API")
+        expect(concept_1.reload.similarity_threshold).to eq(0.45)
+        expect(Concepts::BackfillClassifierWorker).to have_received(:perform_async).with(concept_1.id)
+      end
+
+      it "denies updating other concepts" do
+        patch api_concept_path(concept_2), params: valid_params, headers: user_headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "as a regular user without access" do
+      it "denies updating" do
+        patch api_concept_path(concept_1), params: valid_params, headers: user_headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "GET /api/concepts/:id/articles" do
+    let!(:article_low) { create(:article, score: 10, published: true) }
+    let!(:article_high) { create(:article, score: 100, published: true) }
+    let!(:membership_low) { create(:concept_membership, concept: concept_1, record: article_low, distance: 0.1) }
+    let!(:membership_high) { create(:concept_membership, concept: concept_1, record: article_high, distance: 0.9) }
+
+    context "as a regular user with access" do
+      before do
+        create(:concept_access, user: user, concept: concept_1)
+      end
+
+      it "returns mapped articles" do
+        get articles_api_concept_path(concept_1), headers: user_headers
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+        expect(json.length).to eq(2)
+      end
+
+      it "orders articles by distance by default" do
+        get articles_api_concept_path(concept_1), headers: user_headers
+        json = JSON.parse(response.body)
+        expect(json[0]["id"]).to eq(article_low.id)
+        expect(json[1]["id"]).to eq(article_high.id)
+      end
+
+      it "orders articles by score DESC when sort=score is specified" do
+        get articles_api_concept_path(concept_1, sort: "score"), headers: user_headers
+        json = JSON.parse(response.body)
+        expect(json[0]["id"]).to eq(article_high.id)
+        expect(json[1]["id"]).to eq(article_low.id)
+      end
+    end
+
+    context "as a regular user without access" do
+      it "denies access" do
+        get articles_api_concept_path(concept_1), headers: user_headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "Article unpublishing cleanup" do
+    let!(:article) { create(:article, score: 50, published: true) }
+    let!(:trend) { create(:trend) }
+    let!(:concept_membership) { create(:concept_membership, concept: concept_1, record: article, distance: 0.1) }
+    let!(:trend_membership) { create(:trend_membership, trend: trend, article: article, distance: 0.1) }
+
+    it "destroys memberships and decrements count when the article is unpublished" do
+      expect(concept_1.concept_memberships.count).to eq(1)
+      expect(trend.trend_memberships.count).to eq(1)
+      expect(trend.reload.articles_count).to eq(1)
+
+      Articles::Unpublish.call(article.user, article)
+
+      expect(concept_1.concept_memberships.count).to eq(0)
+      expect(trend.trend_memberships.count).to eq(0)
+      expect(trend.reload.articles_count).to eq(0)
     end
   end
 end

--- a/spec/requests/api/v1/trends_spec.rb
+++ b/spec/requests/api/v1/trends_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Api::V1::Trends" do
       trend_json = response.parsed_body.first
       expect(trend_json.keys).to match_array(%w[
         type_of id name slug description key_questions score articles_count
-        cover_image first_observed_at last_observed_at created_at updated_at top_articles
+        cover_image first_observed_at last_observed_at created_at updated_at
       ])
       expect(trend_json["type_of"]).to eq("trend")
       expect(trend_json["name"]).to eq("AI Agents")
@@ -57,11 +57,12 @@ RSpec.describe "Api::V1::Trends" do
       expect(response.headers["surrogate-key"]).to eq(trend1.record_key)
     end
 
-    it "finds trend by Slug" do
+    it "finds trend by Slug and returns top_articles" do
       get "/api/trends/#{trend2.slug}", headers: headers
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["name"]).to eq("AI Agents")
+      expect(response.parsed_body).to have_key("top_articles")
     end
 
     it "returns 404 for non-existent trend" do

--- a/spec/requests/api/v1/trends_spec.rb
+++ b/spec/requests/api/v1/trends_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Api::V1::Trends" do
       trend_json = response.parsed_body.first
       expect(trend_json.keys).to match_array(%w[
         type_of id name slug description key_questions score articles_count
-        cover_image first_observed_at last_observed_at created_at updated_at
+        cover_image first_observed_at last_observed_at created_at updated_at top_articles
       ])
       expect(trend_json["type_of"]).to eq("trend")
       expect(trend_json["name"]).to eq("AI Agents")
@@ -110,6 +110,17 @@ RSpec.describe "Api::V1::Trends" do
 
       expected_keys = [trend2.record_key, article1.record_key, article2.record_key].to_set
       expect(response.headers["surrogate-key"].split.to_set).to eq(expected_keys)
+    end
+
+    it "orders articles by score DESC when sort=score is specified" do
+      # Let's make the high distance one have a higher score, and low distance have a lower score to differentiate
+      # distance order (article1 = 0.1, score = 100 vs article2 = 0.2, score = 50)
+      # Let's adjust article2 score to 150
+      article2.update!(score: 150)
+      get "/api/trends/#{trend2.slug}/articles", params: { sort: "score" }, headers: headers
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.first["title"]).to eq("Building my first AI agent") # score 150
+      expect(response.parsed_body.last["title"]).to eq("AI agents are taking over")    # score 100
     end
 
     it "returns 404 if trend is not found" do

--- a/spec/system/articles/user_creates_an_article_spec.rb
+++ b/spec/system/articles/user_creates_an_article_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe "Creating an article with the editor" do
 
   it "creates a new article", :flaky, js: true do
     visit new_path
+    expect(page).to have_selector("body[data-loaded='true']")
     fill_in "article_body_markdown", with: template
     click_button "Save changes"
     expect(page).to have_selector("header h1", text: "Sample Article")
@@ -91,6 +92,7 @@ RSpec.describe "Creating an article with the editor" do
 
     it "displays a rate limit warning", :flaky, js: true do
       visit new_path
+      expect(page).to have_selector("body[data-loaded='true']")
       fill_in "article_body_markdown", with: template
       click_button "Save changes"
       expect(page).to have_text("Rate limit reached")

--- a/spec/system/articles/user_edits_an_article_spec.rb
+++ b/spec/system/articles/user_edits_an_article_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Editing with an editor", js: true do
 
   it "user previews their changes" do
     visit "/#{user.username}/#{article.slug}/edit"
+    expect(page).to have_selector("body[data-loaded='true']")
     fill_in "article_body_markdown", with: template.gsub("Suspendisse", "Yooo")
     click_button("Preview")
     expect(page).to have_text("Yooo")
@@ -23,6 +24,7 @@ RSpec.describe "Editing with an editor", js: true do
 
   it "user updates their post" do
     visit "/#{user.username}/#{article.slug}/edit"
+    expect(page).to have_selector("body[data-loaded='true']")
     fill_in "article_body_markdown", with: template.gsub("Suspendisse", "Yooo")
     click_button("Save changes")
     expect(page).to have_text("Yooo")
@@ -30,6 +32,7 @@ RSpec.describe "Editing with an editor", js: true do
 
   it "user unpublishes their post" do
     visit "/#{user.username}/#{article.slug}/edit"
+    expect(page).to have_selector("body[data-loaded='true']")
     fill_in("article_body_markdown", with: template.gsub("true", "false"), fill_options: { clear: :backspace })
     click_button("Save changes")
     expect(page).to have_text("Unpublished Post.")
@@ -49,6 +52,7 @@ RSpec.describe "Editing with an editor", js: true do
 
     it "displays a rate limit warning", :flaky, js: true do
       visit "/#{user.username}/#{article.slug}/edit"
+      expect(page).to have_selector("body[data-loaded='true']")
       fill_in "article_body_markdown", with: template.gsub("Suspendisse", "Yooo")
       click_button "Save changes"
       expect(page).to have_text("Rate limit reached")

--- a/spec/system/user_uses_the_editor_spec.rb
+++ b/spec/system/user_uses_the_editor_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe "Using the editor" do
 
   def fill_markdown_with(content)
     visit "/new"
-    expect(page).to have_selector("body[data-loaded='true']", wait: 30)
+    expect(page).to have_selector("body[data-loaded='true']")
     within("#article-form") { fill_in "article_body_markdown", with: content }
   end
 
   describe "Viewing the editor", :js do
     it "renders the logo or Community name as expected" do
       visit "/new"
-      expect(page).to have_selector("body[data-loaded='true']", wait: 30)
+      expect(page).to have_selector("body[data-loaded='true']")
       expect(page).to have_css(".site-logo")
       within(".truncate-at-2") do
         expect(page).to have_text("DEV(local)")
@@ -36,7 +36,7 @@ RSpec.describe "Using the editor" do
     it "renders the AI Editor Buddy conditionally with dynamic community nomenclature" do
       stub_const("AI_AVAILABLE", true)
       visit "/new"
-      expect(page).to have_selector("body[data-loaded='true']", wait: 30)
+      expect(page).to have_selector("body[data-loaded='true']")
       
       expect(page).to have_css("#editor-ai-toggle-btn")
       find("#editor-ai-toggle-btn").click
@@ -114,6 +114,7 @@ RSpec.describe "Using the editor" do
   describe "using v2 editor", :js do
     it "fill out form with rich content and click publish" do
       visit "/new"
+      expect(page).to have_selector("body[data-loaded='true']")
       within "form#article-form" do
         fill_in "article-form-title", with: "This is a <span> test"
         find_by_id("tag-input").native.send_keys("what", :return)


### PR DESCRIPTION
This PR implements upgrades for trends and concepts:
1. Support for sorting articles by score (`sort=score`) on both trends and concepts API endpoints.
2. Capability to modify `similarity_threshold` and `description` via the Concepts API for authorized users, with automatic classifier backfilling.
3. Automated cleanup of memberships for unpublished/draft articles to avoid discrepancies where article counts are shown but no articles are displayed.
4. Manual `score` setting field on concepts via the API and HTML Admin dashboard.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786538373&installation_id=139885019&pr_number=23597&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23597&signature=48b44198d1905fd9177eaea6da5ad494658cfcb2abc54ba6e912356a32175334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->