### PR TITLE
Let organization showcase copy use the available width

### DIFF
--- a/app/assets/stylesheets/views/organizations_showcase.scss
+++ b/app/assets/stylesheets/views/organizations_showcase.scss
@@ -51,7 +51,6 @@ $exclude-embeds: ':not(.crayons-btn):not([class*="ltag"] *):not(.crayons-story *
   }
 
   > p#{$exclude-embeds} {
-    max-width: 72ch;
     margin: 0 0 var(--su-5);
   }
 


### PR DESCRIPTION
## Summary

- Remove the fixed line-length cap from top-level organization showcase paragraphs.
- Preserve the existing spacing and embed-specific selector exclusions.

## Why

The showcase container already constrains the available layout width. Applying another paragraph-level cap creates an unnecessarily narrow text column and leaves substantial unused space at wider viewports.

## Impact

Top-level showcase copy can wrap naturally within the page container. Embedded Liquid tags retain their existing layout behavior.

## Validation

- `git diff --check`
- Manual desktop-width visual comparison

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786897304&installation_id=139885019&pr_number=23636&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23636&signature=882960db814aad71032485ae3a2ee49edfa65a7a00e3be7b023e29d73757bdb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->