### PR TITLE
Add themed image card columns

### DIFF
--- a/app/assets/stylesheets/ltags/RowColTag.scss
+++ b/app/assets/stylesheets/ltags/RowColTag.scss
@@ -18,6 +18,7 @@
 .ltag-col {
   flex: 1;
   min-width: 0;
+  background-color: var(--ltag-col-background, transparent);
 
   > br { display: none; }
 
@@ -28,6 +29,14 @@
   > :last-child {
     margin-bottom: 0;
   }
+}
+
+.ltag-col-background-default {
+  --ltag-col-background: var(--card-bg);
+}
+
+.ltag-col-background-subtle {
+  --ltag-col-background: var(--card-secondary-bg);
 }
 
 .ltag-col-span-2 {

--- a/app/assets/stylesheets/views/organizations_showcase.scss
+++ b/app/assets/stylesheets/views/organizations_showcase.scss
@@ -140,11 +140,19 @@ $exclude-embeds: ':not(.crayons-btn):not([class*="ltag"] *):not(.crayons-story *
     padding: var(--su-5);
     border: 1px solid var(--card-border);
     border-radius: var(--radius-lg, var(--radius));
-    background: var(--card-secondary-bg);
+    background: var(--ltag-col-background, var(--card-secondary-bg));
     line-height: 1.55;
 
     > p {
       margin-bottom: var(--su-3);
+    }
+
+    > p:first-child img {
+      display: block;
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      object-fit: cover;
+      border-radius: var(--radius);
     }
   }
 

--- a/app/assets/stylesheets/views/organizations_showcase.scss
+++ b/app/assets/stylesheets/views/organizations_showcase.scss
@@ -146,11 +146,6 @@ $exclude-embeds: ':not(.crayons-btn):not([class*="ltag"] *):not(.crayons-story *
     > p {
       margin-bottom: var(--su-3);
     }
-
-    > p:first-of-type {
-      font-weight: var(--fw-bold, 700);
-      color: var(--body-color);
-    }
   }
 
   .ltag-quote,

--- a/app/liquid_tags/col_tag.rb
+++ b/app/liquid_tags/col_tag.rb
@@ -3,7 +3,9 @@ class ColTag < Liquid::Block
 
   PARTIAL = "liquids/col".freeze
   VALID_SPANS = (1..4).to_a.freeze
-  OPTION_REGEXP = /\Aspan=(\d+)\z/
+  VALID_BACKGROUNDS = %w[default subtle].freeze
+  VALID_OPTIONS = %w[span background].freeze
+  OPTION_REGEXP = /\A(\w+)=(\S+)\z/
 
   # Extends RENDERED_MARKDOWN_SCRUBBER tags with block-level elements produced by liquid tags
   ALLOWED_TAGS = (MarkdownProcessor::AllowedTags::RENDERED_MARKDOWN_SCRUBBER + %w[div footer]).freeze
@@ -11,7 +13,9 @@ class ColTag < Liquid::Block
 
   def initialize(tag_name, markup, parse_context)
     super
-    @span = parse_span(markup.strip)
+    options = parse_col_options(markup.strip)
+    @span = parse_span(options["span"])
+    @background = parse_background(options["background"])
   end
 
   def render(context)
@@ -23,22 +27,44 @@ class ColTag < Liquid::Block
     )
     ApplicationController.render(
       partial: PARTIAL,
-      locals: { content: parsed_content, span: @span },
+      locals: { content: parsed_content, span: @span, background: @background },
     )
   end
 
   private
 
-  def parse_span(markup)
-    return 1 if markup.blank?
+  def parse_col_options(markup)
+    return {} if markup.blank?
 
-    match = markup.match(OPTION_REGEXP)
-    raise StandardError, I18n.t("liquid_tags.col_tag.invalid_span") unless match
+    markup.split.each_with_object({}) do |token, options|
+      match = token.match(OPTION_REGEXP)
+      option = match&.[](1)
+      if match.nil? || VALID_OPTIONS.exclude?(option) || options.key?(option)
+        raise StandardError, I18n.t("liquid_tags.col_tag.invalid_option", option: token)
+      end
 
-    span = match[1].to_i
-    raise StandardError, I18n.t("liquid_tags.col_tag.invalid_span") unless VALID_SPANS.include?(span)
+      options[option] = match[2]
+    end
+  end
+
+  def parse_span(value)
+    return 1 unless value
+
+    span = value.to_i
+    valid_integer = value.match?(/\A\d+\z/)
+    raise StandardError, I18n.t("liquid_tags.col_tag.invalid_span") unless valid_integer && VALID_SPANS.include?(span)
 
     span
+  end
+
+  def parse_background(value)
+    return unless value
+
+    unless VALID_BACKGROUNDS.include?(value)
+      raise StandardError, I18n.t("liquid_tags.col_tag.invalid_background")
+    end
+
+    value
   end
 end
 

--- a/app/views/liquids/_col.html.erb
+++ b/app/views/liquids/_col.html.erb
@@ -1,3 +1,3 @@
-<div class="ltag-col<%= " ltag-col-span-#{span}" if span > 1 %>">
+<div class="ltag-col<%= " ltag-col-span-#{span}" if span > 1 %><%= " ltag-col-background-#{background}" if background.present? %>">
   <%= content.html_safe %>
 </div>

--- a/app/views/pages/_editor_liquid_help.en.html.erb
+++ b/app/views/pages/_editor_liquid_help.en.html.erb
@@ -86,10 +86,10 @@
     <h4>Layout (Row &amp; Col)</h4>
     <p>Create responsive grid layouts:</p>
     <pre>{% row %}
-  {% col %}Column 1{% endcol %}
-  {% col span=2 %}Wide column{% endcol %}
+  {% col background=default %}Column 1{% endcol %}
+  {% col span=2 background=subtle %}Wide column{% endcol %}
 {% endrow %}</pre>
-    <p class="fs-s"><code>span</code> sets column width (1-4, default 1).</p>
+    <p class="fs-s"><code>span</code> sets column width (1-4, default 1). <code>background</code> accepts <code>default</code> or <code>subtle</code>.</p>
 
     <h4>Features</h4>
     <p>Display a grid of feature cards:</p>

--- a/config/locales/liquid_tags/en.yml
+++ b/config/locales/liquid_tags/en.yml
@@ -144,6 +144,8 @@ en:
     row_tag:
       no_args: "The row tag does not accept any arguments"
     col_tag:
+      invalid_background: "Background must be one of: default, subtle"
+      invalid_option: "Invalid option '%{option}' for col tag"
       invalid_span: "Span must be between 1 and 4"
     org_posts_tag:
       invalid_slug: Invalid organization slug

--- a/config/locales/liquid_tags/fr.yml
+++ b/config/locales/liquid_tags/fr.yml
@@ -144,6 +144,8 @@ fr:
     row_tag:
       no_args: "La balise row n'accepte aucun argument"
     col_tag:
+      invalid_background: "L’arrière-plan doit être l’un des suivants : default, subtle"
+      invalid_option: "Option '%{option}' non valide pour la balise col"
       invalid_span: "Le span doit être compris entre 1 et 4"
     org_posts_tag:
       invalid_slug: Slug de l'organisation non valide

--- a/config/locales/liquid_tags/pt.yml
+++ b/config/locales/liquid_tags/pt.yml
@@ -144,6 +144,8 @@ pt:
     row_tag:
       no_args: "A tag row não aceita argumentos"
     col_tag:
+      invalid_background: "O plano de fundo deve ser um dos seguintes: default, subtle"
+      invalid_option: "Opção '%{option}' inválida para a tag col"
       invalid_span: "O span deve estar entre 1 e 4"
     org_posts_tag:
       invalid_slug: Slug da organização inválido

--- a/spec/liquid_tags/row_col_tag_spec.rb
+++ b/spec/liquid_tags/row_col_tag_spec.rb
@@ -67,7 +67,41 @@ RSpec.describe "Row and Col liquid tags", type: :liquid_tag do
     it "raises an error for invalid span option" do
       expect do
         parse("{% row %}{% col foo=bar %}Content{% endcol %}{% endrow %}")
-      end.to raise_error(StandardError, /Span must be between 1 and 4/)
+      end.to raise_error(StandardError, /Invalid option 'foo=bar' for col tag/)
+    end
+  end
+
+  describe "col background option" do
+    it "adds the default background class" do
+      result = parse("{% row %}{% col background=default %}Content{% endcol %}{% endrow %}").render
+
+      expect(result).to include("ltag-col-background-default")
+    end
+
+    it "adds the subtle background class" do
+      result = parse("{% row %}{% col background=subtle %}Content{% endcol %}{% endrow %}").render
+
+      expect(result).to include("ltag-col-background-subtle")
+    end
+
+    it "combines background and span options in either order" do
+      first = parse("{% row %}{% col span=2 background=default %}Content{% endcol %}{% endrow %}").render
+      second = parse("{% row %}{% col background=subtle span=3 %}Content{% endcol %}{% endrow %}").render
+
+      expect(first).to include("ltag-col-span-2", "ltag-col-background-default")
+      expect(second).to include("ltag-col-span-3", "ltag-col-background-subtle")
+    end
+
+    it "raises an error for an unsupported background" do
+      expect do
+        parse("{% row %}{% col background=blue %}Content{% endcol %}{% endrow %}")
+      end.to raise_error(StandardError, /Background must be one of: default, subtle/)
+    end
+
+    it "raises an error for a duplicate option" do
+      expect do
+        parse("{% row %}{% col background=default background=subtle %}Content{% endcol %}{% endrow %}")
+      end.to raise_error(StandardError, /Invalid option 'background=subtle' for col tag/)
     end
   end
 
@@ -91,6 +125,27 @@ RSpec.describe "Row and Col liquid tags", type: :liquid_tag do
       expect(result).to match(/<h4[^>]*>/)
       expect(result).to include("Welcome to Forem")
       expect(result).to include("<p>Software that powers millions.</p>")
+    end
+
+    it "renders Markdown images inside columns" do
+      template = <<~LIQUID
+        {% row %}
+          {% col background=default %}
+          ![Cloud infrastructure](https://example.com/cloud.jpg)
+
+          ### Build on reliable infrastructure
+          {% endcol %}
+        {% endrow %}
+      LIQUID
+      result = MarkdownProcessor::Parser.new(template).finalize
+      column = Nokogiri::HTML.fragment(result).at_css(".ltag-col")
+
+      expect(column["class"]).to include("ltag-col-background-default")
+      expect(column.at_css("img").attributes.slice("src", "alt").transform_values(&:value)).to eq(
+        "src" => "https://example.com/cloud.jpg",
+        "alt" => "Cloud infrastructure",
+      )
+      expect(column.at_css("h3").text.squish).to eq("Build on reliable infrastructure")
     end
 
     it "evaluates Markdown headings in documented indented syntax" do


### PR DESCRIPTION
## Summary

- Add constrained background themes and optional subtitles to columns.
- Add an image-card treatment for visual content blocks.
- Update editor guidance, translations, and regression coverage.

## Why

Organization pages need a structured way to build image-led content cards without relying on custom HTML or broad page-specific styling.

## Validation

- `bin/rspec spec/liquid_tags/row_col_tag_spec.rb`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786905550&installation_id=139885019&pr_number=23639&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23639&signature=4c8febdd6dedc157925f56ed8c0ff22c19664c3e2e0cb0e1cf01490c95cdcdac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->