### PR TITLE
Fix nested Markdown rendering in block Liquid tags

### DIFF
--- a/app/liquid_tags/col_tag.rb
+++ b/app/liquid_tags/col_tag.rb
@@ -1,5 +1,5 @@
 class ColTag < Liquid::Block
-  include ActionView::Helpers::SanitizeHelper
+  include LiquidTagHelpers
 
   PARTIAL = "liquids/col".freeze
   VALID_SPANS = (1..4).to_a.freeze
@@ -16,9 +16,11 @@ class ColTag < Liquid::Block
 
   def render(context)
     content = super
-    renderer = Redcarpet::Render::HTMLRouge.new(hard_wrap: true, filter_html: false)
-    markdown = Redcarpet::Markdown.new(renderer, Constants::Redcarpet::CONFIG)
-    parsed_content = sanitize(markdown.render(content), tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES)
+    parsed_content = render_nested_markdown(
+      content,
+      allowed_tags: ALLOWED_TAGS,
+      allowed_attributes: ALLOWED_ATTRIBUTES,
+    )
     ApplicationController.render(
       partial: PARTIAL,
       locals: { content: parsed_content, span: @span },

--- a/app/liquid_tags/concerns/liquid_tag_helpers.rb
+++ b/app/liquid_tags/concerns/liquid_tag_helpers.rb
@@ -21,6 +21,29 @@ module LiquidTagHelpers
     options
   end
 
+  def render_nested_markdown(content, allowed_tags: MarkdownProcessor::AllowedTags::MARKDOWN_PROCESSOR_DEFAULT,
+                             allowed_attributes: MarkdownProcessor::AllowedAttributes::MARKDOWN_PROCESSOR)
+    fragment = Nokogiri::HTML.fragment(content)
+
+    # The outer Markdown pass can split a Liquid block across paragraph tags
+    # and turn source newlines into <br> elements. Reconstruct Markdown from
+    # those direct children before rendering the block body a second time.
+    fragment.xpath("./p").each do |paragraph|
+      paragraph.replace("\n\n#{paragraph.inner_html}\n\n")
+    end
+
+    markdown = fragment.to_html.gsub(%r{<br\s*/?>\r?\n?}, "\n")
+    markdown = remove_structural_indentation(markdown).strip
+    renderer = Redcarpet::Render::HTMLRouge.new(hard_wrap: true, filter_html: false)
+    parsed_content = Redcarpet::Markdown.new(renderer, Constants::Redcarpet::CONFIG).render(markdown)
+
+    ActionController::Base.helpers.sanitize(
+      parsed_content,
+      tags: allowed_tags,
+      attributes: allowed_attributes,
+    )
+  end
+
   def validate_url!(url, option_name = "url")
     return if url.blank?
 
@@ -28,5 +51,15 @@ module LiquidTagHelpers
     raise StandardError, I18n.t("liquid_tags.invalid_url_scheme", option: option_name) unless %w[http https].include?(uri.scheme)
   rescue URI::InvalidURIError
     raise StandardError, I18n.t("liquid_tags.invalid_url_scheme", option: option_name)
+  end
+
+  private
+
+  def remove_structural_indentation(content)
+    first_content_line = content.each_line.detect { |line| line.match?(/\S/) }
+    indentation = first_content_line&.match(/\A[ \t]*/)&.to_s
+    return content if indentation.blank?
+
+    content.each_line.map { |line| line.delete_prefix(indentation) }.join
   end
 end

--- a/app/liquid_tags/feature_tag.rb
+++ b/app/liquid_tags/feature_tag.rb
@@ -14,7 +14,7 @@ class FeatureTag < Liquid::Block
 
   def render(context)
     content = super
-    parsed_content = MarkdownProcessor::Parser.new(content).evaluate_markdown
+    parsed_content = render_nested_markdown(content)
     ApplicationController.render(
       partial: PARTIAL,
       locals: {

--- a/spec/liquid_tags/features_tag_spec.rb
+++ b/spec/liquid_tags/features_tag_spec.rb
@@ -65,6 +65,24 @@ RSpec.describe "Features and Feature liquid tags", type: :liquid_tag do
       expect(result).to include("<strong>Bold</strong>")
     end
 
+    it "does not duplicate formatting breaks in indented multiline content" do
+      markdown = <<~LIQUID
+        {% features %}
+          {% feature title="Test" %}
+          First line
+          second line
+          {% endfeature %}
+        {% endfeatures %}
+      LIQUID
+
+      result = MarkdownProcessor::Parser.new(markdown).finalize
+      body = Nokogiri::HTML.fragment(result).at_css(".ltag-feature__body")
+
+      expect(body.css("p").length).to eq(1)
+      expect(body.css("br").length).to eq(1)
+      expect(body.text.split.join(" ")).to eq("First line second line")
+    end
+
     it "raises error when title is missing" do
       expect do
         parse('{% features %}{% feature icon="star-line" %}No title{% endfeature %}{% endfeatures %}')

--- a/spec/liquid_tags/row_col_tag_spec.rb
+++ b/spec/liquid_tags/row_col_tag_spec.rb
@@ -92,6 +92,25 @@ RSpec.describe "Row and Col liquid tags", type: :liquid_tag do
       expect(result).to include("Welcome to Forem")
       expect(result).to include("<p>Software that powers millions.</p>")
     end
+
+    it "evaluates Markdown headings in documented indented syntax" do
+      markdown = <<~LIQUID
+        {% row %}
+          {% col %}
+          ### Predictable
+
+          Body copy.
+          {% endcol %}
+        {% endrow %}
+      LIQUID
+
+      result = MarkdownProcessor::Parser.new(markdown).finalize
+      column = Nokogiri::HTML.fragment(result).at_css(".ltag-col")
+
+      expect(column.at_css("h3").text.strip).to eq("Predictable")
+      expect(column.at_css("p").text).to eq("Body copy.")
+      expect(column.text).not_to include("###")
+    end
   end
 
   describe "content filtering" do


### PR DESCRIPTION
## Summary

- Add a shared helper for reconstructing and sanitizing Markdown nested inside block Liquid tags.
- Use it for feature and column content.
- Add regression coverage for multiline feature copy and indented column headings.

## Root cause

The outer Markdown pass can wrap block-tag content in paragraph elements and convert source newlines into break elements before the block body is rendered. The previous tag-specific render paths did not consistently reconstruct that source structure, which could duplicate line breaks or leave heading syntax unparsed.

## Impact

Documented indented syntax now renders headings and multiline copy consistently while retaining the existing sanitization allowlists.

## Validation

- `bin/rspec spec/liquid_tags/features_tag_spec.rb spec/liquid_tags/row_col_tag_spec.rb`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786897308&installation_id=139885019&pr_number=23638&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23638&signature=64d5dab54113ed8f9b62947ae96fdbdee82adcb581a0aebd538c08b0c15ba1f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->