### PR TITLE
Limit Fastly cache TTL for error responses (status >= 400) to 30s

### DIFF
--- a/app/views/organizations/_header.html.erb
+++ b/app/views/organizations/_header.html.erb
@@ -81,6 +81,9 @@
     height: 3px;
     background: var(--profile-brand-color);
   }
+  .org-header-tabs .crayons-tabs__item {
+    width: auto;
+  }
 </style>
 
 <div class="org-header-cover"></div>
@@ -250,19 +253,13 @@
       showcase_path = is_custom_domain ? "/" : "/#{@organization.slug}"
       all_posts_path = is_custom_domain ? "/?mode=all-posts" : "/#{@organization.slug}?mode=all-posts"
     %>
-    <nav class="crayons-tabs mt-4" aria-label="Organization Profile Navigation">
-      <ul class="crayons-tabs__list">
-        <li>
-          <a href="<%= showcase_path %>" class="crayons-tabs__item <%= 'crayons-tabs__item--current' if params[:mode] != 'all-posts' %>" <%= 'aria-current="page"' if params[:mode] != 'all-posts' %> data-text="<%= t('views.organizations.showcase') %>">
-            <%= t('views.organizations.showcase') %>
-          </a>
-        </li>
-        <li>
-          <a href="<%= all_posts_path %>" class="crayons-tabs__item <%= 'crayons-tabs__item--current' if params[:mode] == 'all-posts' %>" <%= 'aria-current="page"' if params[:mode] == 'all-posts' %> data-text="<%= t('views.organizations.all_posts') %>">
-            <%= t('views.organizations.all_posts') %>
-          </a>
-        </li>
-      </ul>
+    <nav class="crayons-tabs org-header-tabs" aria-label="Organization Profile Navigation">
+      <a href="<%= showcase_path %>" class="crayons-tabs__item <%= 'crayons-tabs__item--current' if params[:mode] != 'all-posts' %>" <%= 'aria-current="page"' if params[:mode] != 'all-posts' %> data-text="<%= t('views.organizations.showcase') %>">
+        <%= t('views.organizations.showcase') %>
+      </a>
+      <a href="<%= all_posts_path %>" class="crayons-tabs__item <%= 'crayons-tabs__item--current' if params[:mode] == 'all-posts' %>" <%= 'aria-current="page"' if params[:mode] == 'all-posts' %> data-text="<%= t('views.organizations.all_posts') %>">
+        <%= t('views.organizations.all_posts') %>
+      </a>
     </nav>
   <% end %>
 </div>

--- a/config/fastly/snippets/stale_while_revalidate_controls.vcl
+++ b/config/fastly/snippets/stale_while_revalidate_controls.vcl
@@ -2,4 +2,9 @@ sub vcl_fetch {
   if (req.url == "/" || req.url == "/?i=i") {
     set beresp.stale_while_revalidate = 15s;
   }
+
+  if (beresp.status >= 400) {
+    set beresp.ttl = 30s;
+    set beresp.cacheable = true;
+  }
 }


### PR DESCRIPTION
### Goal

Limit the Fastly cache TTL for error status responses (HTTP status >= 400) to 30 seconds.

### Problem Context

When a request to a custom domain (or standard page) fails or is misconfigured, Fastly caches the resulting 404 response page (or fallback redirects) using its default service TTL (which is configured for up to 30 days) when the response lacks explicit Cache-Control/Surrogate-Control headers. This causes pages (like newly-published articles) to render as 404 to users for an extended period, even after they have been published or the domain configuration is corrected.

### Proposed Changes

This PR modifies the  block in the Fastly VCL snippet `stale_while_revalidate_controls.vcl` to:
- Detect error responses (`beresp.status >= 400`).
- Set `beresp.ttl = 30s` (caching them for at most 30 seconds to absorb traffic spikes without keeping errors stuck indefinitely).
- Set `beresp.cacheable = true` so the error responses are explicitly cacheable for that duration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786745892&installation_id=139885019&pr_number=23616&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23616&signature=48758024ebe1a23cc836dc7465f2ed6e6dc8d1a1e9012307d5b8144c47211eaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->