### PR TITLE
Align stylesheets during InstantClick internal page transitions

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -157,6 +157,31 @@
     <%= yield %>
     <div id="runtime-banner-container"></div>
     <div id="i18n-translations" data-translations="<%= i18n_translations_for_javascript.to_json %>"></div>
+    <% if internal_navigation? %>
+      <script>
+        (function() {
+          var expectedStyles = {
+            "minimal": "<%= stylesheet_path('minimal') %>",
+            "views": "<%= stylesheet_path('views') %>",
+            "crayons": "<%= stylesheet_path('crayons') %>"
+          };
+          var qualifiers = ["main", "secondary"];
+          for (var name in expectedStyles) {
+            var expectedHref = expectedStyles[name];
+            for (var i = 0; i < qualifiers.length; i++) {
+              var id = qualifiers[i] + "-" + name + "-stylesheet";
+              var link = document.getElementById(id);
+              if (link) {
+                var currentHref = link.getAttribute('href');
+                if (currentHref && currentHref !== expectedHref) {
+                  link.setAttribute('href', expectedHref);
+                }
+              }
+            }
+          }
+        })();
+      </script>
+    <% end %>
   </div>
 </div>
 <% unless internal_navigation? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -166,7 +166,7 @@
             "crayons": "<%= stylesheet_path('crayons') %>"
           };
           var qualifiers = ["main", "secondary"];
-          for (var name in expectedStyles) {
+          Object.keys(expectedStyles).forEach(function(name) {
             var expectedHref = expectedStyles[name];
             for (var i = 0; i < qualifiers.length; i++) {
               var id = qualifiers[i] + "-" + name + "-stylesheet";
@@ -178,7 +178,7 @@
                 }
               }
             }
-          }
+          });
         })();
       </script>
     <% end %>

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -556,4 +556,25 @@ RSpec.describe "StoriesIndex" do
       end
     end
   end
+
+  describe "InstantClick stylesheet alignment" do
+    it "does not render the alignment script under normal navigation" do
+      get "/"
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("expectedStyles")
+      # Expect outer shell link tags
+      expect(response.body).to include('id="main-minimal-stylesheet"')
+    end
+
+    it "renders the alignment script with correct asset paths under internal navigation" do
+      get "/", params: { i: "i" }
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("expectedStyles")
+      expect(response.body).to include("minimal")
+      expect(response.body).to include("views")
+      expect(response.body).to include("crayons")
+      # Internal navigation excludes the outer layout, so the outer shell links should not be rendered
+      expect(response.body).not_to include('id="main-minimal-stylesheet"')
+    end
+  end
 end

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -570,9 +570,12 @@ RSpec.describe "StoriesIndex" do
       get "/", params: { i: "i" }
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("expectedStyles")
-      expect(response.body).to include("minimal")
-      expect(response.body).to include("views")
-      expect(response.body).to include("crayons")
+      expected_minimal = ActionController::Base.helpers.stylesheet_path("minimal")
+      expected_views = ActionController::Base.helpers.stylesheet_path("views")
+      expected_crayons = ActionController::Base.helpers.stylesheet_path("crayons")
+      expect(response.body).to include(%("minimal": "#{expected_minimal}"))
+      expect(response.body).to include(%("views": "#{expected_views}"))
+      expect(response.body).to include(%("crayons": "#{expected_crayons}"))
       # Internal navigation excludes the outer layout, so the outer shell links should not be rendered
       expect(response.body).not_to include('id="main-minimal-stylesheet"')
     end


### PR DESCRIPTION
This PR adds inline JS logic inside the internal portion of layout templates to check and align stylesheet URLs when navigating with InstantClick. This ensures page designs match and align properly regardless of the cache/deployment status of the shell vs. the page content.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786818886&installation_id=139885019&pr_number=23632&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23632&signature=3b25f6602a7332eb5759b6414017dbaf0c42c70d1ace48809d18c33c0e659f53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->