### PR TITLE
Add Showcase and All Posts tabs for custom organization pages

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -216,7 +216,8 @@ class StoriesController < ApplicationController
     return if performed?
 
     main_page = @organization.main_page
-    is_readme = main_page.present? && FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[@organization])
+    has_readme = main_page.present? && FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[@organization])
+    is_readme = has_readme && params[:mode] != "all-posts"
     @stories = ArticleDecorator.decorate_collection(@organization.articles.published.from_subforem
       .includes(:distinct_reaction_categories, :subforem)
       .limited_column_select

--- a/app/views/organizations/_header.html.erb
+++ b/app/views/organizations/_header.html.erb
@@ -242,6 +242,29 @@
       </div>
     </div>
   <% end %>
+
+  <%# Render Showcase and All Posts tabs if organization has custom readme page feature enabled %>
+  <% if @organization.main_page.present? && FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[@organization]) %>
+    <%
+      is_custom_domain = request.env["forem.custom_domain_org"].present?
+      showcase_path = is_custom_domain ? "/" : "/#{@organization.slug}"
+      all_posts_path = is_custom_domain ? "/?mode=all-posts" : "/#{@organization.slug}?mode=all-posts"
+    %>
+    <nav class="crayons-tabs mt-4" aria-label="Organization Profile Navigation">
+      <ul class="crayons-tabs__list">
+        <li>
+          <a href="<%= showcase_path %>" class="crayons-tabs__item <%= 'crayons-tabs__item--current' if params[:mode] != 'all-posts' %>" <%= 'aria-current="page"' if params[:mode] != 'all-posts' %> data-text="<%= t('views.organizations.showcase') %>">
+            <%= t('views.organizations.showcase') %>
+          </a>
+        </li>
+        <li>
+          <a href="<%= all_posts_path %>" class="crayons-tabs__item <%= 'crayons-tabs__item--current' if params[:mode] == 'all-posts' %>" <%= 'aria-current="page"' if params[:mode] == 'all-posts' %> data-text="<%= t('views.organizations.all_posts') %>">
+            <%= t('views.organizations.all_posts') %>
+          </a>
+        </li>
+      </ul>
+    </nav>
+  <% end %>
 </div>
 
 <%= javascript_include_tag "organizationDropdown",

--- a/config/locales/views/organizations/en.yml
+++ b/config/locales/views/organizations/en.yml
@@ -162,6 +162,8 @@ en:
       cover_image_alt: "%{org} cover image"
       settings_link: Organization Settings
       admin_link: Admin
+      showcase: Showcase
+      all_posts: All Posts
       confirm_invitation:
         title: Confirm Organization Invitation
         greeting: "Hi %{name}!"

--- a/config/locales/views/organizations/fr.yml
+++ b/config/locales/views/organizations/fr.yml
@@ -161,6 +161,8 @@ fr:
       cover_image_alt: "Image de couverture de %{org}"
       settings_link: Paramètres de l'organisation
       admin_link: Admin
+      showcase: Showcase
+      all_posts: Tous les articles
       confirm_invitation:
         title: Confirmer l'invitation à l'organisation
         greeting: "Bonjour %{name} !"

--- a/config/locales/views/organizations/pt.yml
+++ b/config/locales/views/organizations/pt.yml
@@ -162,6 +162,8 @@ pt:
       cover_image_alt: "Imagem de capa de %{org}"
       settings_link: Configurações da Organização
       admin_link: Admin
+      showcase: Showcase
+      all_posts: Todos os posts
       confirm_invitation:
         title: Confirmar Convite da Organização
         greeting: "Olá %{name}!"

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -490,6 +490,13 @@ RSpec.describe "StoriesIndex" do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("sidebar-left")
       end
+
+      it "does not render showcase/all posts tabs" do
+        get "/#{organization.slug}"
+        expect(response.body).not_to include("Organization Profile Navigation")
+        expect(response.body).not_to include("Showcase")
+        expect(response.body).not_to include("All Posts")
+      end
     end
 
     context "when organization has a readme page and org_readme flag is enabled" do
@@ -503,11 +510,29 @@ RSpec.describe "StoriesIndex" do
 
       after { FeatureFlag.disable(:org_readme) }
 
-      it "renders the readme show template" do
+      it "renders the readme show template with showcase tab active" do
         get "/#{organization.slug}"
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("<strong>Welcome to our org!</strong>")
         expect(response.body).not_to include("sidebar-left")
+        
+        # Tabs should be present
+        expect(response.body).to include("Organization Profile Navigation")
+        expect(response.body).to include("crayons-tabs__item crayons-tabs__item--current")
+        expect(response.body).to include("Showcase")
+        expect(response.body).to include("All Posts")
+      end
+
+      it "renders the classic feed template with all posts tab active when mode is all-posts" do
+        get "/#{organization.slug}", params: { mode: "all-posts" }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("<strong>Welcome to our org!</strong>")
+        expect(response.body).to include("sidebar-left")
+
+        # Tabs should be present
+        expect(response.body).to include("Organization Profile Navigation")
+        expect(response.body).to include("Showcase")
+        expect(response.body).to include("All Posts")
       end
     end
 
@@ -523,6 +548,11 @@ RSpec.describe "StoriesIndex" do
         get "/#{organization.slug}"
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("sidebar-left")
+      end
+
+      it "does not render showcase/all posts tabs" do
+        get "/#{organization.slug}"
+        expect(response.body).not_to include("Organization Profile Navigation")
       end
     end
   end


### PR DESCRIPTION
Adds the Showcase and All Posts tabs to custom organization profiles.

### Changes:
- **Backend**: Update `handle_organization_index` in `StoriesController` to allow bypassing the custom readme profile view (Showcase) when `params[:mode]` is `"all-posts"`.
- **Frontend**: Add a navigation tabs layout inside `_header.html.erb` when custom readme page features are enabled.
- **i18n**: Add translations for the tab labels under `views.organizations` for `en`, `fr`, and `pt`.
- **Specs**: Add new request specs for checking tab rendering on profiles with/without custom pages, and when in all posts mode.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786735722&installation_id=139885019&pr_number=23613&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23613&signature=bbf932fe6dc47d023f557be9039ee85ec1e4219d916ebe043c235f7c1b49d0aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->