### PR TITLE
Fix liquid tag and story card styling override in organization README page

### DIFF
--- a/app/assets/stylesheets/ltags/GithubReadmeTag.scss
+++ b/app/assets/stylesheets/ltags/GithubReadmeTag.scss
@@ -139,13 +139,20 @@
 // ==========================================================================
 // Custom premium styling for the organization's README page
 // ==========================================================================
+$exclude-embeds: ':not([class*="ltag"] *):not(.crayons-story *):not(.bluesky-embed *)';
+
 .org-header-cover ~ #index-container .crayons-article__body {
   font-family: var(--ff-sans-serif, -apple-system, BlinkMacSystemFont, sans-serif);
   color: var(--body-color);
   line-height: 1.7;
   font-size: 1.05rem;
 
-  h1, h2, h3, h4, h5, h6 {
+  h1#{$exclude-embeds},
+  h2#{$exclude-embeds},
+  h3#{$exclude-embeds},
+  h4#{$exclude-embeds},
+  h5#{$exclude-embeds},
+  h6#{$exclude-embeds} {
     color: var(--body-color);
     font-weight: var(--fw-bold, 700);
     margin-top: 1.8em;
@@ -153,28 +160,29 @@
     line-height: 1.3;
   }
 
-  h1 {
+  h1#{$exclude-embeds} {
     font-size: 2rem;
     border-bottom: 1px solid var(--form-border);
     padding-bottom: 0.3em;
   }
 
-  h2 {
+  h2#{$exclude-embeds} {
     font-size: 1.5rem;
     border-bottom: 1px solid var(--form-border);
     padding-bottom: 0.3em;
   }
 
-  h3 {
+  h3#{$exclude-embeds} {
     font-size: 1.25rem;
   }
 
-  p, li {
+  p#{$exclude-embeds},
+  li#{$exclude-embeds} {
     margin-bottom: 1.2em;
     color: var(--card-color-secondary);
   }
 
-  a {
+  a#{$exclude-embeds} {
     color: var(--link-branded-color);
     text-decoration: underline;
     text-underline-offset: 3px;
@@ -185,12 +193,13 @@
     }
   }
 
-  ul, ol {
+  ul#{$exclude-embeds},
+  ol#{$exclude-embeds} {
     padding-left: 2em;
     margin-bottom: 1.5em;
   }
 
-  blockquote {
+  blockquote#{$exclude-embeds} {
     border-left: 4px solid var(--accent-brand);
     background-color: var(--card-secondary-bg);
     padding: var(--su-4) var(--su-5);
@@ -203,7 +212,7 @@
     }
   }
 
-  table {
+  table#{$exclude-embeds} {
     width: 100%;
     border-collapse: collapse;
     margin: 1.5em 0;
@@ -225,19 +234,20 @@
     }
   }
 
-  pre, code {
+  pre#{$exclude-embeds},
+  code#{$exclude-embeds} {
     font-family: var(--ff-monospace, monospace);
     border-radius: var(--radius);
   }
 
-  code {
+  code#{$exclude-embeds} {
     background-color: var(--card-secondary-bg);
     color: var(--accent-brand);
     padding: 0.2em 0.4em;
     font-size: 85%;
   }
 
-  pre {
+  pre#{$exclude-embeds} {
     background-color: var(--card-secondary-bg);
     border: 1px solid var(--form-border);
     padding: var(--su-4);


### PR DESCRIPTION
### Goal
Fix a styling regression on the custom organization profile/README page (introduced in #23623) where the premium page elements styling was applied to nested liquid tags (like `{% org_posts %}`) and embedded cards (`.crayons-story`).

### Solution
Exclude any descendants of liquid tags (classes matching `ltag`), embedded story cards (`.crayons-story`), and Bluesky embeds (`.bluesky-embed`) from the custom page layout rules via `:not()` CSS selectors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786809364&installation_id=139885019&pr_number=23629&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23629&signature=0acf7c7a002a799b8cc94124fff2f1790fc51c0a53064f3490409e55a2c08e2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->