### PR TITLE
feat(dev-sync): include DEV created_at in trackable_payload

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -863,6 +863,7 @@ class User < ApplicationRecord
   def trackable_payload
     {
       "id" => id, "username" => username, "email" => email, "name" => name,
+      "created_at" => created_at&.iso8601,
       "confirmed_at" => confirmed_at&.iso8601,
       "email_newsletter" => notification_setting&.email_newsletter,
       "mlh_user_id" => identities.where(provider: "mlh").pick(:uid)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -67,18 +67,19 @@ RSpec.describe User do
       expect(user.trackable_user_ids).to eq([user.id])
     end
 
-    it "ships a curated payload of identity, confirmation, newsletter, and Core-link state" do
+    it "ships a curated payload of identity, registration, confirmation, newsletter, and Core-link state" do
       user = create(:user)
       expect(user.trackable_payload.keys).to contain_exactly(
-        "id", "username", "email", "name", "confirmed_at", "email_newsletter", "mlh_user_id"
+        "id", "username", "email", "name", "created_at", "confirmed_at", "email_newsletter", "mlh_user_id"
       )
     end
 
-    it "reflects confirmation and newsletter state in the payload" do
+    it "reflects registration, confirmation, and newsletter state in the payload" do
       user = create(:user)
       user.notification_setting.update!(email_newsletter: true)
       payload = user.reload.trackable_payload
 
+      expect(payload["created_at"]).to eq(user.created_at.iso8601)
       expect(payload["confirmed_at"]).to eq(user.confirmed_at.iso8601)
       expect(payload["email_newsletter"]).to be(true)
     end


### PR DESCRIPTION
## What

Adds `"created_at" => created_at&.iso8601` to `User#trackable_payload` (app/models/user.rb), mirroring the existing `confirmed_at` key. This ships the DEV account's registration date on every `user_created` / `user_updated` event sent to the Customer.io CDP.

## Why

MLH Core consumes these events to materialize/update the linked Core user. Core's mass-import already sets the Core user's `created_at` from the DEV `registered_at`, but the **live** sync currently has no registration date to work from and defaults the new Core user's creation time to "now". That wrongly grace-protects old DEV accounts from account-age-aware moderation cleanup (a recently-created Core record looks like a brand-new signup). Carrying the true DEV `created_at` through the live path lets Core apply the same account-age logic it uses for imported users.

## Notes

- The key is purely **additive** — Core ignores `created_at` until the consuming change deploys, so this is safe to ship independently.
- Follows the curated-payload contract: string keys (Sidekiq `strict_args!`-safe), `iso8601` serialization, no full user row.

## Tests

- Updated the payload-keys and payload-state examples in `spec/models/user_spec.rb` to assert the new `created_at` key and its `iso8601` value.
- `bundle exec rspec spec/models/user_spec.rb -e Trackable` → 34 examples, 0 failures.
- `bundle exec rubocop` clean on the changed lines.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786719489&installation_id=139885019&pr_number=23608&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23608&signature=791a17598b48db0a877f8c58d5cdb64ec0a1cd9bcdeaf89fcfe4ea870606624e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->