### PR TITLE
Optimize hybrid semantic search: route through Algolia when available with DB validation and fallback

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -21,25 +21,99 @@ module Api
         per_page = [per_page, 1].max
         page = [params[:page].to_i, 1].max
 
+        embedding = nil
+        quoted_vector = nil
         begin
-          embedding = Ai::Embedding.new(wrapper: self).call(
-            query_text,
-            task_type: "RETRIEVAL_QUERY",
-            output_dimensionality: 768
-          )
+          query_hash = Digest::SHA256.hexdigest(query_text)
+          embedding = Rails.cache.fetch("semantic_search_embedding/#{query_hash}", expires_in: 1.hour) do
+            Ai::Embedding.new(wrapper: self).call(
+              query_text,
+              task_type: "RETRIEVAL_QUERY",
+              output_dimensionality: 768
+            )
+          end
+          vector_literal = "[#{embedding.to_a.join(',')}]"
+          quoted_vector = Article.connection.quote(vector_literal)
         rescue StandardError => e
           Rails.logger.error("Failed to generate embedding for article semantic search: #{e.message}")
+        end
+
+        # Try Algolia search if configured and enabled
+        algolia_configured = (ApplicationConfig["ALGOLIA_APPLICATION_ID"].present? &&
+                              ApplicationConfig["ALGOLIA_API_KEY"].present?) ||
+                             (Settings::General.algolia_application_id.present? &&
+                              Settings::General.algolia_api_key.present?)
+        algolia_enabled = Settings::General.algolia_search_enabled?
+
+        if algolia_configured && algolia_enabled
+          algolia_ids = []
+          begin
+            search_params = {
+              hitsPerPage: 100,
+              facetFilters: []
+            }
+            subforem_id = RequestStore.store[:subforem_id]
+            if subforem_id.present?
+              search_params[:facetFilters] << "subforem_id:#{subforem_id}"
+            end
+
+            raw_res = Article.raw_search(query_text, search_params)
+            algolia_ids = raw_res["hits"].map { |hit| hit["objectID"].to_i }
+          rescue => e
+            Rails.logger.warn("Algolia search failed: #{e.message}. Falling back to DB search.")
+          end
+
+          if algolia_ids.any?
+            # Fetch and validate records from database to ensure they are published
+            @articles = Article.published.from_subforem
+              .where(id: algolia_ids)
+              .where("score >= ?", Settings::UserExperience.index_minimum_score)
+              .includes([{ user: :profile }, :organization])
+
+            if quoted_vector.present?
+              @articles = @articles.select("articles.*, (semantic_embedding <=> #{quoted_vector}) AS distance")
+            end
+
+            indexed_articles = @articles.index_by(&:id)
+            ordered_articles = algolia_ids.map { |id| indexed_articles[id] }.compact
+
+            # Apply threshold filter if present
+            if params[:threshold].present? && quoted_vector.present?
+              threshold_val = params[:threshold].to_f
+              ordered_articles = ordered_articles.select do |article|
+                distance = article.respond_to?(:distance) && article.distance ? article.distance.to_f : nil
+                distance.nil? || distance <= threshold_val
+              end
+            end
+
+            # Paginate validated results
+            paginated_articles = ordered_articles[((page - 1) * per_page)...(page * per_page)] || []
+
+            serialized_articles = paginated_articles.map do |article|
+              distance = article.respond_to?(:distance) && article.distance ? article.distance.to_f : nil
+              similarity = distance ? (1.0 - distance).round(6) : nil
+              article.as_json(only: Api::ArticlesController::INDEX_ATTRIBUTES_FOR_SERIALIZATION).merge(
+                "distance" => distance,
+                "similarity" => similarity
+              )
+            end
+
+            render json: serialized_articles
+            return
+          end
+        end
+
+        # Fallback to Database Hybrid Search (requires query embedding)
+        if quoted_vector.nil?
           render json: { error: "Failed to generate search embedding" }, status: :service_unavailable
           return
         end
 
-        vector_literal = "[#{embedding.to_a.join(',')}]"
-        quoted_vector = Article.connection.quote(vector_literal)
-
         # 1. Retrieve top 100 keyword search candidate metadata
+        cleaned_query = clean_keyword_query(query_text)
         keyword_relation = Article.published.from_subforem
           .where("score >= ?", Settings::UserExperience.index_minimum_score)
-          .search_articles(query_text)
+          .search_articles(cleaned_query)
           .limit(100)
         keyword_data = keyword_relation.pluck(:id, :score, :published_at)
 
@@ -128,6 +202,34 @@ module Api
         end
 
         render json: serialized_articles
+      end
+
+      private
+
+      STOP_WORDS = Set.new(%w[
+        a about above after again against all am an and any are aren't as at be because been before being below
+        between both but by can't cannot couldn't did didn't do does doesn't doing don't down during each few
+        for from further had hadn't has hasn't have haven't having he he'd he'll he's her here here's hers
+        herself him himself his how how's i i'd i'll i'm i've if in into is isn't it it's its itself let's
+        me more most mustn't my myself no nor not of off on once only or other ought our ours ourselves out
+        over own same shan't she she'd she'll she's should shouldn't so some such than that that's the their
+        theirs them themselves then there there's these they they'd they'll they're they've this those through
+        to too under until up very was wasn't we we'd we'll we're we've were weren't what what's whatever when
+        when's where where's which while who who's whom why why's with won't would wouldn't you you'd you'll
+        you're you've your yours yourself yourselves
+      ]).freeze
+
+      def clean_keyword_query(query_text)
+        return "" if query_text.blank?
+
+        # Remove common English contraction endings (e.g. 's, 't, 'd, 're, 've, 'll, 'm)
+        cleaned = query_text.downcase.gsub(/'(s|t|d|re|ve|ll|m)\b/, "")
+        # Replace non-alphanumeric characters with spaces
+        words = cleaned.gsub(/[^a-z0-9\s]/, " ").split
+        # Filter out stop words and single-character words
+        cleaned_words = words.reject { |w| w.length <= 1 || STOP_WORDS.include?(w) }
+
+        cleaned_words.empty? ? query_text : cleaned_words.join(" ")
       end
     end
   end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1767,5 +1767,95 @@ RSpec.describe "Api::V1::Articles" do
       json = JSON.parse(response.body)
       expect(json).to eq([])
     end
+
+    context "when Algolia is available" do
+      before do
+        allow(ApplicationConfig).to receive(:[]).and_call_original
+        allow(ApplicationConfig).to receive(:[]).with("ALGOLIA_APPLICATION_ID").and_return("test_app_id")
+        allow(ApplicationConfig).to receive(:[]).with("ALGOLIA_API_KEY").and_return("test_api_key")
+        allow(Settings::General).to receive(:algolia_search_enabled?).and_return(true)
+      end
+
+      it "routes the query through Algolia and validates results against the database" do
+        algolia_article = create(:article, title: "Algolia Match Title", published: true)
+        algolia_article.update_columns(score: 100, semantic_embedding: Array.new(768, 0.1))
+
+        expect(Article).to receive(:raw_search)
+          .with("fable", hash_including(hitsPerPage: 100))
+          .and_return({ "hits" => [{ "objectID" => algolia_article.id.to_s }] })
+
+        get "/api/articles/semantic_search", params: { q: "fable" }, headers: auth_headers
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+        expect(json.length).to eq(1)
+        expect(json[0]["id"]).to eq(algolia_article.id)
+      end
+
+      it "filters out unpublished or low-score articles returned by Algolia" do
+        draft_article = create(:article, title: "Algolia Draft", published: false)
+        low_score_article = create(:article, title: "Algolia Low Score", published: true)
+        low_score_article.update_columns(score: -10)
+
+        expect(Article).to receive(:raw_search)
+          .and_return({ "hits" => [
+            { "objectID" => draft_article.id.to_s },
+            { "objectID" => low_score_article.id.to_s }
+          ] })
+
+        get "/api/articles/semantic_search", params: { q: "fable" }, headers: auth_headers
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+        expect(json).to eq([])
+      end
+
+      it "falls back to DB hybrid search if Algolia search fails" do
+        db_article = create(:article, title: "Database Match Fable", published: true)
+        db_article.update_columns(score: 100, semantic_embedding: nil)
+
+        expect(Article).to receive(:raw_search).and_raise(StandardError.new("Algolia Error"))
+
+        get "/api/articles/semantic_search", params: { q: "fable" }, headers: auth_headers
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+        expect(json.find { |item| item["id"] == db_article.id }).to be_present
+      end
+    end
+
+    it "caches the embedding API call for identical queries" do
+      memory_store = ActiveSupport::Cache.lookup_store(:memory_store)
+      allow(Rails).to receive(:cache).and_return(memory_store)
+
+      embedding_mock = instance_double(Ai::Embedding)
+      expect(Ai::Embedding).to receive(:new).once.and_return(embedding_mock)
+      expect(embedding_mock).to receive(:call).once.and_return(query_embedding)
+
+      # First request: should call the service
+      get "/api/articles/semantic_search", params: { q: "cache query" }, headers: auth_headers
+      expect(response).to be_successful
+
+      # Second request: should read from cache and not call the service again
+      get "/api/articles/semantic_search", params: { q: "cache query" }, headers: auth_headers
+      expect(response).to be_successful
+    end
+
+    it "strips stop words and contractions from database keyword query" do
+      allow(Settings::General).to receive(:algolia_search_enabled?).and_return(false)
+
+      embedding_mock = instance_double(Ai::Embedding)
+      allow(Ai::Embedding).to receive(:new).and_return(embedding_mock)
+      expect(embedding_mock).to receive(:call)
+        .with("what's the latest with anthropic fable", task_type: "RETRIEVAL_QUERY", output_dimensionality: 768)
+        .and_return(query_embedding)
+
+      keyword_article = create(:article, title: "An amazing latest news fable by anthropic", published: true)
+      keyword_article.update_columns(score: 100, semantic_embedding: nil)
+
+      get "/api/articles/semantic_search", params: { q: "what's the latest with anthropic fable" }, headers: auth_headers
+      expect(response).to be_successful
+      json = JSON.parse(response.body)
+
+      matching_item = json.find { |item| item["id"] == keyword_article.id }
+      expect(matching_item).to be_present
+    end
   end
 end


### PR DESCRIPTION
## Summary
This PR optimizes the hybrid semantic search implementation to route through Algolia when configured and enabled, avoiding the expensive local database GIN and vector search queries while verifying all results against the database and falling back cleanly to the optimized DB search.

## Changes
- **Algolia Prioritization**: When Algolia is present, queries run via `Article.raw_search`. Retrieved article IDs are validated against the database (ensuring they are `published`, from the correct `subforem`, and have a valid score).
- **Metric Maintenance**: We retrieve the query embedding (from cache or API) to calculate the cosine distance against database results, maintaining identical response format and `threshold` parameter support.
- **Resilient Fallback**: Falls back to the optimized database keyword and semantic search if Algolia is disabled, not configured, or fails.
- **Regression Tests**: Added spec coverage in `spec/requests/api/v1/articles_spec.rb` verifying routing, filtering, fallback, caching, and query cleaning.

## Verification
RSpec tests ran and passed successfully:
`bundle exec rspec spec/requests/api/v1/articles_spec.rb:1659`
`13 examples, 0 failures`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786731745&installation_id=139885019&pr_number=23612&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23612&signature=fc956306e5519d685724391fb7a7c15bf70e625ae36ec9bb5ae4e4ef5a5b25de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->