### PR TITLE
Emit DEV digest consent to MLH Core

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -866,6 +866,7 @@ class User < ApplicationRecord
       "registered_at" => registered_at&.iso8601,
       "confirmed_at" => confirmed_at&.iso8601,
       "email_newsletter" => notification_setting&.email_newsletter,
+      "email_digest_periodic" => notification_setting&.email_digest_periodic,
       "mlh_user_id" => identities.where(provider: "mlh").pick(:uid)
     }
   end

--- a/app/models/users/notification_setting.rb
+++ b/app/models/users/notification_setting.rb
@@ -13,7 +13,7 @@ module Users
     alias_attribute :subscribed_to_email_follower_notifications, :email_follower_notifications
 
     after_commit :subscribe_to_mailchimp_newsletter
-    after_commit :track_newsletter_change, on: :update
+    after_commit :track_email_consent_changes, on: :update
     after_save if: :saved_change_to_email_newsletter? do
       user&.sync_base_email_eligible!
     end
@@ -28,14 +28,30 @@ module Users
 
     private
 
-    # Newsletter consent changes must reach MLH Core (source of truth for
-    # email subscriptions), which cannot see this table otherwise. Fires on
-    # every toggle path: settings page, one-click unsubscribe links,
-    # onboarding, and the Mailchimp unsubscribe webhook.
+    # Email consent changes must reach MLH Core (source of truth for email
+    # subscriptions), which cannot see this table otherwise. Fires on every
+    # toggle path: settings page, one-click unsubscribe links, onboarding, and
+    # the Mailchimp unsubscribe webhook.
+    #
+    # The newsletter and the periodic digest are SEPARATE consents — EmailDigest
+    # selects on email_digest_periodic alone and never reads email_newsletter —
+    # so each needs its own signal. A save that flips both emits both events.
+    def track_email_consent_changes
+      track_newsletter_change
+      track_digest_change
+    end
+
     def track_newsletter_change
       return unless saved_change_to_email_newsletter?
 
       event = email_newsletter? ? "user_newsletter_subscribed" : "user_newsletter_unsubscribed"
+      user&.track!(event)
+    end
+
+    def track_digest_change
+      return unless saved_change_to_email_digest_periodic?
+
+      event = email_digest_periodic? ? "user_digest_subscribed" : "user_digest_unsubscribed"
       user&.track!(event)
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -67,21 +67,35 @@ RSpec.describe User do
       expect(user.trackable_user_ids).to eq([user.id])
     end
 
-    it "ships a curated payload of identity, registration, confirmation, newsletter, and Core-link state" do
+    it "ships a curated payload of identity, registration, confirmation, email consent, and Core-link state" do
       user = create(:user)
       expect(user.trackable_payload.keys).to contain_exactly(
-        "id", "username", "email", "name", "registered_at", "confirmed_at", "email_newsletter", "mlh_user_id"
+        "id", "username", "email", "name", "registered_at", "confirmed_at", "email_newsletter",
+        "email_digest_periodic", "mlh_user_id"
       )
     end
 
-    it "reflects registration, confirmation, and newsletter state in the payload" do
+    it "reflects registration, confirmation, and email consent state in the payload" do
       user = create(:user)
-      user.notification_setting.update!(email_newsletter: true)
+      user.notification_setting.update!(email_newsletter: true, email_digest_periodic: true)
       payload = user.reload.trackable_payload
 
       expect(payload["registered_at"]).to eq(user.registered_at.iso8601)
       expect(payload["confirmed_at"]).to eq(user.confirmed_at.iso8601)
       expect(payload["email_newsletter"]).to be(true)
+      expect(payload["email_digest_periodic"]).to be(true)
+    end
+
+    # The two consents are independent: EmailDigest selects on
+    # email_digest_periodic alone, so the payload must carry them separately.
+    it "carries digest consent independently of newsletter consent" do
+      user = create(:user)
+      user.notification_setting.update!(email_newsletter: false, email_digest_periodic: true)
+
+      payload = user.reload.trackable_payload
+
+      expect(payload["email_newsletter"]).to be(false)
+      expect(payload["email_digest_periodic"]).to be(true)
     end
 
     it "includes the Core user id from the mlh identity in the payload" do

--- a/spec/models/users/notification_setting_spec.rb
+++ b/spec/models/users/notification_setting_spec.rb
@@ -72,6 +72,36 @@ RSpec.describe Users::NotificationSetting do
         .with(anything, /user_newsletter/, anything, anything, anything)
     end
 
+    # The digest is a separate consent from the newsletter: EmailDigest selects
+    # on email_digest_periodic alone, so Core needs its own signal for it.
+    it "emits user_digest_subscribed when email_digest_periodic flips on" do
+      notification_setting.update!(email_digest_periodic: true)
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_digest_subscribed", [user.id], anything, anything)
+    end
+
+    it "emits user_digest_unsubscribed when email_digest_periodic flips off" do
+      notification_setting.update!(email_digest_periodic: true)
+      notification_setting.update!(email_digest_periodic: false)
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_digest_unsubscribed", [user.id], anything, anything)
+    end
+
+    it "does not emit a digest event when only the newsletter changes" do
+      notification_setting.update!(email_newsletter: true)
+      expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+        .with(anything, /user_digest/, anything, anything, anything)
+    end
+
+    it "emits both events when one save flips newsletter and digest together" do
+      notification_setting.update!(email_newsletter: true, email_digest_periodic: true)
+
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_newsletter_subscribed", [user.id], anything, anything)
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_digest_subscribed", [user.id], anything, anything)
+    end
+
     it "does not emit when the sync gates are off" do
       Settings::General.customerio_cdp_enabled = false
       notification_setting.update!(email_newsletter: true)


### PR DESCRIPTION
## What

`email_digest_periodic` now crosses the DEV → Core boundary:

- added to `User#trackable_payload`
- new `user_digest_subscribed` / `user_digest_unsubscribed` events, emitted from `Users::NotificationSetting` alongside the existing newsletter events

## Why

The newsletter and the periodic digest are **separate consents**. `EmailDigest` selects recipients on `notification_setting.email_digest_periodic` alone and never reads `email_newsletter`:

```ruby
.where(notification_setting: { email_digest_periodic: true })
```

Only `email_newsletter` was crossing to Core, so Core had no representation of the digest audience — a digest subscriber with the newsletter off was invisible there entirely.

Core is moving DEV email to Customer.io, where the digest becomes its own subscription topic (id 11, default-off). Seeding that topic from **real per-user consent** rather than defaulting it on is what keeps opted-out users from being mailed, and that needs this flag. Keeping it correct afterwards needs a signal on every toggle — hence the events, which fire on all the same paths the newsletter ones do (settings page, one-click unsubscribe, onboarding, Mailchimp webhook).

A save that flips both consents emits both events.

## Safety

Core's inbound registry routes only events it has explicitly registered; unregistered ones dispatch to zero handlers and return 200. So this is inert until Core ships its side and can land independently.

## Testing

```
bundle exec rspec spec/models/users/notification_setting_spec.rb   # 13 examples, 0 failures
bundle exec rspec spec/models/user_spec.rb -e 'curated payload' -e 'email consent' -e 'digest consent independently'
```

Rubocop on the changed files is unchanged from baseline (the 19 offenses in `user.rb`/`user_spec.rb` are pre-existing).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786728750&installation_id=139885019&pr_number=23610&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23610&signature=735c1a46bfbb796be1312f88d0c8f9a523fff29cb681788d29022906647fad17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->