### PR TITLE
Hand drip and admin broadcast email off to Customer.io at full cutover

### DIFF
--- a/app/controllers/admin/emails_controller.rb
+++ b/app/controllers/admin/emails_controller.rb
@@ -2,6 +2,8 @@ module Admin
   class EmailsController < Admin::ApplicationController
     layout "admin"
 
+    before_action :ensure_no_customerio_cutover, only: %i[new edit create update]
+
     def index
       @emails = Email.includes([:audience_segment]).order("id DESC")
 
@@ -61,6 +63,13 @@ module Admin
     end
 
     private
+
+    def ensure_no_customerio_cutover
+      if ForemInstance.customerio_email_cutover?
+        flash[:danger] = I18n.t("admin.emails.customerio_cutover_notice")
+        redirect_to admin_emails_path
+      end
+    end
 
     def email_params
       params.require(:email).permit(:subject, :body, :user_query_id, :variables, :type_of, :drip_day, :status,

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -79,6 +79,9 @@ class Email < ApplicationRecord
   end
 
   def deliver_to_test_emails(addresses_string)
+    # Broadcasts/newsletters are authored in Customer.io after cutover.
+    return if ForemInstance.customerio_email_cutover?
+
     addresses_string ||= test_email_addresses
     return if addresses_string.blank?
 
@@ -91,6 +94,8 @@ class Email < ApplicationRecord
   end
 
   def deliver_to_users
+    # Broadcasts/newsletters are authored in Customer.io after cutover.
+    return if ForemInstance.customerio_email_cutover?
     return if type_of == "onboarding_drip"
     return unless saved_change_to_status? && active?
 

--- a/app/models/forem_instance.rb
+++ b/app/models/forem_instance.rb
@@ -53,6 +53,13 @@ class ForemInstance
     ApplicationConfig["CUSTOMERIO_APP_KEY"].present?
   end
 
+  # Full cutover: Customer.io handles campaign/broadcast email (drip, admin
+  # one-offs/newsletters) only when the integration is on AND the delivery
+  # flag is enabled globally, not just for rollout batches.
+  def self.customerio_email_cutover?
+    customerio_enabled? && FeatureFlag.enabled?(Deliverable::CUSTOMERIO_FLAG)
+  end
+
   def self.sendgrid_enabled?
     ENV["SENDGRID_API_KEY"].present?
   end

--- a/app/views/admin/emails/index.html.erb
+++ b/app/views/admin/emails/index.html.erb
@@ -37,11 +37,13 @@
       
       <%= submit_tag("Filter", class: "crayons-btn") %>
     <% end %>
-    <div class="ml-auto">
-      <div class="justify-end">
-        <%= link_to "Compose New Email", new_admin_email_path, class: "crayons-btn" %>
+    <% unless ForemInstance.customerio_email_cutover? %>
+      <div class="ml-auto">
+        <div class="justify-end">
+          <%= link_to "Compose New Email", new_admin_email_path, class: "crayons-btn" %>
+        </div>
       </div>
-    </div>
+    <% end %>
   </nav>
 
   <%= paginate @emails %>

--- a/app/views/admin/emails/index.html.erb
+++ b/app/views/admin/emails/index.html.erb
@@ -1,5 +1,11 @@
 <h1 class="crayons-title mb-3">Emails</h1>
 
+<% if ForemInstance.customerio_email_cutover? %>
+  <div class="crayons-notice crayons-notice--warning mb-4" role="alert">
+    <%= t("admin.emails.customerio_cutover_notice") %>
+  </div>
+<% end %>
+
 <div
   data-controller="confirmation-modal"
   data-confirmation-modal-root-selector-value="#confirmation-modal-root"

--- a/app/workers/emails/batch_custom_send_worker.rb
+++ b/app/workers/emails/batch_custom_send_worker.rb
@@ -7,6 +7,8 @@ module Emails
     sidekiq_throttle(concurrency: { limit: ENV.fetch("EMAIL_BATCH_CONCURRENCY_LIMIT", 5).to_i })
 
     def perform(user_ids, subject, content, type_of, email_id, from_name = nil)
+      return if ForemInstance.customerio_email_cutover?
+
       user_ids = user_ids.map(&:to_i)
 
       # Optimized: Load all users in one query instead of N queries (avoids N+1)

--- a/app/workers/emails/drip_email_worker.rb
+++ b/app/workers/emails/drip_email_worker.rb
@@ -8,6 +8,8 @@ module Emails
     # Treat nil or zero as default grouping
 
     def perform
+      # After full cutover, drip runs as a CIO Journeys campaign triggered by the user_created CDP event.
+      return if ForemInstance.customerio_email_cutover?
       return unless FeatureFlag.enabled?("onboarding_drip_emails")
 
       last_drip_day = Email.where(type_of: "onboarding_drip").maximum(:drip_day)

--- a/app/workers/emails/enqueue_custom_batch_send_worker.rb
+++ b/app/workers/emails/enqueue_custom_batch_send_worker.rb
@@ -13,6 +13,8 @@ module Emails
     BATCH_SIZE = Rails.env.production? ? 1000 : 10
 
     def perform(email_id, min_id = nil, max_id = nil)
+      return if ForemInstance.customerio_email_cutover?
+
       email = Email.find_by(id: email_id)
       return unless email
 

--- a/config/locales/controllers/admin/en.yml
+++ b/config/locales/controllers/admin/en.yml
@@ -68,6 +68,8 @@ en:
       deleted: Billboard has been deleted!
       updated: Billboard has been updated!
       wrong: Something went wrong with deleting the Billboard.
+    emails:
+      customerio_cutover_notice: Email sending has moved to Customer.io. Records below are historical; compose new broadcasts and newsletters in the Customer.io workspace.
     emails_controller:
       created: Emails has been created!
       drafted: Email has been drafted!

--- a/config/locales/controllers/admin/fr.yml
+++ b/config/locales/controllers/admin/fr.yml
@@ -68,6 +68,8 @@ fr:
       deleted: L'annonce a été supprimée !
       updated: L'annonce publicitaire a été mise à jour !
       wrong: Quelque chose s'est mal passé avec la suppression de l'annonce publicitaire.
+    emails:
+      customerio_cutover_notice: L'envoi d'e-mails a été transféré à Customer.io. Les enregistrements ci-dessous sont historiques ; composez les nouvelles diffusions et infolettres dans l'espace de travail Customer.io.
     emails_controller:
       created: Emails are being sent!
       drafted: Email has been drafted!

--- a/config/locales/controllers/admin/pt.yml
+++ b/config/locales/controllers/admin/pt.yml
@@ -33,6 +33,8 @@ pt:
       deleted: Painel publicitário foi excluído!
       updated: Painel publicitário foi atualizado!
       wrong: Algo deu errado ao excluir o painel publicitário.
+    emails:
+      customerio_cutover_notice: O envio de e-mails foi transferido para o Customer.io. Os registros abaixo são históricos; crie novas transmissões e newsletters no workspace do Customer.io.
     emails_controller:
       created: E-mails foram criados!
       drafted: E-mail foi rascunhado!

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -96,10 +96,38 @@ RSpec.describe Email, type: :model do
       email.deliver_to_users
       expect(email.reload.status).to eq("delivered")
     end
+
+    context "when Customer.io cutover is active" do
+      let(:email) { create(:email, status: "draft") }
+
+      before do
+        allow(ForemInstance).to receive(:customerio_email_cutover?).and_return(true)
+      end
+
+      it "does not enqueue any jobs to EnqueueCustomBatchSendWorker" do
+        email.update(status: "active")
+        email.deliver_to_users
+
+        expect(Emails::EnqueueCustomBatchSendWorker).not_to have_received(:perform_async)
+      end
+    end
+
+    context "when Customer.io cutover is not active" do
+      let(:email) { create(:email, status: "draft") }
+
+      before do
+        allow(ForemInstance).to receive(:customerio_email_cutover?).and_return(false)
+      end
+
+      it "enqueues a job to EnqueueCustomBatchSendWorker as before" do
+        email.update(status: "active")
+        email.deliver_to_users
+
+        expect(Emails::EnqueueCustomBatchSendWorker).to have_received(:perform_async).once.with(email.id)
+      end
+    end
   end
 
-  # The `#deliver_to_test_emails` method is unchanged
-  # because it still calls `Emails::BatchCustomSendWorker`.
   describe "#deliver_to_test_emails" do
     let(:email) { create(:email, subject: "Test Subject", body: "Test Body", type_of: "newsletter") }
 
@@ -156,6 +184,40 @@ RSpec.describe Email, type: :model do
       it "does not enqueue any jobs" do
         expect(Emails::BatchCustomSendWorker).not_to receive(:perform_async)
         email.deliver_to_test_emails("")
+      end
+    end
+
+    context "when Customer.io cutover is active" do
+      before do
+        create(:user, email: "test1@example.com")
+        allow(ForemInstance).to receive(:customerio_email_cutover?).and_return(true)
+      end
+
+      it "does not enqueue any jobs to BatchCustomSendWorker" do
+        email.deliver_to_test_emails("test1@example.com")
+
+        expect(Emails::BatchCustomSendWorker).not_to have_received(:perform_async)
+      end
+    end
+
+    context "when Customer.io cutover is not active" do
+      let!(:user_1) { create(:user, email: "test1@example.com") }
+
+      before do
+        allow(ForemInstance).to receive(:customerio_email_cutover?).and_return(false)
+      end
+
+      it "enqueues a job to BatchCustomSendWorker as before" do
+        email.deliver_to_test_emails("test1@example.com")
+
+        expect(Emails::BatchCustomSendWorker).to have_received(:perform_async).with(
+          contain_exactly(user_1.id),
+          "[TEST] #{email.subject}",
+          email.body,
+          email.type_of,
+          email.id,
+          email.default_from_name_based_on_type,
+        )
       end
     end
   end

--- a/spec/models/forem_instance_spec.rb
+++ b/spec/models/forem_instance_spec.rb
@@ -109,6 +109,34 @@ RSpec.describe ForemInstance do
     end
   end
 
+  describe ".customerio_email_cutover?" do
+    after { FeatureFlag.remove(Deliverable::CUSTOMERIO_FLAG) }
+
+    it "is true when CUSTOMERIO_APP_KEY is present and the flag is enabled globally" do
+      allow(ApplicationConfig).to receive(:[]).and_call_original
+      allow(ApplicationConfig).to receive(:[]).with("CUSTOMERIO_APP_KEY").and_return("app-key")
+      FeatureFlag.enable(Deliverable::CUSTOMERIO_FLAG)
+
+      expect(described_class.customerio_email_cutover?).to be(true)
+    end
+
+    it "is false when CUSTOMERIO_APP_KEY is present but the flag is only enabled for an actor" do
+      allow(ApplicationConfig).to receive(:[]).and_call_original
+      allow(ApplicationConfig).to receive(:[]).with("CUSTOMERIO_APP_KEY").and_return("app-key")
+      FeatureFlag.enable(Deliverable::CUSTOMERIO_FLAG, FeatureFlag::Actor[create(:user)])
+
+      expect(described_class.customerio_email_cutover?).to be(false)
+    end
+
+    it "is false when CUSTOMERIO_APP_KEY is absent even if the flag is enabled globally" do
+      allow(ApplicationConfig).to receive(:[]).and_call_original
+      allow(ApplicationConfig).to receive(:[]).with("CUSTOMERIO_APP_KEY").and_return(nil)
+      FeatureFlag.enable(Deliverable::CUSTOMERIO_FLAG)
+
+      expect(described_class.customerio_email_cutover?).to be(false)
+    end
+  end
+
   describe ".contact_email" do
     let(:email) { "contact@dev.to" }
 

--- a/spec/requests/admin/emails_spec.rb
+++ b/spec/requests/admin/emails_spec.rb
@@ -155,4 +155,39 @@ RSpec.describe "/admin/emails" do
       end
     end
   end
+
+  describe "when Customer.io email cutover is active" do
+    before do
+      allow(ForemInstance).to receive(:customerio_email_cutover?).and_return(true)
+    end
+
+    it "redirects GET /admin/emails/new to the index page" do
+      get new_admin_email_path
+      expect(response).to redirect_to(admin_emails_path)
+      expect(flash[:danger]).to eq(I18n.t("admin.emails.customerio_cutover_notice"))
+    end
+
+    it "redirects GET /admin/emails/:id/edit to the index page" do
+      email = create(:email)
+      get edit_admin_email_path(email)
+      expect(response).to redirect_to(admin_emails_path)
+      expect(flash[:danger]).to eq(I18n.t("admin.emails.customerio_cutover_notice"))
+    end
+
+    it "redirects POST /admin/emails to the index page without creating one" do
+      expect do
+        post admin_emails_path, params: { email: { subject: "Test", body: "Test" } }
+      end.not_to change(Email, :count)
+      expect(response).to redirect_to(admin_emails_path)
+      expect(flash[:danger]).to eq(I18n.t("admin.emails.customerio_cutover_notice"))
+    end
+
+    it "redirects PATCH /admin/emails/:id to the index page without updating one" do
+      email = create(:email, subject: "Original")
+      patch admin_email_path(email), params: { email: { subject: "Changed" } }
+      expect(response).to redirect_to(admin_emails_path)
+      expect(flash[:danger]).to eq(I18n.t("admin.emails.customerio_cutover_notice"))
+      expect(email.reload.subject).to eq("Original")
+    end
+  end
 end

--- a/spec/workers/emails/batch_custom_send_worker_spec.rb
+++ b/spec/workers/emails/batch_custom_send_worker_spec.rb
@@ -17,6 +17,17 @@ RSpec.describe Emails::BatchCustomSendWorker, type: :worker do
       allow(Rails.logger).to receive(:error)
     end
 
+    context "when Customer.io email cutover is active" do
+      before do
+        allow(ForemInstance).to receive(:customerio_email_cutover?).and_return(true)
+      end
+
+      it "does not send any emails and no-ops" do
+        worker.perform(user_ids, subject_line, content, type_of, email_id)
+        expect(CustomMailer).not_to have_received(:with)
+      end
+    end
+
     context "when testing the async call" do
       it "queues the job with the correct arguments regardless of user ID order" do
         # Stub the class method perform_async

--- a/spec/workers/emails/drip_email_worker_spec.rb
+++ b/spec/workers/emails/drip_email_worker_spec.rb
@@ -167,5 +167,30 @@ RSpec.describe Emails::DripEmailWorker, type: :worker do
       expect(CustomMailer).not_to have_received(:with).with(hash_including(user: unsub))
       expect(CustomMailer).not_to have_received(:with).with(hash_including(user: @user_recent_email))
     end
+
+    context "when Customer.io cutover is active" do
+      before do
+        allow(ForemInstance).to receive(:customerio_email_cutover?).and_return(true)
+      end
+
+      it "does not send any drip emails, even with a matching template and eligible user" do
+        worker.perform
+
+        expect(CustomMailer).not_to have_received(:with)
+      end
+    end
+
+    context "when Customer.io cutover is not active" do
+      before do
+        allow(ForemInstance).to receive(:customerio_email_cutover?).and_return(false)
+      end
+
+      it "sends drip emails as before" do
+        worker.perform
+
+        expect(CustomMailer)
+          .to have_received(:with).with(hash_including(subject: default_email_day_1.subject)).at_least(:once)
+      end
+    end
   end
 end

--- a/spec/workers/emails/enqueue_custom_batch_send_worker_spec.rb
+++ b/spec/workers/emails/enqueue_custom_batch_send_worker_spec.rb
@@ -9,6 +9,17 @@ RSpec.describe Emails::EnqueueCustomBatchSendWorker, type: :worker do
       allow(Emails::BatchCustomSendWorker).to receive(:perform_async).and_return(true)
     end
 
+    context "when Customer.io email cutover is active" do
+      before do
+        allow(ForemInstance).to receive(:customerio_email_cutover?).and_return(true)
+      end
+
+      it "does not process the email or enqueue any BatchCustomSendWorker jobs" do
+        described_class.new.perform(email.id)
+        expect(Emails::BatchCustomSendWorker).not_to have_received(:perform_async)
+      end
+    end
+
     context "when email has an audience segment" do
       let!(:audience_segment) { create(:audience_segment) }
       let!(:email) { create(:email, subject: "Segmented", audience_segment: audience_segment) }


### PR DESCRIPTION
## What

PR 6 of the Customer.io email series (stacked on #23626): hands campaign/broadcast email off to Customer.io at **full cutover** — defined as `CUSTOMERIO_APP_KEY` present AND `:customerio_email_delivery` enabled via the **global** boolean gate. Per-actor / percentage-of-actors rollout does NOT trip this: Rails drip and admin broadcasts keep running during partial rollout (verified against Flipper's gate implementations).

- `ForemInstance.customerio_email_cutover?` — the gate.
- `Emails::DripEmailWorker` no-ops at cutover (onboarding drip becomes a Customer.io Journeys campaign triggered by the `user_created` CDP event).
- `Email#deliver_to_users` / `#deliver_to_test_emails` no-op at cutover (one-offs/newsletters are authored in the Customer.io workspace).
- Admin → Emails index shows a notice at cutover pointing composers to Customer.io (i18n: en/fr/pt).

## Behavior

- Key unset or flag not globally enabled: zero change anywhere.
- At cutover: drip/broadcast sending stops in Rails; `Email` records remain as history; transactional email (PRs 1–5) is unaffected.

## Deploy note

Build the Customer.io drip campaign (triggered off `user_created`, filtered on synced consent attributes) and any recurring newsletters in the CIO workspace **before** flipping the flag global.

## Testing

50 examples, 1 known pre-existing env failure. The cutover truth table is tested against real Flipper gates (global vs per-actor), not stubs. RuboCop/erb-lint clean on new lines.

https://claude.ai/code/session_01BmQuaEra1zTGjE1Dv2rNPw

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786806108&installation_id=139885019&pr_number=23627&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23627&signature=afc089ae1b9ddc5a3a171c64181e57fb5c635176ce8bb1b02979ae7c45f6d543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->