### PR TITLE
feat: implement short link redirects at /a/:code

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -2,7 +2,7 @@ class ArticlesController < ApplicationController
   include ApplicationHelper
 
   # NOTE: It seems quite odd to not authenticate the user for the :new action.
-  before_action :authenticate_user!, except: %i[feed new]
+  before_action :authenticate_user!, except: %i[feed new short_link]
   before_action :set_article, only: %i[edit manage update destroy stats admin_unpublish admin_featured_toggle]
   # NOTE: Consider pushing this check into the associated Policy.  We could choose to raise a
   #       different error which we could then rescue as part of our exception handling.
@@ -78,6 +78,21 @@ class ArticlesController < ApplicationController
       allowed_attributes: MarkdownProcessor::AllowedAttributes::FEED,
       scrubber: FeedMarkdownScrubber.new
     }
+  end
+
+  def short_link
+    skip_authorization
+    code = params[:code].to_s.downcase
+    id = code.reverse.to_i(26)
+    @article = Article.published.find_by(id: id)
+
+    if @article
+      set_surrogate_key_header("articles/#{@article.id}")
+      set_cache_control_headers(1.hour.to_i)
+      redirect_to @article.path
+    else
+      not_found
+    end
   end
 
   # @note The /new path is a unique creature.  We want to ensure that folks coming to the /new with

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
 
   get "/r/mobile", to: "deep_links#mobile"
   get "/.well-known/apple-app-site-association", to: "deep_links#aasa"
+  get "/a/:code", to: "articles#short_link", as: :article_short, constraints: { code: /[0-9a-pA-P]+/ }
 
   constraints OrgCustomDomainConstraint.new do
     get "/", to: "stories#custom_domain_index"

--- a/spec/requests/articles/short_link_spec.rb
+++ b/spec/requests/articles/short_link_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe "Article Short Links" do
+  let(:article) { create(:article, published: true) }
+  let(:short_code) { article.id.to_s(26).reverse }
+
+  context "when the article exists and is published" do
+    it "redirects to the article path" do
+      get "/a/#{short_code}"
+
+      expect(response).to redirect_to(article.path)
+      expect(response).to have_http_status(:found)
+    end
+
+    it "handles case insensitivity" do
+      get "/a/#{short_code.upcase}"
+
+      expect(response).to redirect_to(article.path)
+      expect(response).to have_http_status(:found)
+    end
+
+    context "with caching headers" do
+      before { get "/a/#{short_code}" }
+
+      it "sets Fastly Cache-Control headers" do
+        expect(response.headers["Cache-Control"]).to eq("public, no-cache")
+      end
+
+      it "sets Fastly Surrogate-Key headers" do
+        expect(response.headers["Surrogate-Key"]).to eq("articles/#{article.id}")
+      end
+    end
+  end
+
+  context "when the article is unpublished" do
+    let(:unpublished_article) { create(:article, published: false) }
+    let(:unpublished_code) { unpublished_article.id.to_s(26).reverse }
+
+    it "raises record not found error" do
+      expect {
+        get "/a/#{unpublished_code}"
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  context "when the article does not exist" do
+    it "raises record not found error" do
+      expect {
+        get "/a/nonexistentcode"
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end


### PR DESCRIPTION
Implements a short link redirect handler at /a/:code which redirects to published articles by converting their base-26 reversed id code. Includes caching headers, surrogate keys, and request specs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786729984&installation_id=139885019&pr_number=23611&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23611&signature=4b527ab8b5a9465ca07427b440fcc1b7dcd1e0ef1a3b8528b559118af4769a8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->