### PR TITLE
Fix flaky comment view datetime spec

### DIFF
--- a/spec/system/comments/user_views_a_comment_spec.rb
+++ b/spec/system/comments/user_views_a_comment_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Viewing a comment", js: true do
   let(:comment) { create(:comment, commentable: article, user: user) }
 
   before do
-    Timecop.freeze
+    Timecop.freeze(Time.current.change(usec: 0))
     ENV["DESYNC_TIMEZONE"] = "true"
     mock_user_tz = ActiveSupport::TimeZone[Zonebie.random_timezone].tzinfo.name
     ENV["TZ"] = mock_user_tz
@@ -23,6 +23,7 @@ RSpec.describe "Viewing a comment", js: true do
     it "contains a time tag with the correct value for the datetime attribute" do
       sign_in user
       visit comment.path
+      comment.reload
       timestamp = comment.decorate.published_timestamp
 
       expect(page).to have_selector(".comment-date time[datetime='#{timestamp}']")
@@ -31,6 +32,7 @@ RSpec.describe "Viewing a comment", js: true do
     it "shows the published date in the user's local time zone" do
       sign_in user
       visit comment.path
+      comment.reload
       date = comment.created_at.getlocal.strftime("%b %-d")
 
       expect(page).to have_selector(".comment-date time", text: date)
@@ -40,12 +42,13 @@ RSpec.describe "Viewing a comment", js: true do
   context "when a year has passed" do
     before do
       comment
-      Timecop.freeze(1.year.from_now)
+      Timecop.freeze(1.year.from_now.change(usec: 0))
     end
 
     it "shows the published date in the correct format" do
       sign_in user
       visit comment.path
+      comment.reload
       date = comment.created_at.getlocal.strftime("%b %-d '%y")
 
       expect(page).to have_selector(".comment-date time", text: date)
@@ -54,13 +57,14 @@ RSpec.describe "Viewing a comment", js: true do
 
   context "when the comment is edited and a year has passed" do
     before do
-      comment.update(body_markdown: "This message is edited.", edited_at: 1.day.from_now)
-      Timecop.freeze(1.year.from_now)
+      comment.update(body_markdown: "This message is edited.", edited_at: 1.day.from_now.change(usec: 0))
+      Timecop.freeze(1.year.from_now.change(usec: 0))
     end
 
     it "shows the edited date in the correct format" do
       sign_in user
       visit comment.path
+      comment.reload
       date = comment.edited_at.getlocal.strftime("%b %-d")
 
       expect(page).to have_content("Edited on #{date}")


### PR DESCRIPTION
Fixes the flaky test `Viewing a comment when viewing the comment date contains a time tag with the correct value for the datetime attribute` by freezing Timecop to whole seconds and reloading the comment record to sync timestamps.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786820932&installation_id=139885019&pr_number=23633&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23633&signature=71c8afbba37dbd5c8c63859eb2dee18ea648727ea62055919b05ea4982395fa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->