### PR TITLE
Implement custom organization pages, styling, custom domain resolutio…

### DIFF
--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -31,6 +31,7 @@ var instantClick
     , $isPreloading = false
     , $isWaitingForCompletion = false
     , $trackedAssets = []
+    , $keepScrollPosition = false
 
   // Variables defined by public functions
     , $preloadOnMousedown
@@ -131,6 +132,8 @@ var instantClick
       document.getElementById('search-input').value = ''
       searchTypeahead.classList.add('hidden');
     }
+    var currentScrollY = window.pageYOffset
+
     document.body.replaceChild(body, pageContentDiv)
 
     var prog = document.getElementById("navigation-progress");
@@ -159,9 +162,13 @@ var instantClick
           hashElem = hashElem.offsetParent
         }
       }
-      if (!samePage){
+      if ($keepScrollPosition) {
+        scrollTo(0, currentScrollY)
+      }
+      else if (!samePage && !$keepScrollPosition){
         scrollTo(0, offset)
       }
+      $keepScrollPosition = false
 
 
       $currentLocationWithoutHash = removeHash(newUrl)
@@ -295,6 +302,7 @@ var instantClick
       if (e.which > 1 || e.metaKey || e.ctrlKey) { // Opening in new tab
         return
       }
+      $keepScrollPosition = a.hasAttribute('data-instant-keep-scroll')
       display(a.href);
       e.preventDefault();
     }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -482,7 +482,7 @@ class ApplicationController < ActionController::Base
     return unless request.get? || request.head?
     return unless request.format.html?
 
-    if controller_name == "stories" && (action_name.in?(%w[custom_domain_index custom_domain_show]) || params[:page_suffix].present?)
+    if controller_name == "stories" && (action_name.in?(%w[custom_domain_index custom_domain_show]) || (action_name == "index" && params[:page_suffix].present?))
       return
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -482,7 +482,7 @@ class ApplicationController < ActionController::Base
     return unless request.get? || request.head?
     return unless request.format.html?
 
-    if controller_name == "stories" && action_name.in?(%w[custom_domain_index custom_domain_show])
+    if controller_name == "stories" && (action_name.in?(%w[custom_domain_index custom_domain_show]) || params[:page_suffix].present?)
       return
     end
 

--- a/app/controllers/organization_pages_controller.rb
+++ b/app/controllers/organization_pages_controller.rb
@@ -1,0 +1,85 @@
+class OrganizationPagesController < ApplicationController
+  include OrganizationAdminScoped
+  before_action :set_page, only: %i[edit update destroy]
+  before_action :check_pages_feature
+
+  def index
+    @pages = @organization.pages.order(:created_at)
+  end
+
+  def new
+    @page = @organization.pages.build(template: "full_within_layout")
+  end
+
+  def create
+    is_first_page = !@organization.pages.exists?
+    @page = @organization.pages.build(page_params)
+    @page.template = "full_within_layout"
+    
+    if is_first_page
+      @page.slug = "#{@organization.slug}/readme"
+      @page.title = @organization.name if @page.title.blank?
+    elsif params.dig(:page, :slug_suffix).present?
+      suffix = params[:page][:slug_suffix].to_s.strip.downcase.gsub(/[^a-z0-9\-]/, "-").gsub(/-+/, "-").strip
+      @page.slug = "#{@organization.slug}/#{suffix}"
+    end
+
+    @page.description = @organization.summary.presence || @organization.name if @page.description.blank?
+
+    if @page.save
+      flash[:settings_notice] = I18n.t("views.organization_settings.pages.created")
+      redirect_to organization_pages_path(@organization.slug)
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    @page.assign_attributes(page_params)
+    
+    if @page.slug.end_with?("/readme")
+      @page.slug = "#{@organization.slug}/readme"
+    elsif params.dig(:page, :slug_suffix).present?
+      suffix = params[:page][:slug_suffix].to_s.strip.downcase.gsub(/[^a-z0-9\-]/, "-").gsub(/-+/, "-").strip
+      @page.slug = "#{@organization.slug}/#{suffix}"
+    end
+
+    if @page.save
+      flash[:settings_notice] = I18n.t("views.organization_settings.pages.updated")
+      redirect_to organization_pages_path(@organization.slug)
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @page.destroy
+    flash[:settings_notice] = I18n.t("views.organization_settings.pages.deleted")
+    redirect_to organization_pages_path(@organization.slug)
+  end
+
+  def preview
+    renderer = ContentRenderer.new(params[:body_markdown].to_s, source: @organization, user: current_user)
+    result = renderer.process
+    render json: { processed_html: result.processed_html }
+  rescue ContentRenderer::ContentParsingError => e
+    render json: { error: e.message }, status: :unprocessable_entity
+  end
+
+  private
+
+  def set_page
+    @page = @organization.pages.find(params[:id])
+  end
+
+  def check_pages_feature
+    not_found unless FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[@organization])
+  end
+
+  def page_params
+    params.require(:page).permit(:title, :body_markdown, :description)
+  end
+end

--- a/app/controllers/organization_pages_controller.rb
+++ b/app/controllers/organization_pages_controller.rb
@@ -1,7 +1,7 @@
 class OrganizationPagesController < ApplicationController
   include OrganizationAdminScoped
-  before_action :set_page, only: %i[edit update destroy]
   before_action :check_pages_feature
+  before_action :set_page, only: %i[edit update destroy]
 
   def index
     @pages = @organization.pages.order(:created_at)
@@ -19,8 +19,12 @@ class OrganizationPagesController < ApplicationController
     if is_first_page
       @page.slug = "#{@organization.slug}/readme"
       @page.title = @organization.name if @page.title.blank?
-    elsif params.dig(:page, :slug_suffix).present?
-      suffix = params[:page][:slug_suffix].to_s.strip.downcase.gsub(/[^a-z0-9\-]/, "-").gsub(/-+/, "-").strip
+    else
+      suffix = params.dig(:page, :slug_suffix).to_s.strip.downcase.gsub(/[^a-z0-9\-]/, "-").gsub(/-+/, "-").gsub(/\A-+|-+\z/, "")
+      if suffix.blank?
+        @page.errors.add(:slug, "suffix is required and must contain alphanumeric characters or hyphens")
+        return render :new, status: :unprocessable_entity
+      end
       @page.slug = "#{@organization.slug}/#{suffix}"
     end
 
@@ -30,7 +34,7 @@ class OrganizationPagesController < ApplicationController
       flash[:settings_notice] = I18n.t("views.organization_settings.pages.created")
       redirect_to organization_pages_path(@organization.slug)
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -42,8 +46,12 @@ class OrganizationPagesController < ApplicationController
     
     if @page.slug.end_with?("/readme")
       @page.slug = "#{@organization.slug}/readme"
-    elsif params.dig(:page, :slug_suffix).present?
-      suffix = params[:page][:slug_suffix].to_s.strip.downcase.gsub(/[^a-z0-9\-]/, "-").gsub(/-+/, "-").strip
+    else
+      suffix = params.dig(:page, :slug_suffix).to_s.strip.downcase.gsub(/[^a-z0-9\-]/, "-").gsub(/-+/, "-").gsub(/\A-+|-+\z/, "")
+      if suffix.blank?
+        @page.errors.add(:slug, "suffix is required and must contain alphanumeric characters or hyphens")
+        return render :edit, status: :unprocessable_entity
+      end
       @page.slug = "#{@organization.slug}/#{suffix}"
     end
 
@@ -51,7 +59,7 @@ class OrganizationPagesController < ApplicationController
       flash[:settings_notice] = I18n.t("views.organization_settings.pages.updated")
       redirect_to organization_pages_path(@organization.slug)
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/organization_settings_controller.rb
+++ b/app/controllers/organization_settings_controller.rb
@@ -52,13 +52,8 @@ class OrganizationSettingsController < ApplicationController
       return
     end
 
-    raw_page_markdown = params.dig(:organization, :page_markdown)
-
     was_verified = @organization.verified?
     if @organization.update(organization_params.merge(profile_updated_at: Time.current))
-      if FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[@organization])
-        sync_org_page(raw_page_markdown) if params[:organization].key?(:page_markdown)
-      end
       @organization.users.touch_all(:organization_info_updated_at)
       notice = I18n.t("organizations_controller.updated")
       if was_verified && !@organization.verified?
@@ -82,23 +77,6 @@ class OrganizationSettingsController < ApplicationController
     )
   end
 
-  def sync_org_page(markdown)
-    if markdown.present?
-      page = @organization.main_page || @organization.pages.new
-      page.assign_attributes(
-        title: @organization.name,
-        body_markdown: markdown,
-        description: @organization.summary.presence || @organization.name,
-        slug: "#{@organization.slug}/readme",
-        template: "full_within_layout",
-      )
-      page.save!
-    elsif @organization.main_page
-      @organization.main_page.destroy!
-    end
-  rescue ActiveRecord::RecordInvalid, StandardError => e
-    flash[:error] = I18n.t("organizations_controller.page_save_error", message: e.message)
-  end
 
   def organization_params
     permitted = params.require(:organization).permit(

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -54,6 +54,12 @@ class StoriesController < ApplicationController
       ensure
         RequestStore.store[:subforem_id] = previous_subforem_id
       end
+    elsif FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[@organization]) &&
+          (@org_page = @organization.pages.find_by(slug: "#{@organization.slug}/#{params[:slug]}"))
+      params[:page_suffix] = params[:slug]
+      handle_organization_index
+      return if performed?
+      render "stories/index"
     else
       not_found
     end
@@ -217,7 +223,16 @@ class StoriesController < ApplicationController
 
     main_page = @organization.main_page
     has_readme = main_page.present? && FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[@organization])
-    is_readme = has_readme && params[:mode] != "all-posts"
+    @org_page = nil
+    if params[:page_suffix].present?
+      if FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[@organization])
+        @org_page = @organization.pages.find_by(slug: "#{@organization.slug}/#{params[:page_suffix]}")
+      end
+      not_found if @org_page.nil?
+    elsif has_readme && params[:mode] != "all-posts"
+      @org_page = main_page
+    end
+    is_readme = @org_page.present?
     @stories = ArticleDecorator.decorate_collection(@organization.articles.published.from_subforem
       .includes(:distinct_reaction_categories, :subforem)
       .limited_column_select
@@ -266,9 +281,10 @@ class StoriesController < ApplicationController
     set_organization_json_ld
     set_surrogate_key_header @organization.record_key
 
+    @cover_image_url = @organization.cover_image_url if @organization.cover_image.present?
+
     if is_readme
-      @readme_html = main_page.processed_html
-      @cover_image_url = @organization.cover_image_url if @organization.cover_image.present?
+      @readme_html = @org_page.processed_html
       @org_readme_show = true
       render template: "organizations/show_readme"
     else
@@ -340,6 +356,7 @@ class StoriesController < ApplicationController
   end
 
   def redirect_if_inactive_in_subforem_for_organization
+    return if @org_page.present?
     return if request.env["forem.custom_domain_org"].present?
     return unless @stories.none? &&
       RequestStore.store[:subforem_id] != RequestStore.store[:default_subforem_id]

--- a/app/javascript/packs/organizationDropdown.js
+++ b/app/javascript/packs/organizationDropdown.js
@@ -1,14 +1,10 @@
 import { initializeDropdown } from '@utilities/dropdownUtils';
-import { waitOnBaseData } from '@utilities/waitOnBaseData';
 
 function initDropdown() {
   const profileDropdownDiv = document.querySelector('.profile-dropdown');
+  if (!profileDropdownDiv) return;
 
   if (profileDropdownDiv.dataset.dropdownInitialized === 'true') {
-    return;
-  }
-
-  if (!profileDropdownDiv) {
     return;
   }
 
@@ -21,7 +17,9 @@ function initDropdown() {
   const reportAbuseLink = profileDropdownDiv.querySelector(
     '.report-abuse-link-wrapper',
   );
-  reportAbuseLink.innerHTML = `<a href="${reportAbuseLink.dataset.path}" class="crayons-link crayons-link--block">Report Abuse</a>`;
+  if (reportAbuseLink) {
+    reportAbuseLink.innerHTML = `<a href="${reportAbuseLink.dataset.path}" class="crayons-link crayons-link--block">Report Abuse</a>`;
+  }
 
   profileDropdownDiv.dataset.dropdownInitialized = true;
 }
@@ -52,6 +50,77 @@ function initHeaderCtaDropdown() {
   });
 }
 
+function initTabsMoreDropdown() {
+  const trigger = document.getElementById('org-tabs-more-trigger');
+  const menu = document.getElementById('org-tabs-more-menu');
+  if (!trigger || !menu) return;
 
-initDropdown();
-initHeaderCtaDropdown();
+  initializeDropdown({
+    triggerElementId: 'org-tabs-more-trigger',
+    dropdownContentId: 'org-tabs-more-menu',
+  });
+}
+
+function handleTabsOverflow() {
+  const nav = document.getElementById('org-tab-nav');
+  if (!nav) return;
+
+  const container = nav.querySelector('.org-custom-tabs-container');
+  const dropdownMenu = nav.querySelector('#org-tabs-more-menu');
+  const dropdownTrigger = nav.querySelector('.org-tabs-more-dropdown');
+  
+  if (!container || !dropdownMenu || !dropdownTrigger) return;
+
+  // Move all custom page tabs from dropdown back to visible container
+  const dropdownItems = Array.from(dropdownMenu.children);
+  dropdownItems.forEach(item => {
+    item.classList.remove('crayons-link', 'crayons-link--block');
+    item.classList.add('crayons-tabs__item');
+    container.appendChild(item);
+  });
+
+  dropdownTrigger.style.display = 'none';
+
+  // Pop tabs into the dropdown while we are overflowing and have more than 1 tab (Showcase must stay)
+  let attempts = 0;
+  const maxAttempts = container.children.length;
+
+  while (container.scrollWidth > container.clientWidth && container.children.length > 1 && attempts < maxAttempts) {
+    dropdownTrigger.style.display = 'inline-block';
+    const lastChild = container.lastElementChild;
+    if (!lastChild) break;
+
+    // Transform to dropdown item styling
+    lastChild.classList.remove('crayons-tabs__item');
+    lastChild.classList.add('crayons-link', 'crayons-link--block');
+
+    // Prepend to dropdown menu to keep original order
+    dropdownMenu.insertBefore(lastChild, dropdownMenu.firstChild);
+    attempts++;
+  }
+}
+
+function initTabs() {
+  initTabsMoreDropdown();
+  handleTabsOverflow();
+}
+
+function run() {
+  initDropdown();
+  initHeaderCtaDropdown();
+  initTabs();
+}
+
+if (document.readyState !== 'loading') {
+  run();
+} else {
+  document.addEventListener('DOMContentLoaded', run);
+}
+
+// Recalculate on resize
+window.addEventListener('resize', handleTabsOverflow);
+
+// Handle InstantClick page transition
+if (window.InstantClick) {
+  window.InstantClick.on('change', run);
+}

--- a/app/javascript/packs/organizationDropdown.js
+++ b/app/javascript/packs/organizationDropdown.js
@@ -24,10 +24,34 @@ function initDropdown() {
   profileDropdownDiv.dataset.dropdownInitialized = true;
 }
 
+function handleCtaOutsideClick(e) {
+  const toggle = document.getElementById('header-cta-toggle');
+  const menu = document.getElementById('header-cta-menu');
+  if (!toggle || !menu || menu.style.display === 'none') return;
+
+  if (!toggle.contains(e.target) && !menu.contains(e.target)) {
+    menu.style.display = 'none';
+    toggle.setAttribute('aria-expanded', 'false');
+  }
+}
+
+function handleCtaEscapeKey(e) {
+  if (e.key === 'Escape') {
+    const toggle = document.getElementById('header-cta-toggle');
+    const menu = document.getElementById('header-cta-menu');
+    if (!toggle || !menu || menu.style.display === 'none') return;
+
+    menu.style.display = 'none';
+    toggle.setAttribute('aria-expanded', 'false');
+  }
+}
+
 function initHeaderCtaDropdown() {
   const toggle = document.getElementById('header-cta-toggle');
   const menu = document.getElementById('header-cta-menu');
   if (!toggle || !menu) return;
+
+  if (toggle.dataset.ctaInitialized === 'true') return;
 
   toggle.addEventListener('click', () => {
     const isOpen = menu.style.display !== 'none';
@@ -35,19 +59,13 @@ function initHeaderCtaDropdown() {
     toggle.setAttribute('aria-expanded', String(!isOpen));
   });
 
-  document.addEventListener('click', (e) => {
-    if (!toggle.contains(e.target) && !menu.contains(e.target)) {
-      menu.style.display = 'none';
-      toggle.setAttribute('aria-expanded', 'false');
-    }
-  });
+  if (!window._headerCtaListenersRegistered) {
+    document.addEventListener('click', handleCtaOutsideClick);
+    document.addEventListener('keydown', handleCtaEscapeKey);
+    window._headerCtaListenersRegistered = true;
+  }
 
-  document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape') {
-      menu.style.display = 'none';
-      toggle.setAttribute('aria-expanded', 'false');
-    }
-  });
+  toggle.dataset.ctaInitialized = 'true';
 }
 
 function initTabsMoreDropdown() {
@@ -118,9 +136,13 @@ if (document.readyState !== 'loading') {
 }
 
 // Recalculate on resize
-window.addEventListener('resize', handleTabsOverflow);
+if (!window._orgTabsResizeRegistered) {
+  window.addEventListener('resize', handleTabsOverflow);
+  window._orgTabsResizeRegistered = true;
+}
 
 // Handle InstantClick page transition
-if (window.InstantClick) {
+if (window.InstantClick && !window._orgDropdownChangeRegistered) {
   window.InstantClick.on('change', run);
+  window._orgDropdownChangeRegistered = true;
 }

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -186,6 +186,7 @@ class Page < ApplicationRecord
   end
 
   def validate_slug_uniqueness
+    return if slug.blank?
     # Custom cross-model validation to allow for the same slug in different subforems for pages
     return if Page.where(slug: slug).exists? && Page.where(slug: slug, subforem_id: subforem_id).where.not(id: id).none?
 

--- a/app/views/organization_pages/_form.html.erb
+++ b/app/views/organization_pages/_form.html.erb
@@ -1,0 +1,142 @@
+<style>
+  #org-page-editor-root .crayons-article-form__content {
+    border: 1px solid var(--base-20);
+    border-radius: var(--radius);
+    min-height: 480px;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+  #org-page-editor-root .crayons-article-form__header {
+    border-bottom: 1px solid var(--base-20);
+    padding: var(--su-1) var(--su-2);
+    background: var(--card-bg);
+    border-radius: var(--radius) var(--radius) 0 0;
+  }
+  #org-page-editor-root .crayons-article-form__header--fixed {
+    z-index: 100;
+    border-radius: 0;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  }
+  #org-page-editor-root .crayons-article-form__header--placeholder {
+    height: 44px;
+  }
+  #org-page-editor-root .crayons-tabs {
+    margin-left: 0;
+  }
+  #org-page-editor-root .crayons-tabs__list {
+    width: auto;
+  }
+  #org-page-editor-root .crayons-tabs__list li {
+    width: auto;
+  }
+  #org-page-editor-root .crayons-tabs__item {
+    width: auto;
+    white-space: nowrap;
+  }
+  #org-page-editor-root .crayons-article-form__body {
+    flex: 1;
+  }
+  #org-page-editor-root #org_page_markdown {
+    min-height: 400px;
+  }
+  #org-page-editor-root .crayons-article__body .crayons-textfield {
+    min-height: 0;
+    font-size: var(--fs-base);
+  }
+  #org-page-editor-root .ltag-quote {
+    min-width: 0;
+  }
+</style>
+
+<%= form_for @page, url: url, method: method, html: { class: "grid gap-6" } do |f| %>
+  <% if @page.errors.any? %>
+    <div class="crayons-notice crayons-notice--danger">
+      <% @page.errors.full_messages.each do |msg| %>
+        <p><%= msg %></p>
+      <% end %>
+    </div>
+  <% end %>
+
+  <div class="crayons-card crayons-card--content-rows">
+    <h2><%= is_new ? "Create a new page" : "Edit page" %></h2>
+
+    <div class="crayons-field">
+      <%= f.label :title, class: "crayons-field__label" %>
+      <%= f.text_field :title, class: "crayons-textfield", required: true, placeholder: "e.g. About Us" %>
+    </div>
+
+    <% if @page.slug.blank? || !@page.slug.end_with?("/readme") %>
+      <div class="crayons-field">
+        <%= label_tag "page[slug_suffix]", "Slug suffix", class: "crayons-field__label" %>
+        <div class="flex items-center">
+          <span class="fs-base color-base-60 mr-2"><%= request.host %>/<%= @organization.slug %>/p/</span>
+          <%= text_field_tag "page[slug_suffix]", @page.slug&.sub(%r{\A#{@organization.slug}/}, ""), class: "crayons-textfield", required: true, pattern: "[a-z0-9\\-]+", placeholder: "e.g. about" %>
+        </div>
+        <p class="crayons-field__description">Only lowercase letters, numbers, and hyphens (e.g. "about-us"). Accessible via the profile tab.</p>
+      </div>
+    <% else %>
+      <div class="crayons-field">
+        <label class="crayons-field__label">Slug suffix</label>
+        <div class="flex items-center">
+          <span class="fs-base color-base-60 mr-2"><%= request.host %>/<%= @organization.slug %>/</span>
+          <input type="text" class="crayons-textfield" value="readme" disabled />
+        </div>
+        <p class="crayons-field__description">This is the Showcase (default) page, so the slug suffix is fixed to "readme".</p>
+      </div>
+    <% end %>
+
+    <div class="crayons-field">
+      <%= f.label :description, class: "crayons-field__label" %>
+      <%= f.text_field :description, class: "crayons-textfield", placeholder: "Short description for SEO and sharing..." %>
+    </div>
+
+    <div class="crayons-field">
+      <%= f.label :body_markdown, "Page Content (Markdown)", class: "crayons-field__label" %>
+
+      <% if @page.slug.blank? || @page.slug.end_with?("/readme") %>
+        <div class="crayons-notice crayons-notice--info mb-4">
+          <p class="fw-medium mb-1"><%= t("views.organization_settings.page.default_notice") %></p>
+          <p class="fs-s color-base-70 mb-2"><%= t("views.organization_settings.page.default_explanation") %></p>
+          <details>
+            <summary class="cursor-pointer fw-medium fs-s crayons-link"><%= t("views.organization_settings.page.default_example_toggle") %></summary>
+            <pre class="crayons-card crayons-card--secondary p-3 mt-2 ff-monospace fs-s" style="white-space: pre-wrap;"><%= t("views.organization_settings.page.default_example", slug: @organization.slug) %></pre>
+          </details>
+        </div>
+      <% end %>
+
+      <div id="org-page-editor-root"
+           data-default-value="<%= @page.body_markdown %>"
+           data-textarea-name="page[body_markdown]"
+           data-preview-url="<%= organization_pages_preview_path(@organization.slug) %>">
+        <%# Fallback layout mimicking the JS component to prevent FOUC %>
+        <div class="crayons-article-form__content">
+          <div class="crayons-article-form__header">
+            <nav class="crayons-article-form__tabs crayons-tabs ml-auto" aria-label="View post modes">
+              <ul class="crayons-tabs__list">
+                <li>
+                  <button data-text="Edit" class="crayons-tabs__item crayons-tabs__item--current" type="button" aria-current="page">Edit</button>
+                </li>
+                <li>
+                  <button data-text="Preview" class="crayons-tabs__item" type="button">Preview</button>
+                </li>
+              </ul>
+            </nav>
+          </div>
+          <div class="crayons-article-form__body drop-area text-padding">
+            <div class="crayons-article-form__cover" role="presentation"></div>
+            <div class="crayons-article-form__title"></div>
+            <%= f.text_area :body_markdown, id: "org_page_markdown", class: "crayons-textfield crayons-textfield--ghost crayons-article-form__body__field ff-monospace fs-l h-100", style: "min-height: 400px;", placeholder: t("views.organization_settings.page.readme_placeholder") %>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex gap-2 mt-4">
+      <button type="submit" class="crayons-btn"><%= t("views.organization_settings.page.save") %></button>
+      <%= link_to "Cancel", organization_pages_path(@organization.slug), class: "crayons-btn crayons-btn--secondary" %>
+    </div>
+  </div>
+<% end %>
+
+<%= javascript_include_tag "orgPageEditor", defer: true %>

--- a/app/views/organization_pages/_form.html.erb
+++ b/app/views/organization_pages/_form.html.erb
@@ -59,40 +59,40 @@
   <% end %>
 
   <div class="crayons-card crayons-card--content-rows">
-    <h2><%= is_new ? "Create a new page" : "Edit page" %></h2>
+    <h2><%= is_new ? t("views.organization_settings.pages.create_heading") : t("views.organization_settings.pages.edit_heading") %></h2>
 
     <div class="crayons-field">
-      <%= f.label :title, class: "crayons-field__label" %>
+      <%= f.label :title, t("views.organization_settings.pages.title"), class: "crayons-field__label" %>
       <%= f.text_field :title, class: "crayons-textfield", required: true, placeholder: "e.g. About Us" %>
     </div>
 
     <% if @page.slug.blank? || !@page.slug.end_with?("/readme") %>
       <div class="crayons-field">
-        <%= label_tag "page[slug_suffix]", "Slug suffix", class: "crayons-field__label" %>
+        <%= label_tag "page[slug_suffix]", t("views.organization_settings.pages.slug"), class: "crayons-field__label" %>
         <div class="flex items-center">
           <span class="fs-base color-base-60 mr-2"><%= request.host %>/<%= @organization.slug %>/p/</span>
           <%= text_field_tag "page[slug_suffix]", @page.slug&.sub(%r{\A#{@organization.slug}/}, ""), class: "crayons-textfield", required: true, pattern: "[a-z0-9\\-]+", placeholder: "e.g. about" %>
         </div>
-        <p class="crayons-field__description">Only lowercase letters, numbers, and hyphens (e.g. "about-us"). Accessible via the profile tab.</p>
+        <p class="crayons-field__description"><%= t("views.organization_settings.pages.slug_help") %></p>
       </div>
     <% else %>
       <div class="crayons-field">
-        <label class="crayons-field__label">Slug suffix</label>
+        <label class="crayons-field__label"><%= t("views.organization_settings.pages.slug") %></label>
         <div class="flex items-center">
           <span class="fs-base color-base-60 mr-2"><%= request.host %>/<%= @organization.slug %>/</span>
           <input type="text" class="crayons-textfield" value="readme" disabled />
         </div>
-        <p class="crayons-field__description">This is the Showcase (default) page, so the slug suffix is fixed to "readme".</p>
+        <p class="crayons-field__description"><%= t("views.organization_settings.pages.showcase_slug_help") %></p>
       </div>
     <% end %>
 
     <div class="crayons-field">
-      <%= f.label :description, class: "crayons-field__label" %>
-      <%= f.text_field :description, class: "crayons-textfield", placeholder: "Short description for SEO and sharing..." %>
+      <%= f.label :description, t("views.organization_settings.pages.description"), class: "crayons-field__label" %>
+      <%= f.text_field :description, class: "crayons-textfield", placeholder: t("views.organization_settings.pages.description_placeholder") %>
     </div>
 
     <div class="crayons-field">
-      <%= f.label :body_markdown, "Page Content (Markdown)", class: "crayons-field__label" %>
+      <%= f.label :body_markdown, t("views.organization_settings.pages.content_label"), class: "crayons-field__label" %>
 
       <% if @page.slug.blank? || @page.slug.end_with?("/readme") %>
         <div class="crayons-notice crayons-notice--info mb-4">
@@ -115,10 +115,10 @@
             <nav class="crayons-article-form__tabs crayons-tabs ml-auto" aria-label="View post modes">
               <ul class="crayons-tabs__list">
                 <li>
-                  <button data-text="Edit" class="crayons-tabs__item crayons-tabs__item--current" type="button" aria-current="page">Edit</button>
+                  <button data-text="<%= t("views.organization_settings.pages.edit") %>" class="crayons-tabs__item crayons-tabs__item--current" type="button" aria-current="page"><%= t("views.organization_settings.pages.edit") %></button>
                 </li>
                 <li>
-                  <button data-text="Preview" class="crayons-tabs__item" type="button">Preview</button>
+                  <button data-text="<%= t("views.organization_settings.page.preview") %>" class="crayons-tabs__item" type="button"><%= t("views.organization_settings.page.preview") %></button>
                 </li>
               </ul>
             </nav>
@@ -134,7 +134,7 @@
 
     <div class="flex gap-2 mt-4">
       <button type="submit" class="crayons-btn"><%= t("views.organization_settings.page.save") %></button>
-      <%= link_to "Cancel", organization_pages_path(@organization.slug), class: "crayons-btn crayons-btn--secondary" %>
+      <%= link_to t("views.organization_settings.pages.cancel"), organization_pages_path(@organization.slug), class: "crayons-btn crayons-btn--secondary" %>
     </div>
   </div>
 <% end %>

--- a/app/views/organization_pages/edit.html.erb
+++ b/app/views/organization_pages/edit.html.erb
@@ -1,0 +1,10 @@
+<% title t("views.organization_settings.pages.edit_page") %>
+
+<div class="crayons-layout crayons-layout--limited-l pt-7">
+  <div class="flex items-center justify-between mb-6">
+    <h1 class="crayons-title"><%= t("views.organization_settings.pages.edit_page") %></h1>
+    <%= link_to "&larr; Back to pages".html_safe, organization_pages_path(@organization.slug), class: "crayons-btn crayons-btn--secondary" %>
+  </div>
+
+  <%= render "form", url: update_organization_page_path(@organization.slug, @page), method: :patch, is_new: false %>
+</div>

--- a/app/views/organization_pages/index.html.erb
+++ b/app/views/organization_pages/index.html.erb
@@ -1,0 +1,51 @@
+<% title t("views.organization_settings.pages.heading") %>
+
+<div class="crayons-layout crayons-layout--limited-l pt-7">
+  <div class="flex items-center justify-between mb-6">
+    <h1 class="crayons-title"><%= t("views.organization_settings.pages.heading") %></h1>
+    <div class="flex gap-2">
+      <%= link_to "&larr; #{t("views.organization_settings.lead_forms.back_to_settings")}".html_safe, organization_settings_path(@organization.slug), class: "crayons-btn crayons-btn--secondary" %>
+      <%= link_to t("views.organization_settings.pages.new_page"), new_organization_page_path(@organization.slug), class: "crayons-btn" %>
+    </div>
+  </div>
+
+  <% if @pages.any? %>
+    <div class="crayons-card crayons-card--content-rows">
+      <h2>Your Pages</h2>
+      <div class="grid gap-4 mt-4">
+        <% @pages.each do |page| %>
+          <% 
+            is_showcase = page.slug.end_with?("/readme")
+            suffix = page.slug.split("/").last
+          %>
+          <div class="crayons-card crayons-card--secondary p-4 flex items-start justify-between gap-4">
+            <div class="flex-1">
+              <div class="flex items-center gap-2 mb-1">
+                <h3 class="crayons-subtitle-2"><%= page.title %></h3>
+                <%
+                  is_custom_domain = request.env["forem.custom_domain_org"].present?
+                  page_url = is_showcase ? (is_custom_domain ? "/" : "/#{@organization.slug}") : (is_custom_domain ? "/p/#{suffix}" : "/#{@organization.slug}/p/#{suffix}")
+                %>
+                <% if is_showcase %>
+                  <%= link_to t("views.organization_settings.pages.showcase"), page_url, target: "_blank", class: "crayons-tag crayons-tag--monochrome", style: "background: var(--accent-brand-a10); color: var(--accent-brand); text-decoration: none;" %>
+                <% else %>
+                  <%= link_to "/#{suffix}", page_url, target: "_blank", class: "crayons-tag crayons-tag--monochrome", style: "font-family: var(--ff-monospace); text-decoration: none;" %>
+                <% end %>
+              </div>
+              <p class="fs-s color-base-60 mb-0"><%= page.description %></p>
+            </div>
+            <div class="flex gap-2 shrink-0">
+              <%= link_to t("views.organization_settings.pages.edit"), edit_organization_page_path(@organization.slug, page), class: "crayons-btn crayons-btn--secondary crayons-btn--xs" %>
+              <%= button_to t("views.organization_settings.lead_forms.delete"), organization_page_path(@organization.slug, page), method: :delete, data: { confirm: t("views.organization_settings.pages.confirm_delete") }, class: "crayons-btn crayons-btn--danger crayons-btn--xs" %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% else %>
+    <div class="crayons-card p-8 text-center color-base-60">
+      <p><%= t("views.organization_settings.pages.no_pages") %></p>
+      <%= link_to t("views.organization_settings.pages.new_page"), new_organization_page_path(@organization.slug), class: "crayons-btn mt-4" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/organization_pages/index.html.erb
+++ b/app/views/organization_pages/index.html.erb
@@ -11,7 +11,7 @@
 
   <% if @pages.any? %>
     <div class="crayons-card crayons-card--content-rows">
-      <h2>Your Pages</h2>
+      <h2><%= t("views.organization_settings.pages.your_pages") %></h2>
       <div class="grid gap-4 mt-4">
         <% @pages.each do |page| %>
           <% 

--- a/app/views/organization_pages/new.html.erb
+++ b/app/views/organization_pages/new.html.erb
@@ -1,0 +1,10 @@
+<% title t("views.organization_settings.pages.new_page") %>
+
+<div class="crayons-layout crayons-layout--limited-l pt-7">
+  <div class="flex items-center justify-between mb-6">
+    <h1 class="crayons-title"><%= t("views.organization_settings.pages.new_page") %></h1>
+    <%= link_to "&larr; Back to pages".html_safe, organization_pages_path(@organization.slug), class: "crayons-btn crayons-btn--secondary" %>
+  </div>
+
+  <%= render "form", url: organization_pages_path(@organization.slug), method: :post, is_new: true %>
+</div>

--- a/app/views/organization_settings/edit.html.erb
+++ b/app/views/organization_settings/edit.html.erb
@@ -76,59 +76,9 @@
     min-width: min(100%, 200px);
   }
 
-  #org-page-editor-root .crayons-article-form__content {
-    border: 1px solid var(--base-20);
-    border-radius: var(--radius);
-    min-height: 480px;
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-  }
-  #org-page-editor-root .crayons-article-form__header {
-    border-bottom: 1px solid var(--base-20);
-    padding: var(--su-1) var(--su-2);
-    background: var(--card-bg);
-    border-radius: var(--radius) var(--radius) 0 0;
-  }
-  #org-page-editor-root .crayons-article-form__header--fixed {
-    z-index: 100;
-    border-radius: 0;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  }
-  #org-page-editor-root .crayons-article-form__header--placeholder {
-    height: 44px;
-  }
-  #org-page-editor-root .crayons-tabs {
-    margin-left: 0;
-  }
-  #org-page-editor-root .crayons-tabs__list {
-    width: auto;
-  }
-  #org-page-editor-root .crayons-tabs__list li {
-    width: auto;
-  }
-  #org-page-editor-root .crayons-tabs__item {
-    width: auto;
-    white-space: nowrap;
-  }
-  #org-page-editor-root .crayons-article-form__body {
-    flex: 1;
-  }
-  #org-page-editor-root #org_page_markdown {
-    min-height: 400px;
-  }
-  /* Reset lead form inputs inside the preview so they don't inherit the editor textarea sizing */
-  #org-page-editor-root .crayons-article__body .crayons-textfield {
-    min-height: 0;
-    font-size: var(--fs-base);
-  }
-  /* Give quote cards room to breathe in the narrow preview context */
-  #org-page-editor-root .ltag-quote {
-    min-width: 0;
-  }
-  #section-page,
   #section-profile,
   #section-social,
+  #section-pages-list,
   #section-header-cta,
   #section-sidebar-cta,
   #section-members,
@@ -171,11 +121,11 @@
     <%# ── Sidebar Navigation ── %>
     <aside class="org-settings-sidebar">
       <nav id="org-settings-nav">
-        <% if FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[@organization]) %>
-          <a href="#section-page"><%= t("views.organization_settings.page.heading") %></a>
-        <% end %>
         <a href="#section-profile"><%= t("views.settings.org.admin.details") %></a>
         <a href="#section-social"><%= t("views.organization_settings.social_links.heading") %></a>
+        <% if FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[@organization]) %>
+          <a href="#section-pages-list"><%= t("views.organization_settings.pages.heading") %></a>
+        <% end %>
         <a href="#section-header-cta"><%= t("views.organization_settings.header_cta.heading") %></a>
         <a href="#section-sidebar-cta"><%= t("views.settings.org.admin.cta") %></a>
         <a href="#section-members"><%= t("views.settings.org.admin.members") %></a>
@@ -202,67 +152,7 @@
     <div class="grid gap-6">
 
       <%= form_for @organization, url: organization_settings_path(@organization.slug), method: :patch, html: { id: "org-settings-form", class: "grid gap-6", multipart: true } do |f| %>
-      <%# ── Page: Cover image + README editor ── %>
-      <% if FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[@organization]) %>
-        <div id="section-page" class="crayons-card crayons-card--content-rows">
-          <h2><%= t("views.organization_settings.page.heading") %></h2>
 
-          <div class="crayons-field">
-            <%= f.label :cover_image, t("views.organization_settings.page.cover_image"), class: "crayons-field__label" %>
-            <% if @organization.cover_image_url.present? %>
-              <div class="mb-2">
-                <img src="<%= @organization.cover_image_url %>" alt="<%= t("views.organizations.cover_image_alt", org: @organization.name) %>" style="max-width: 100%; max-height: 150px; object-fit: cover;" class="radius-default" />
-              </div>
-            <% end %>
-            <%= f.file_field :cover_image, accept: "image/*", class: "crayons-card crayons-card--secondary p-3 flex items-center flex-1 w-100" %>
-            <p class="crayons-field__description"><%= t("views.organization_settings.page.cover_image_hint") %></p>
-          </div>
-
-          <div class="crayons-field">
-            <label for="org_page_markdown" class="crayons-field__label"><%= t("views.organization_settings.page.readme") %></label>
-
-            <% page_markdown = @organization.main_page&.body_markdown %>
-            <% if page_markdown.blank? %>
-              <div class="crayons-notice crayons-notice--info mb-4">
-                <p class="fw-medium mb-1"><%= t("views.organization_settings.page.default_notice") %></p>
-                <p class="fs-s color-base-70 mb-2"><%= t("views.organization_settings.page.default_explanation") %></p>
-                <details>
-                  <summary class="cursor-pointer fw-medium fs-s crayons-link"><%= t("views.organization_settings.page.default_example_toggle") %></summary>
-                  <pre class="crayons-card crayons-card--secondary p-3 mt-2 ff-monospace fs-s" style="white-space: pre-wrap;"><%= t("views.organization_settings.page.default_example", slug: @organization.slug) %></pre>
-                </details>
-              </div>
-            <% end %>
-
-            <div id="org-page-editor-root"
-                 data-default-value="<%= page_markdown %>"
-                 data-textarea-name="organization[page_markdown]"
-                 data-preview-url="<%= organization_settings_preview_path(@organization.slug) %>">
-              <%# Fallback layout mimicking the JS component to prevent FOUC %>
-              <div class="crayons-article-form__content">
-                <div class="crayons-article-form__header">
-                  <nav class="crayons-article-form__tabs crayons-tabs ml-auto" aria-label="View post modes">
-                    <ul class="crayons-tabs__list">
-                      <li>
-                        <button data-text="Edit" class="crayons-tabs__item crayons-tabs__item--current" type="button" aria-current="page">Edit</button>
-                      </li>
-                      <li>
-                        <button data-text="Preview" class="crayons-tabs__item" type="button">Preview</button>
-                      </li>
-                    </ul>
-                  </nav>
-                </div>
-                <div class="crayons-article-form__body drop-area text-padding">
-                  <textarea name="organization[page_markdown]"
-                            id="org_page_markdown"
-                            rows="20"
-                            class="crayons-textfield crayons-textfield--ghost crayons-article-form__body__field ff-monospace fs-l h-100"
-                            placeholder="<%= t("views.organization_settings.page.readme_placeholder") %>"><%= page_markdown %></textarea>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      <% end %>
 
       <%# ── Profile details ── %>
       <div id="section-profile" class="crayons-card crayons-card--content-rows">
@@ -289,6 +179,19 @@
               <%= f.file_field :profile_image, accept: "image/*", class: "crayons-card crayons-card--secondary p-3 flex items-center flex-1 w-100" %>
             </div>
           </div>
+
+          <% if FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[@organization]) %>
+            <div class="crayons-field">
+              <%= f.label :cover_image, t("views.organization_settings.page.cover_image"), class: "crayons-field__label" %>
+              <% if @organization.cover_image_url.present? %>
+                <div class="mb-2">
+                  <img src="<%= @organization.cover_image_url %>" alt="<%= t("views.organizations.cover_image_alt", org: @organization.name) %>" style="max-width: 100%; max-height: 150px; object-fit: cover;" class="radius-default" />
+                </div>
+              <% end %>
+              <%= f.file_field :cover_image, accept: "image/*", class: "crayons-card crayons-card--secondary p-3 flex items-center flex-1 w-100" %>
+              <p class="crayons-field__description"><%= t("views.organization_settings.page.cover_image_hint") %></p>
+            </div>
+          <% end %>
 
           <div class="crayons-field">
             <%= f.label :url, "Website url", class: "crayons-field__label" %>
@@ -386,6 +289,50 @@
           </div>
 
       </div>
+
+      <%# ── Organization Pages List ── %>
+      <% if FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[@organization]) %>
+        <div id="section-pages-list" class="crayons-card crayons-card--content-rows">
+          <header class="flex items-center justify-between flex-wrap gap-2">
+            <div>
+              <h2 class="mb-2"><%= t("views.organization_settings.pages.heading") %></h2>
+              <p class="color-base-70">Manage the pages of your organization, including the default Showcase page.</p>
+            </div>
+            <div class="flex gap-2">
+              <%= link_to t("views.organization_settings.pages.new_page"), new_organization_page_path(@organization.slug), class: "crayons-btn crayons-btn--secondary crayons-btn--s" %>
+              <%= link_to "Manage Pages", organization_pages_path(@organization.slug), class: "crayons-btn crayons-btn--secondary crayons-btn--s" %>
+            </div>
+          </header>
+
+          <div class="grid gap-3 mt-4">
+            <% if @organization.pages.any? %>
+              <% @organization.pages.order(:created_at).each do |page| %>
+                <% 
+                  is_showcase = page.slug.end_with?("/readme")
+                  suffix = page.slug.split("/").last
+                %>
+                <div class="crayons-card crayons-card--secondary p-3 flex items-center justify-between gap-3">
+                  <div class="flex items-center gap-2">
+                    <span class="fw-medium color-base-90"><%= page.title %></span>
+                    <%
+                      is_custom_domain = request.env["forem.custom_domain_org"].present?
+                      page_url = is_showcase ? (is_custom_domain ? "/" : "/#{@organization.slug}") : (is_custom_domain ? "/p/#{suffix}" : "/#{@organization.slug}/p/#{suffix}")
+                    %>
+                    <% if is_showcase %>
+                      <%= link_to "Showcase", page_url, target: "_blank", class: "crayons-tag crayons-tag--monochrome", style: "background: var(--accent-brand-a10); color: var(--accent-brand); text-decoration: none;" %>
+                    <% else %>
+                      <%= link_to "/#{suffix}", page_url, target: "_blank", class: "crayons-tag crayons-tag--monochrome", style: "font-family: var(--ff-monospace); text-decoration: none;" %>
+                    <% end %>
+                  </div>
+                  <%= link_to "Edit", edit_organization_page_path(@organization.slug, page), class: "crayons-link fw-medium fs-s" %>
+                </div>
+              <% end %>
+            <% else %>
+              <p class="color-base-60 fs-s mb-0">No custom pages created yet. Click "Create new page" to get started.</p>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
 
       <%# ── Header CTA Button ── %>
       <div id="section-header-cta" class="crayons-card crayons-card--content-rows">
@@ -947,4 +894,3 @@
 </script>
 
 <div id="snack-zone"></div>
-<%= javascript_include_tag "orgPageEditor", defer: true %>

--- a/app/views/organization_settings/edit.html.erb
+++ b/app/views/organization_settings/edit.html.erb
@@ -296,11 +296,11 @@
           <header class="flex items-center justify-between flex-wrap gap-2">
             <div>
               <h2 class="mb-2"><%= t("views.organization_settings.pages.heading") %></h2>
-              <p class="color-base-70">Manage the pages of your organization, including the default Showcase page.</p>
+              <p class="color-base-70"><%= t("views.organization_settings.pages.description_help") %></p>
             </div>
             <div class="flex gap-2">
               <%= link_to t("views.organization_settings.pages.new_page"), new_organization_page_path(@organization.slug), class: "crayons-btn crayons-btn--secondary crayons-btn--s" %>
-              <%= link_to "Manage Pages", organization_pages_path(@organization.slug), class: "crayons-btn crayons-btn--secondary crayons-btn--s" %>
+              <%= link_to t("views.organization_settings.pages.manage_pages"), organization_pages_path(@organization.slug), class: "crayons-btn crayons-btn--secondary crayons-btn--s" %>
             </div>
           </header>
 
@@ -319,16 +319,16 @@
                       page_url = is_showcase ? (is_custom_domain ? "/" : "/#{@organization.slug}") : (is_custom_domain ? "/p/#{suffix}" : "/#{@organization.slug}/p/#{suffix}")
                     %>
                     <% if is_showcase %>
-                      <%= link_to "Showcase", page_url, target: "_blank", class: "crayons-tag crayons-tag--monochrome", style: "background: var(--accent-brand-a10); color: var(--accent-brand); text-decoration: none;" %>
+                      <%= link_to t("views.organization_settings.pages.showcase"), page_url, target: "_blank", class: "crayons-tag crayons-tag--monochrome", style: "background: var(--accent-brand-a10); color: var(--accent-brand); text-decoration: none;" %>
                     <% else %>
                       <%= link_to "/#{suffix}", page_url, target: "_blank", class: "crayons-tag crayons-tag--monochrome", style: "font-family: var(--ff-monospace); text-decoration: none;" %>
                     <% end %>
                   </div>
-                  <%= link_to "Edit", edit_organization_page_path(@organization.slug, page), class: "crayons-link fw-medium fs-s" %>
+                  <%= link_to t("views.organization_settings.pages.edit"), edit_organization_page_path(@organization.slug, page), class: "crayons-link fw-medium fs-s" %>
                 </div>
               <% end %>
             <% else %>
-              <p class="color-base-60 fs-s mb-0">No custom pages created yet. Click "Create new page" to get started.</p>
+              <p class="color-base-60 fs-s mb-0"><%= t("views.organization_settings.pages.no_pages") %></p>
             <% end %>
           </div>
         </div>

--- a/app/views/organizations/_header.html.erb
+++ b/app/views/organizations/_header.html.erb
@@ -251,8 +251,8 @@
     <%
       is_custom_domain = request.env["forem.custom_domain_org"].present?
       org_pages = @organization.pages.order(:created_at).to_a
-      showcase_page = org_pages.first
-      custom_pages = org_pages[1..] || []
+      showcase_page = org_pages.find { |page| page.slug&.end_with?("/readme") } || org_pages.first
+      custom_pages = org_pages.reject { |page| page == showcase_page }
       
       showcase_path = is_custom_domain ? "/" : "/#{@organization.slug}"
       all_posts_path = is_custom_domain ? "/?mode=all-posts" : "/#{@organization.slug}?mode=all-posts"

--- a/app/views/organizations/_header.html.erb
+++ b/app/views/organizations/_header.html.erb
@@ -246,18 +246,54 @@
     </div>
   <% end %>
 
-  <%# Render Showcase and All Posts tabs if organization has custom readme page feature enabled %>
+  <%# Render Showcase, custom pages and All Posts tabs if organization has custom readme page feature enabled %>
   <% if @organization.main_page.present? && FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[@organization]) %>
     <%
       is_custom_domain = request.env["forem.custom_domain_org"].present?
+      org_pages = @organization.pages.order(:created_at).to_a
+      showcase_page = org_pages.first
+      custom_pages = org_pages[1..] || []
+      
       showcase_path = is_custom_domain ? "/" : "/#{@organization.slug}"
       all_posts_path = is_custom_domain ? "/?mode=all-posts" : "/#{@organization.slug}?mode=all-posts"
     %>
-    <nav class="crayons-tabs org-header-tabs" aria-label="Organization Profile Navigation">
-      <a href="<%= showcase_path %>" class="crayons-tabs__item <%= 'crayons-tabs__item--current' if params[:mode] != 'all-posts' %>" <%= 'aria-current="page"' if params[:mode] != 'all-posts' %> data-text="<%= t('views.organizations.showcase') %>">
-        <%= t('views.organizations.showcase') %>
-      </a>
-      <a href="<%= all_posts_path %>" class="crayons-tabs__item <%= 'crayons-tabs__item--current' if params[:mode] == 'all-posts' %>" <%= 'aria-current="page"' if params[:mode] == 'all-posts' %> data-text="<%= t('views.organizations.all_posts') %>">
+    <style>
+      .org-header-tabs .crayons-tabs__item--current {
+        font-weight: var(--fw-bold, bold) !important;
+      }
+    </style>
+    <nav class="crayons-tabs org-header-tabs flex items-center" aria-label="Organization Profile Navigation" id="org-tab-nav" style="width: 100%; display: flex; align-items: center;">
+      <div class="org-custom-tabs-container flex items-center flex-grow" style="overflow: hidden; white-space: nowrap; display: flex; align-items: center; min-width: 0;">
+        <!-- Showcase (first page) -->
+        <a href="<%= showcase_path %>" data-instant-keep-scroll="true" class="crayons-tabs__item <%= 'crayons-tabs__item--current' if params[:page_suffix].blank? && params[:mode] != 'all-posts' %>" <%= 'aria-current="page"' if params[:page_suffix].blank? && params[:mode] != 'all-posts' %> data-text="<%= t('views.organizations.showcase') %>">
+          <%= t('views.organizations.showcase') %>
+        </a>
+        
+        <!-- Custom Pages -->
+        <% custom_pages.each do |page| %>
+          <% 
+            suffix = page.slug.split("/").last
+            page_path = is_custom_domain ? "/p/#{suffix}" : "/#{@organization.slug}/p/#{suffix}"
+            is_current = params[:page_suffix] == suffix
+          %>
+          <a href="<%= page_path %>" data-instant-keep-scroll="true" class="crayons-tabs__item <%= 'crayons-tabs__item--current' if is_current %>" <%= 'aria-current="page"' if is_current %> data-text="<%= page.title %>">
+            <%= page.title %>
+          </a>
+        <% end %>
+      </div>
+
+      <!-- More dropdown trigger (three dots), initially hidden -->
+      <div class="org-tabs-more-dropdown relative ml-1" style="display: none;">
+        <button id="org-tabs-more-trigger" aria-expanded="false" aria-controls="org-tabs-more-menu" aria-haspopup="true" class="crayons-btn crayons-btn--ghost-dimmed crayons-btn--icon" style="padding: 0 var(--su-2);">
+          <%= crayons_icon_tag("overflow-horizontal", class: "dropdown-icon", title: "More pages") %>
+        </button>
+        <div id="org-tabs-more-menu" class="crayons-dropdown right-0 top-100 mt-1" style="display: none; min-width: 180px;">
+          <!-- Overflowing tabs will be dynamically moved here by Javascript -->
+        </div>
+      </div>
+
+      <!-- All Posts -->
+      <a href="<%= all_posts_path %>" data-instant-keep-scroll="true" class="crayons-tabs__item org-tab-all-posts <%= 'crayons-tabs__item--current' if params[:mode] == 'all-posts' %>" <%= 'aria-current="page"' if params[:mode] == 'all-posts' %> data-text="<%= t('views.organizations.all_posts') %>" style="<%= custom_pages.any? ? 'margin-left: auto;' : '' %>">
         <%= t('views.organizations.all_posts') %>
       </a>
     </nav>

--- a/config/locales/views/organizations/en.yml
+++ b/config/locales/views/organizations/en.yml
@@ -27,8 +27,18 @@ en:
         confirm_delete: Are you sure you want to delete this page?
         showcase: Showcase
         showcase_hint: This is the default Showcase landing page.
-        no_pages: No custom pages created yet.
+        no_pages: No custom pages created yet. Click "Create new page" to get started.
         edit: Edit
+        manage_pages: Manage Pages
+        description_help: Manage the pages of your organization, including the default Showcase page.
+        create_heading: Create a new page
+        edit_heading: Edit page
+        slug_help: Only lowercase letters, numbers, and hyphens (e.g. "about-us"). Accessible via the profile tab.
+        showcase_slug_help: This is the Showcase (default) page, so the slug suffix is fixed to "readme".
+        content_label: Page Content (Markdown)
+        description_placeholder: Short description for SEO and sharing...
+        cancel: Cancel
+        your_pages: Your Pages
       header_cta:
         heading: Header CTA Button
         description: Add a call-to-action button to your organization's page header. You can create a simple button or a dropdown with multiple links.

--- a/config/locales/views/organizations/en.yml
+++ b/config/locales/views/organizations/en.yml
@@ -14,6 +14,21 @@ en:
         default_example: "## Meet the team\n{%% org_team %{slug} %%}\n\n## Latest posts\n{%% org_posts %{slug} %%}"
         save: Save page
         preview: Preview
+      pages:
+        heading: Custom Pages
+        new_page: Create new page
+        edit_page: Edit page
+        title: Title
+        slug: Slug suffix
+        description: Description
+        created: Page created successfully.
+        updated: Page updated successfully.
+        deleted: Page deleted successfully.
+        confirm_delete: Are you sure you want to delete this page?
+        showcase: Showcase
+        showcase_hint: This is the default Showcase landing page.
+        no_pages: No custom pages created yet.
+        edit: Edit
       header_cta:
         heading: Header CTA Button
         description: Add a call-to-action button to your organization's page header. You can create a simple button or a dropdown with multiple links.

--- a/config/locales/views/organizations/fr.yml
+++ b/config/locales/views/organizations/fr.yml
@@ -27,8 +27,18 @@ fr:
         confirm_delete: Êtes-vous sûr de vouloir supprimer cette page ?
         showcase: Showcase
         showcase_hint: Il s'agit de la page d'accueil Showcase par défaut.
-        no_pages: Aucune page personnalisée créée pour le moment.
+        no_pages: Aucune page personnalisée créée pour le moment. Cliquez sur "Créer une nouvelle page" pour commencer.
         edit: Modifier
+        manage_pages: Gérer les pages
+        description_help: Gérez les pages de votre organisation, y compris la page Showcase par défaut.
+        create_heading: Créer une nouvelle page
+        edit_heading: Modifier la page
+        slug_help: Uniquement des lettres minuscules, des chiffres et des traits d'union (par ex. "a-propos"). Accessible via l'onglet de profil.
+        showcase_slug_help: Il s'agit de la page Showcase (par défaut), le suffixe du slug est donc fixé à "readme".
+        content_label: Contenu de la page (Markdown)
+        description_placeholder: Courte description pour le référencement (SEO) et le partage...
+        cancel: Annuler
+        your_pages: Vos pages
       header_cta:
         heading: Bouton CTA de l'en-tête
         description: "Ajoutez un bouton d'appel à l'action dans l'en-tête de la page de votre organisation. Vous pouvez créer un bouton simple ou un menu déroulant avec plusieurs liens."

--- a/config/locales/views/organizations/fr.yml
+++ b/config/locales/views/organizations/fr.yml
@@ -14,6 +14,21 @@ fr:
         default_example: "## Rencontrez l'équipe\n{%% org_team %{slug} %%}\n\n## Dernières publications\n{%% org_posts %{slug} %%}"
         save: Enregistrer la page
         preview: Aperçu
+      pages:
+        heading: Pages d'organisation
+        new_page: Créer une nouvelle page
+        edit_page: Modifier la page
+        title: Titre
+        slug: Suffixe du slug
+        description: Description
+        created: Page créée avec succès.
+        updated: Page mise à jour avec succès.
+        deleted: Page supprimée avec succès.
+        confirm_delete: Êtes-vous sûr de vouloir supprimer cette page ?
+        showcase: Showcase
+        showcase_hint: Il s'agit de la page d'accueil Showcase par défaut.
+        no_pages: Aucune page personnalisée créée pour le moment.
+        edit: Modifier
       header_cta:
         heading: Bouton CTA de l'en-tête
         description: "Ajoutez un bouton d'appel à l'action dans l'en-tête de la page de votre organisation. Vous pouvez créer un bouton simple ou un menu déroulant avec plusieurs liens."

--- a/config/locales/views/organizations/pt.yml
+++ b/config/locales/views/organizations/pt.yml
@@ -14,6 +14,21 @@ pt:
         default_example: "## Conheça a equipe\n{%% org_team %{slug} %%}\n\n## Últimas publicações\n{%% org_posts %{slug} %%}"
         save: Salvar página
         preview: Visualizar
+      pages:
+        heading: Páginas da organização
+        new_page: Criar nova página
+        edit_page: Editar página
+        title: Título
+        slug: Sufixo do slug
+        description: Descrição
+        created: Página criada com sucesso.
+        updated: Página atualizada com sucesso.
+        deleted: Página excluída com sucesso.
+        confirm_delete: Tem certeza que deseja excluir esta página?
+        showcase: Showcase
+        showcase_hint: Esta é a página Showcase padrão.
+        no_pages: Nenhuma página personalizada criada ainda.
+        edit: Editar
       header_cta:
         heading: Botão CTA do Cabeçalho
         description: "Adicione um botão de chamada para ação no cabeçalho da página da sua organização. Você pode criar um botão simples ou um menu suspenso com vários links."

--- a/config/locales/views/organizations/pt.yml
+++ b/config/locales/views/organizations/pt.yml
@@ -27,8 +27,18 @@ pt:
         confirm_delete: Tem certeza que deseja excluir esta página?
         showcase: Showcase
         showcase_hint: Esta é a página Showcase padrão.
-        no_pages: Nenhuma página personalizada criada ainda.
+        no_pages: Nenhuma página personalizada criada ainda. Clique em "Criar nova página" para começar.
         edit: Editar
+        manage_pages: Gerenciar páginas
+        description_help: Gerencie as páginas da sua organização, incluindo a página Showcase padrão.
+        create_heading: Criar nova página
+        edit_heading: Editar página
+        slug_help: Apenas letras minúsculas, números e hifens (ex. "sobre-nos"). Acessível através da guia do perfil.
+        showcase_slug_help: Esta é a página Showcase (padrão), então o sufixo do slug é fixado em "readme".
+        content_label: Conteúdo da página (Markdown)
+        description_placeholder: Breve descrição para SEO e compartilhamento...
+        cancel: Cancelar
+        your_pages: Suas páginas
       header_cta:
         heading: Botão CTA do Cabeçalho
         description: "Adicione um botão de chamada para ação no cabeçalho da página da sua organização. Você pode criar um botão simples ou um menu suspenso com vários links."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,14 +39,16 @@ Rails.application.routes.draw do
     get "/:org_slug/:slug",
         to: "stories#custom_domain_show",
         constraints: {
-          org_slug: %r{(?!(?:api|assets|packs|rails|r|ahoy|enter|users)\z)[^/.]+},
+          org_slug: %r{(?!(?:api|assets|packs|rails|r|ahoy|enter|users|p)\z)[^/.]+},
           slug: %r{[^/.]+}
         }
     get "/:slug",
         to: "stories#custom_domain_show",
         constraints: {
-          slug: %r{(?!(?:api|assets|packs|rails|r|ahoy|enter|users)\z)[^/.]+}
+          slug: %r{(?!(?:api|assets|packs|rails|r|ahoy|enter|users|p)\z)[^/.]+}
         }
+    get "/p/:page_suffix", to: "stories#custom_domain_index", as: "custom_domain_organization_custom_page",
+                           constraints: { format: /html/ }
   end
 
   # [@forem/delightful] - all routes are nested under this optional scope to
@@ -436,6 +438,13 @@ Rails.application.routes.draw do
     post "/:slug/settings/verify", to: "organization_settings#request_verification",
                                    as: :organization_request_verification
     post "/:slug/settings/preview", to: "organization_settings#preview", as: :organization_settings_preview
+    get "/:slug/settings/pages", to: "organization_pages#index", as: :organization_pages
+    get "/:slug/settings/pages/new", to: "organization_pages#new", as: :new_organization_page
+    post "/:slug/settings/pages", to: "organization_pages#create"
+    get "/:slug/settings/pages/:id/edit", to: "organization_pages#edit", as: :edit_organization_page
+    patch "/:slug/settings/pages/:id", to: "organization_pages#update", as: :update_organization_page
+    delete "/:slug/settings/pages/:id", to: "organization_pages#destroy", as: :organization_page
+    post "/:slug/settings/pages/preview", to: "organization_pages#preview", as: :organization_pages_preview
     get "/:slug/settings/lead_forms", to: "organization_lead_forms#index", as: :organization_lead_forms
     post "/:slug/settings/lead_forms", to: "organization_lead_forms#create"
     get "/:slug/settings/lead_forms/:id/edit", to: "organization_lead_forms#edit", as: :edit_organization_lead_form
@@ -588,6 +597,8 @@ Rails.application.routes.draw do
     get "/:username/:slug", to: "stories#show"
     get "/:sitemap", to: "sitemaps#show",
                      constraints: { format: /xml/, sitemap: /sitemap-.+/ }
+    get "/:username/p/:page_suffix", to: "stories#index", as: "organization_custom_page",
+                                     constraints: { format: /html/ }
     get "/:username", to: "stories#index", as: "user_profile", # No txt format
                       constraints: { format: /html/ }
     get "/:slug", to: "pages#show",

--- a/spec/requests/organization_pages_spec.rb
+++ b/spec/requests/organization_pages_spec.rb
@@ -1,0 +1,103 @@
+require "rails_helper"
+
+RSpec.describe "Organization Pages Controller Backend Protection" do
+  let(:admin_user) { create(:user, :org_admin) }
+  let(:organization) { admin_user.organizations.first }
+
+  before do
+    sign_in admin_user
+  end
+
+  describe "GET /:slug/settings/pages" do
+    context "when feature flag is disabled" do
+      before { FeatureFlag.disable(:org_readme) }
+
+      it "returns 404 Not Found" do
+        expect do
+          get organization_pages_path(organization.slug)
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when feature flag is enabled" do
+      before { FeatureFlag.enable(:org_readme, FeatureFlag::Actor[organization]) }
+
+      it "returns 200 OK" do
+        get organization_pages_path(organization.slug)
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  describe "POST /:slug/settings/pages" do
+    before { FeatureFlag.enable(:org_readme, FeatureFlag::Actor[organization]) }
+
+    context "when creating the first page" do
+      it "automatically creates the readme Showcase page" do
+        expect {
+          post organization_pages_path(organization.slug), params: {
+            page: { title: "Welcome", body_markdown: "# Hello showcase" }
+          }
+        }.to change(Page, :count).by(1)
+
+        page = organization.pages.last
+        expect(page.slug).to eq("#{organization.slug}/readme")
+        expect(page.title).to eq("Welcome")
+      end
+    end
+
+    context "when creating subsequent pages" do
+      before do
+        # Create first page
+        create(:page, organization: organization, slug: "#{organization.slug}/readme", template: "full_within_layout")
+      end
+
+      it "creates a custom page with a slug suffix" do
+        expect {
+          post organization_pages_path(organization.slug), params: {
+            page: { title: "About Us", body_markdown: "# Custom about page", slug_suffix: "about" }
+          }
+        }.to change(Page, :count).by(1)
+
+        page = organization.pages.last
+        expect(page.slug).to eq("#{organization.slug}/about")
+      end
+    end
+  end
+
+  describe "PATCH /:slug/settings/pages/:id" do
+    before { FeatureFlag.enable(:org_readme, FeatureFlag::Actor[organization]) }
+
+    let!(:readme_page) { create(:page, organization: organization, slug: "#{organization.slug}/readme", template: "full_within_layout") }
+
+    it "updates details and prevents readme slug suffix change" do
+      patch update_organization_page_path(organization.slug, readme_page), params: {
+        page: { title: "Updated Showcase Title", slug_suffix: "something-else" }
+      }
+      expect(readme_page.reload.title).to eq("Updated Showcase Title")
+      expect(readme_page.slug).to eq("#{organization.slug}/readme")
+    end
+  end
+
+  describe "DELETE /:slug/settings/pages/:id" do
+    before { FeatureFlag.enable(:org_readme, FeatureFlag::Actor[organization]) }
+
+    let!(:readme_page) { create(:page, organization: organization, slug: "#{organization.slug}/readme", template: "full_within_layout") }
+
+    it "deletes the page" do
+      expect {
+        delete organization_page_path(organization.slug, readme_page)
+      }.to change(Page, :count).by(-1)
+    end
+  end
+
+  describe "POST /:slug/settings/pages/preview" do
+    before { FeatureFlag.enable(:org_readme, FeatureFlag::Actor[organization]) }
+
+    it "renders the markdown preview" do
+      post organization_pages_preview_path(organization.slug), params: { body_markdown: "**bold text**" }
+      expect(response).to have_http_status(:success)
+      expect(JSON.parse(response.body)["processed_html"]).to include("<strong>bold text</strong>")
+    end
+  end
+end

--- a/spec/requests/organization_pages_spec.rb
+++ b/spec/requests/organization_pages_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe "Organization Pages Controller Backend Protection" do
     sign_in admin_user
   end
 
+  after do
+    FeatureFlag.disable(:org_readme, FeatureFlag::Actor[organization])
+  end
+
   describe "GET /:slug/settings/pages" do
     context "when feature flag is disabled" do
       before { FeatureFlag.disable(:org_readme) }
@@ -62,6 +66,15 @@ RSpec.describe "Organization Pages Controller Backend Protection" do
         page = organization.pages.last
         expect(page.slug).to eq("#{organization.slug}/about")
       end
+
+      it "fails and returns 422 if the slug suffix is invalid" do
+        expect {
+          post organization_pages_path(organization.slug), params: {
+            page: { title: "About Us", body_markdown: "# Custom about page", slug_suffix: "!!!" }
+          }
+        }.not_to change(Page, :count)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
     end
   end
 
@@ -69,6 +82,7 @@ RSpec.describe "Organization Pages Controller Backend Protection" do
     before { FeatureFlag.enable(:org_readme, FeatureFlag::Actor[organization]) }
 
     let!(:readme_page) { create(:page, organization: organization, slug: "#{organization.slug}/readme", template: "full_within_layout") }
+    let!(:custom_page) { create(:page, organization: organization, slug: "#{organization.slug}/about", template: "full_within_layout") }
 
     it "updates details and prevents readme slug suffix change" do
       patch update_organization_page_path(organization.slug, readme_page), params: {
@@ -76,6 +90,14 @@ RSpec.describe "Organization Pages Controller Backend Protection" do
       }
       expect(readme_page.reload.title).to eq("Updated Showcase Title")
       expect(readme_page.slug).to eq("#{organization.slug}/readme")
+    end
+
+    it "fails and returns 422 if the updated slug suffix is invalid" do
+      patch update_organization_page_path(organization.slug, custom_page), params: {
+        page: { title: "New Title", slug_suffix: "!!!" }
+      }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(custom_page.reload.title).not_to eq("New Title")
     end
   end
 

--- a/spec/requests/organization_settings_spec.rb
+++ b/spec/requests/organization_settings_spec.rb
@@ -11,7 +11,27 @@ RSpec.describe "OrganizationSettings" do
       it "renders the settings page" do
         get "/#{organization.slug}/settings"
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include("Page")
+        expect(response.body).to include("Organization details")
+      end
+
+      context "when org_readme is enabled" do
+        before do
+          FeatureFlag.add(:org_readme)
+          FeatureFlag.enable(:org_readme, FeatureFlag::Actor[organization])
+        end
+
+        it "renders the organization pages section link and list block" do
+          get "/#{organization.slug}/settings"
+          expect(response.body).to include("section-pages-list")
+          expect(response.body).to include("No custom pages created yet.")
+        end
+
+        it "renders the list of pages if pages exist" do
+          create(:page, organization: organization, title: "Our Custom Page Title", slug: "#{organization.slug}/readme", template: "full_within_layout")
+          get "/#{organization.slug}/settings"
+          expect(response.body).to include("Our Custom Page Title")
+          expect(response.body).to include("Showcase")
+        end
       end
     end
 
@@ -40,92 +60,6 @@ RSpec.describe "OrganizationSettings" do
 
   describe "PATCH /:slug/settings" do
     before { sign_in user }
-
-    context "when org_readme is enabled" do
-      before do
-        allow(FeatureFlag).to receive(:enabled?).and_return(false) # Default
-        allow(FeatureFlag).to receive(:enabled?).with(:org_readme, anything).and_return(true)
-      end
-
-      it "creates a Page record when submitting page_markdown" do
-        expect {
-          patch "/#{organization.slug}/settings", params: {
-            organization: { page_markdown: "# Welcome to our org" }
-          }
-        }.to change(Page, :count).by(1)
-
-        page = organization.pages.first
-        expect(page.body_markdown).to eq("# Welcome to our org")
-        expect(page.title).to eq(organization.name)
-        expect(page.slug).to eq("#{organization.slug}/readme")
-      end
-
-      it "processes page_markdown into HTML via Page record" do
-        patch "/#{organization.slug}/settings", params: {
-          organization: { page_markdown: "**bold**" }
-        }
-        page = organization.pages.first
-        expect(page.processed_html).to include("<strong>bold</strong>")
-      end
-
-      it "ignores organization_id spoofing via parameters" do
-        other_org = create(:organization)
-        expect {
-          patch "/#{organization.slug}/settings", params: {
-            organization: { 
-              page_markdown: "# Welcome to our org",
-              organization_id: other_org.id
-            }
-          }
-        }.to change(Page, :count).by(1)
-
-        page = organization.pages.last
-        expect(page.organization_id).to eq(organization.id)
-        expect(page.organization_id).not_to eq(other_org.id)
-      end
-
-      it "updates existing Page record on subsequent edits" do
-        patch "/#{organization.slug}/settings", params: {
-          organization: { page_markdown: "# First" }
-        }
-        expect {
-          patch "/#{organization.slug}/settings", params: {
-            organization: { page_markdown: "# Updated" }
-          }
-        }.not_to change(Page, :count)
-        expect(organization.pages.first.body_markdown).to eq("# Updated")
-      end
-
-      it "destroys Page record when page_markdown is cleared" do
-        patch "/#{organization.slug}/settings", params: {
-          organization: { page_markdown: "# Hello" }
-        }
-        expect {
-          patch "/#{organization.slug}/settings", params: {
-            organization: { page_markdown: "" }
-          }
-        }.to change(Page, :count).by(-1)
-      end
-    end
-
-    context "when org_readme is disabled" do
-      before do
-        allow(FeatureFlag).to receive(:enabled?).and_return(false)
-        allow(FeatureFlag).to receive(:enabled?).with(:org_readme, anything).and_return(false)
-      end
-
-      it "does not process page_markdown" do
-        expect {
-          patch "/#{organization.slug}/settings", params: {
-            organization: { 
-              page_markdown: "# Attempted page update"
-            }
-          }
-        }.not_to change(Page, :count)
-
-        organization.reload
-      end
-    end
 
     it "updates organization profile fields" do
       patch "/#{organization.slug}/settings", params: {

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -534,6 +534,57 @@ RSpec.describe "StoriesIndex" do
         expect(response.body).to include("Showcase")
         expect(response.body).to include("All Posts")
       end
+
+      it "renders the custom page via clean permalink" do
+        create(:page, organization: organization, body_markdown: "**Custom About Us**",
+               title: "About Us", description: "desc", slug: "#{organization.slug}/about",
+               template: "full_within_layout")
+        get "/#{organization.slug}/p/about"
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("<strong>Custom About Us</strong>")
+        expect(response.body).to include("Organization Profile Navigation")
+        expect(response.body).to include("About Us")
+      end
+
+      it "returns 404 for nonexistent custom page permalink" do
+        expect {
+          get "/#{organization.slug}/p/nonexistent"
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      context "under a custom domain" do
+        before do
+          FeatureFlag.add(:org_custom_domain)
+          FeatureFlag.enable(:org_custom_domain, FeatureFlag::Actor[organization])
+          organization.update!(custom_domain: "custom.example.com")
+          allow(Subforem).to receive(:cached_id_by_domain).with("custom.example.com").and_return(nil)
+          create(:page, organization: organization, body_markdown: "**Custom About Us**",
+                 title: "About Us", description: "desc", slug: "#{organization.slug}/about",
+                 template: "full_within_layout")
+        end
+
+        after do
+          FeatureFlag.disable(:org_custom_domain)
+        end
+
+        it "renders the custom page via /about permalink" do
+          get "http://custom.example.com/about"
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("<strong>Custom About Us</strong>")
+        end
+
+        it "renders the custom page via /p/about permalink" do
+          get "http://custom.example.com/p/about"
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("<strong>Custom About Us</strong>")
+        end
+
+        it "renders the custom page via /orgname/p/about permalink" do
+          get "http://custom.example.com/#{organization.slug}/p/about"
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("<strong>Custom About Us</strong>")
+        end
+      end
     end
 
     context "when organization has a readme page but org_readme flag is disabled" do


### PR DESCRIPTION
…n, and scroll position preservation

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

### Goal
Allow organizations to create multiple custom pages, accessible via horizontal tabs on their profile. This moves page editing to a dedicated list and editor view, prevents tab width overflow using a dynamic "three dots" dropdown, adds clean custom domain routing patterns, and preserves scroll position across tab switches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786891336&installation_id=139885019&pr_number=23634&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23634&signature=b57379583d054c4a097c954a938b661c7a21b8b225c87e95c121b41fa1f9e0d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->