### PR TITLE
Load tags stylesheet in body to fix InstantClick page navigation

### DIFF
--- a/app/views/stories/tagged_articles/index.html.erb
+++ b/app/views/stories/tagged_articles/index.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_meta do %>
   <%= render "stories/tagged_articles/meta" %>
-  <%= stylesheet_link_tag "tags", media: "all" %>
 <% end %>
+<%= stylesheet_link_tag "tags", media: "all" %>
 <div class="crayons-layout">
   <div data-tag-id="<%= @tag.id %>"
        data-tag-name="<%= @tag.name %>"

--- a/spec/requests/stories/tagged_articles_spec.rb
+++ b/spec/requests/stories/tagged_articles_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe "Stories::TaggedArticlesIndex" do
           end
         end
 
+        it "renders the tags stylesheet under both standard and internal navigation" do
+          get "/t/#{tag.name}"
+          expect(response.body).to include('href="/assets/tags')
+
+          get "/t/#{tag.name}", params: { i: "i" }
+          expect(response.body).to include('href="/assets/tags')
+        end
+
         it "renders page when tag is not supported but has at least one approved article" do
           create(:article, :past, published: true, approved: true, tags: unsupported_tag,
                                   past_published_at: 5.years.ago)


### PR DESCRIPTION
This PR moves the tags stylesheet out of the `<head>`'s `:page_meta` block and into the page body. This resolves the issue where navigating to tag pages via InstantClick resulted in partial CSS showing (due to InstantClick only replacing the `#page-content` body container and leaving `<head>` changes unprocessed).

Additionally, request specs have been added to verify that the stylesheet loads successfully under both standard and internal navigation (InstantClick).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786799645&installation_id=139885019&pr_number=23618&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23618&signature=1c47e77dbe4950af4f21446b9a04f67ba2c2d8adf7edd8219a5dd63c89a595ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->