### PR TITLE
Add dedicated sitemap.xml for custom organization domains

### DIFF
--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -1,5 +1,5 @@
 class SitemapsController < ApplicationController
-  before_action :set_cache_control_headers, only: %i[show]
+  before_action :set_cache_control_headers, only: %i[show custom_domain_show]
 
   SITEMAP_REGEX = /\Asitemap-(?<date_string>[A-Z][a-z][a-z]-\d{4})\.xml\z/
   RESULTS_LIMIT = Rails.env.production? ? 750 : 5
@@ -13,6 +13,23 @@ class SitemapsController < ApplicationController
     else
       monthly_sitemap
     end
+    set_cache_control_headers(@max_age,
+                              stale_while_revalidate: @stale_while_revalidate,
+                              stale_if_error: @stale_if_error)
+    render @view_template, layout: false
+  end
+
+  def custom_domain_show
+    @organization = custom_domain_org
+    return not_found unless @organization
+
+    @articles = @organization.articles.published.from_subforem
+      .order(published_at: :desc)
+      .limit(50_000)
+      .pluck(:slug, :last_comment_at)
+
+    set_surrogate_controls(Time.current)
+    @view_template = "custom_domain"
     set_cache_control_headers(@max_age,
                               stale_while_revalidate: @stale_while_revalidate,
                               stale_if_error: @stale_if_error)

--- a/app/views/sitemaps/custom_domain.xml.erb
+++ b/app/views/sitemaps/custom_domain.xml.erb
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc><%= URL.url(nil, @organization.custom_domain) %></loc>
+    <lastmod><%= (@organization.articles.published.maximum(:updated_at) || Time.current).strftime("%F") %></lastmod>
+  </url>
+  <% @articles.each do |slug, last_comment_at| %>
+    <url>
+        <loc><%= URL.url("/#{slug}", @organization.custom_domain) %></loc>
+        <lastmod><%= (last_comment_at || Time.current).strftime("%F") %></lastmod>
+    </url>
+  <% end %>
+</urlset>

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -91,7 +91,7 @@ module Rack
     end
 
     throttle("sitemap_throttle", limit: 10, period: 1.minute) do |request|
-      if ENV["SITEMAP_RATE_LIMIT_ENABLED"] == "true" && request.path.starts_with?("/sitemap-")
+      if ENV["SITEMAP_RATE_LIMIT_ENABLED"] == "true" && request.path.starts_with?("/sitemap")
         ip = request.track_and_return_ip
         ip unless GooglebotVerifier.googlebot?(ip)
       end

--- a/config/initializers/reserved_words.rb
+++ b/config/initializers/reserved_words.rb
@@ -191,6 +191,7 @@ class ReservedWords
     security
     sedaily
     settings
+    sitemap
     shoutouts
     signout_confirm
     social

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
     get "/", to: "stories#custom_domain_index"
     get "/feed", to: "articles#feed", as: nil, defaults: { format: "rss" }
     get "/rss", to: "articles#feed", as: nil, defaults: { format: "rss" }
+    get "/sitemap", to: "sitemaps#custom_domain_show", constraints: { format: /xml/ }, defaults: { format: "xml" }
     get "/:org_slug/:slug",
         to: "stories#custom_domain_show",
         constraints: {

--- a/spec/requests/org_custom_domain_spec.rb
+++ b/spec/requests/org_custom_domain_spec.rb
@@ -141,6 +141,22 @@ RSpec.describe "Organization Custom Domain Routing", type: :request do
       end
     end
 
+    describe "sitemap routing" do
+      let(:user) { create(:user) }
+      let!(:article) { create(:article, organization: organization, user: user, title: "Org Article Title") }
+      let!(:other_article) { create(:article, title: "Other Article Title") }
+
+      it "routes /sitemap.xml to the organization's sitemap, returning only organization articles" do
+        get "http://custom.org/sitemap.xml"
+
+        expect(response).to have_http_status(:success)
+        expect(response.content_type).to include("application/xml")
+        expect(response.body).to include("<loc>http://custom.org</loc>")
+        expect(response.body).to include("<loc>http://custom.org/#{article.slug}</loc>")
+        expect(response.body).not_to include("<loc>http://custom.org/#{other_article.slug}</loc>")
+      end
+    end
+
     describe "signed out redirection to custom domain" do
       let(:user) { create(:user) }
       let!(:article) { create(:article, organization: organization, user: user, title: "Test Article Content") }


### PR DESCRIPTION
### Context
This PR adds a dedicated `/sitemap.xml` for custom organization domains. When visited (e.g. `blog.mlh.com/sitemap.xml`), it dynamically generates and lists all the published articles for that organization.

### Changes
1. **Routing**: Added `/sitemap` pointing to `sitemaps#custom_domain_show` within the `OrgCustomDomainConstraint` block in `config/routes.rb`.
2. **Rate Limiting**: Throttles `/sitemap.xml` requests along with `/sitemap-` requests in `config/initializers/rack_attack.rb`.
3. **Reserved Words**: Added `"sitemap"` to the list of reserved words in `config/initializers/reserved_words.rb` to prevent users/organizations from claiming it as a slug.
4. **Sitemaps Controller**: Implemented the `custom_domain_show` action in `app/controllers/sitemaps_controller.rb` which renders the sitemap for a custom domain.
5. **View Template**: Created a new XML view template `app/views/sitemaps/custom_domain.xml.erb` that maps URLs cleanly under the custom domain (e.g., `http://custom.org/` and `http://custom.org/article-slug`).
6. **Tests**: Added request specs in `spec/requests/org_custom_domain_spec.rb` to verify routing, organization scoping, and sitemap layout.

### Verification
- Ran integration specs (`spec/requests/org_custom_domain_spec.rb` and `spec/requests/sitemaps_spec.rb`). All tests passed successfully.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786739370&installation_id=139885019&pr_number=23614&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23614&signature=54a7470b74e37dcc27f76670d9926b3cc17100bea7e64ab43234a7b362193f84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->