### PR TITLE
Add quote collections and polish quote cards

### DIFF
--- a/app/assets/stylesheets/ltags/QuoteTag.scss
+++ b/app/assets/stylesheets/ltags/QuoteTag.scss
@@ -82,9 +82,6 @@
   }
 
   .ltag-quote__body {
-    display: flex;
-    align-items: flex-start;
-    gap: var(--su-2);
     margin: 0;
     padding: 0;
     border: 0;
@@ -92,23 +89,10 @@
     color: var(--card-color);
   }
 
-  .ltag-quote__body .ltag-quote__mark {
-    flex: 0 0 auto;
-    color: var(--card-color-tertiary);
-    font-family: Georgia, serif;
-    font-size: 2.25rem;
-    line-height: 0.8;
-    user-select: none;
-  }
-
-  .ltag-quote__body .ltag-quote__mark--end {
-    align-self: flex-end;
-  }
-
-  .ltag-quote__text {
+  .ltag-quote__body .ltag-quote__text {
     min-width: 0;
-    flex: 1 1 auto;
     font-size: var(--fs-l);
+    font-style: italic;
     line-height: 1.55;
 
     > br {

--- a/app/assets/stylesheets/ltags/QuoteTag.scss
+++ b/app/assets/stylesheets/ltags/QuoteTag.scss
@@ -1,147 +1,163 @@
-.ltag-quote {
+.ltag-quotes {
   width: 100%;
-  max-width: 48rem;
+  max-width: 72rem;
+  margin: 0 auto var(--su-4);
+  columns: 2 24rem;
+  column-gap: var(--su-4);
+}
+
+.ltag-quote {
+  display: flex;
+  width: 100%;
+  max-width: 36rem;
   margin: 0 auto var(--su-4);
   padding: var(--su-5);
-  border: 1px solid var(--card-border);
-  border-radius: var(--radius);
-  background: var(--card-bg);
-  display: flex;
   flex-direction: column;
-  box-sizing: border-box;
   gap: var(--su-4);
+  box-sizing: border-box;
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-lg, var(--radius));
+  background: var(--card-bg);
+  box-shadow: var(--shadow-smooth);
 
-  .ltag-quote__body {
+  .ltag-quote__header {
     display: flex;
-    flex-wrap: wrap;
     align-items: center;
-    gap: var(--su-2);
-    padding: 0;
+    gap: var(--su-3);
+    min-width: 0;
   }
 
-  .ltag-quote__mark {
-    color: var(--card-color-tertiary);
-    user-select: none;
-
-    svg {
-      width: 24px;
-      height: 24px;
-    }
+  .ltag-quote__avatar {
+    display: block;
+    width: 52px;
+    height: 52px;
+    max-height: none;
+    flex: 0 0 52px;
+    border-radius: 50%;
+    object-fit: cover;
+    box-shadow: 0 0 0 1px var(--card-border);
   }
 
-  .ltag-quote__mark--start {
-    width: 100%;
-  }
-
-  .ltag-quote__mark--end {
+  .ltag-quote__identity {
     display: flex;
-    justify-content: flex-end;
-    width: 100%;
+    min-width: 0;
+    flex-direction: column;
+    align-items: flex-start;
+    line-height: 1.3;
   }
 
-  .ltag-quote__text {
-    font-size: var(--fs-xl);
-    line-height: 1.5;
-    color: var(--card-color);
-    width: 100%;
-    flex-grow: 1;
+  .ltag-quote__author {
+    max-width: 100%;
+    overflow: hidden;
+    font-size: var(--fs-l);
+    font-weight: var(--fw-bold);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 
-    > br { display: none; }
-    > :first-child { margin-top: 0; }
-    > :last-child { margin-bottom: 0; }
+  .ltag-quote__role {
+    color: var(--card-color-tertiary);
+    font-size: var(--fs-s);
   }
 
   .ltag-quote__rating {
     display: flex;
-    justify-content: flex-start;
-    gap: 2px;
+    gap: 1px;
+    margin-top: var(--su-1);
+    line-height: 1;
   }
 
   .ltag-quote__star {
-    color: var(--card-color-tertiary);
+    color: var(--card-border);
     font-size: var(--fs-l);
   }
 
   .ltag-quote__star--filled {
-    color: #f5a623;
+    color: var(--accent-brand);
   }
 
-  .ltag-quote__divider {
-    border: none;
-    border-top: 1px solid var(--card-border);
+  .ltag-quote__body {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--su-2);
     margin: 0;
-    width: 100%;
-    opacity: 1;
-    border-radius: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--card-color);
+  }
+
+  .ltag-quote__mark {
+    flex: 0 0 auto;
+    color: var(--card-color-tertiary);
+    font-family: Georgia, serif;
+    font-size: 2.25rem;
+    line-height: 0.8;
+    user-select: none;
+  }
+
+  .ltag-quote__text {
+    min-width: 0;
+    font-size: var(--fs-l);
+    line-height: 1.55;
+
+    > br {
+      display: none;
+    }
+
+    > :first-child {
+      margin-top: 0;
+    }
+
+    > :last-child {
+      margin-bottom: 0;
+    }
   }
 
   .ltag-quote__footer {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: var(--su-4);
+    padding-top: var(--su-3);
+    border-top: 1px solid var(--card-border);
   }
 
-  .ltag-quote__author-info {
-    display: flex;
-    align-items: center;
-    gap: var(--su-2);
-  }
-
-  .ltag-quote__avatar {
-    width: 48px;
-    height: 48px;
-    border-radius: 50%;
-    object-fit: cover;
-    flex-shrink: 0;
-    display: inline-block;
-    max-height: none;
-  }
-
-  .ltag-quote__meta {
-    display: flex;
-    flex-direction: column;
-  }
-
-  .ltag-quote__author {
-    font-weight: var(--fw-bold);
-  }
-
-  .ltag-quote__role,
   .ltag-quote__source {
-    font-size: var(--fs-s);
     color: var(--card-color-tertiary);
+    font-size: var(--fs-s);
+    font-style: normal;
   }
 
   .ltag-quote__link {
-    margin-left: auto;
-    font-weight: var(--fw-medium);
-    color: var(--accent-brand);
-    text-decoration: none;
-    white-space: nowrap;
     display: inline-flex;
     align-items: center;
-    gap: var(--su-2);
+    gap: var(--su-1);
+    color: var(--accent-brand);
+    font-size: var(--fs-s);
+    font-weight: var(--fw-medium);
+    text-decoration: none;
 
     &:hover {
       text-decoration: underline;
     }
   }
+}
 
-  @media (max-width: 767px) {
+.ltag-quotes .ltag-quote {
+  display: inline-flex;
+  max-width: none;
+  margin-bottom: var(--su-4);
+  break-inside: avoid;
+}
+
+@media (max-width: 767px) {
+  .ltag-quotes {
+    columns: 1;
+  }
+
+  .ltag-quote {
     padding: var(--su-4);
 
     .ltag-quote__text {
-      font-size: var(--fs-l);
-    }
-
-    .ltag-quote__footer {
-      align-items: flex-start;
-    }
-
-    .ltag-quote__link {
-      margin-left: 0;
+      font-size: var(--fs-base);
     }
   }
 }

--- a/app/assets/stylesheets/ltags/QuoteTag.scss
+++ b/app/assets/stylesheets/ltags/QuoteTag.scss
@@ -25,6 +25,11 @@
     align-items: center;
     gap: var(--su-3);
     min-width: 0;
+    color: inherit;
+    font-size: 1em;
+    font-style: normal;
+    text-align: left;
+    opacity: 1;
   }
 
   .ltag-quote__avatar {
@@ -87,7 +92,7 @@
     color: var(--card-color);
   }
 
-  .ltag-quote__mark {
+  .ltag-quote__body .ltag-quote__mark {
     flex: 0 0 auto;
     color: var(--card-color-tertiary);
     font-family: Georgia, serif;
@@ -96,8 +101,13 @@
     user-select: none;
   }
 
+  .ltag-quote__body .ltag-quote__mark--end {
+    align-self: flex-end;
+  }
+
   .ltag-quote__text {
     min-width: 0;
+    flex: 1 1 auto;
     font-size: var(--fs-l);
     line-height: 1.55;
 

--- a/app/assets/stylesheets/ltags/QuoteTag.scss
+++ b/app/assets/stylesheets/ltags/QuoteTag.scss
@@ -1,26 +1,26 @@
 .ltag-quote {
-  padding: var(--su-3) var(--su-4);
+  width: 100%;
+  max-width: 48rem;
+  margin: 0 auto var(--su-4);
+  padding: var(--su-5);
   border: 1px solid var(--card-border);
   border-radius: var(--radius);
   background: var(--card-bg);
-  margin-bottom: var(--su-4);
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  height: 100%;
   box-sizing: border-box;
-  gap: 0;
+  gap: var(--su-4);
 
   .ltag-quote__body {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: var(--su-1);
+    gap: var(--su-2);
     padding: 0;
   }
 
   .ltag-quote__mark {
-    color: var(--card-color);
+    color: var(--card-color-tertiary);
     user-select: none;
 
     svg {
@@ -40,7 +40,8 @@
   }
 
   .ltag-quote__text {
-    font-size: var(--fs-l);
+    font-size: var(--fs-xl);
+    line-height: 1.5;
     color: var(--card-color);
     width: 100%;
     flex-grow: 1;
@@ -52,9 +53,8 @@
 
   .ltag-quote__rating {
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
     gap: 2px;
-    margin-top: var(--su-2);
   }
 
   .ltag-quote__star {
@@ -69,7 +69,7 @@
   .ltag-quote__divider {
     border: none;
     border-top: 1px solid var(--card-border);
-    margin: var(--su-1) 0;
+    margin: 0;
     width: 100%;
     opacity: 1;
     border-radius: 0;
@@ -79,7 +79,8 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    gap: var(--su-2);
+    flex-wrap: wrap;
+    gap: var(--su-4);
   }
 
   .ltag-quote__author-info {
@@ -114,6 +115,7 @@
   }
 
   .ltag-quote__link {
+    margin-left: auto;
     font-weight: var(--fw-medium);
     color: var(--accent-brand);
     text-decoration: none;
@@ -124,6 +126,22 @@
 
     &:hover {
       text-decoration: underline;
+    }
+  }
+
+  @media (max-width: 767px) {
+    padding: var(--su-4);
+
+    .ltag-quote__text {
+      font-size: var(--fs-l);
+    }
+
+    .ltag-quote__footer {
+      align-items: flex-start;
+    }
+
+    .ltag-quote__link {
+      margin-left: 0;
     }
   }
 }

--- a/app/assets/stylesheets/views/organizations_showcase.scss
+++ b/app/assets/stylesheets/views/organizations_showcase.scss
@@ -98,6 +98,7 @@ $exclude-embeds: ':not(.crayons-btn):not([class*="ltag"] *):not(.crayons-story *
   // default margins.
   .ltag-features,
   .ltag-row,
+  .ltag-quotes,
   .ltag-quote,
   .ltag-offer,
   .ltag-slides,
@@ -159,6 +160,11 @@ $exclude-embeds: ':not(.crayons-btn):not([class*="ltag"] *):not(.crayons-story *
     padding: var(--su-6);
     border-radius: var(--radius-lg, var(--radius));
     box-shadow: var(--shadow-smooth);
+  }
+
+  .ltag-quotes .ltag-quote {
+    margin-bottom: var(--su-4);
+    padding: var(--su-5);
   }
 
   .ltag-offer {
@@ -301,6 +307,7 @@ $exclude-embeds: ':not(.crayons-btn):not([class*="ltag"] *):not(.crayons-story *
 
     .ltag-features,
     .ltag-row,
+    .ltag-quotes,
     .ltag-quote,
     .ltag-offer,
     .ltag-slides,

--- a/app/liquid_tags/quote_tag.rb
+++ b/app/liquid_tags/quote_tag.rb
@@ -35,9 +35,9 @@ class QuoteTag < Liquid::Block
     )
     # Collapse whitespace between HTML tags so the second Redcarpet pass in
     # MarkdownProcessor::Parser#finalize treats the output as one HTML block
-    # instead of interpreting indented SVG paths as code blocks and blank
-    # lines from ERB conditionals as block breaks. Only collapses whitespace
-    # between tags (template-introduced), preserving newlines within text content.
+    # instead of treating blank lines from ERB conditionals as block breaks.
+    # Only collapse template-introduced whitespace between tags, preserving
+    # newlines within text content.
     html.gsub(/>\s*\n\s*</, "> <").gsub(/\A\s+/, "").gsub(/\s+\z/, "")
   end
 

--- a/app/liquid_tags/quotes_tag.rb
+++ b/app/liquid_tags/quotes_tag.rb
@@ -1,0 +1,21 @@
+class QuotesTag < Liquid::Block
+  PARTIAL = "liquids/quotes".freeze
+
+  def initialize(tag_name, markup, parse_context)
+    super
+    raise StandardError, I18n.t("liquid_tags.quotes_tag.no_args") if markup.strip.present?
+  end
+
+  def render(context)
+    content = @body.nodelist.filter_map do |node|
+      node.render(context) if node.is_a?(QuoteTag)
+    end.join("\n")
+
+    ApplicationController.render(
+      partial: PARTIAL,
+      locals: { content: content },
+    ).gsub(/>\s*\n\s*</, "> <").strip
+  end
+end
+
+Liquid::Template.register_tag("quotes", QuotesTag)

--- a/app/views/liquids/_quote.html.erb
+++ b/app/views/liquids/_quote.html.erb
@@ -22,9 +22,7 @@
     </span>
   </figcaption>
   <blockquote class="ltag-quote__body">
-    <span class="ltag-quote__mark ltag-quote__mark--start" aria-hidden="true">“</span>
     <div class="ltag-quote__text"><%= content.html_safe %></div>
-    <span class="ltag-quote__mark ltag-quote__mark--end" aria-hidden="true">”</span>
   </blockquote>
   <% if source.present? || link.present? %>
     <footer class="ltag-quote__footer">

--- a/app/views/liquids/_quote.html.erb
+++ b/app/views/liquids/_quote.html.erb
@@ -22,8 +22,9 @@
     </span>
   </figcaption>
   <blockquote class="ltag-quote__body">
-    <span class="ltag-quote__mark" aria-hidden="true">“</span>
-    <span class="ltag-quote__text"><%= content.html_safe %></span>
+    <span class="ltag-quote__mark ltag-quote__mark--start" aria-hidden="true">“</span>
+    <div class="ltag-quote__text"><%= content.html_safe %></div>
+    <span class="ltag-quote__mark ltag-quote__mark--end" aria-hidden="true">”</span>
   </blockquote>
   <% if source.present? || link.present? %>
     <footer class="ltag-quote__footer">

--- a/app/views/liquids/_quote.html.erb
+++ b/app/views/liquids/_quote.html.erb
@@ -1,42 +1,40 @@
-<div class="ltag-quote">
-  <div class="ltag-quote__body">
-    <div class="ltag-quote__mark ltag-quote__mark--start">
-      <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-        <path d="M4.583 17.321C3.553 16.227 3 15 3 13.011C3 9.511 5.457 6.374 9.03 4.823L9.923 6.201C6.588 8.005 5.936 10.346 5.676 11.822C6.213 11.544 6.916 11.447 7.605 11.511C9.409 11.678 10.831 13.159 10.831 15C10.831 15.9283 10.4623 16.8185 9.80587 17.4749C9.1495 18.1313 8.25926 18.5 7.331 18.5C6.81766 18.4955 6.31034 18.389 5.83856 18.1866C5.36679 17.9841 4.93999 17.6899 4.583 17.321ZM14.583 17.321C13.553 16.227 13 15 13 13.011C13 9.511 15.457 6.374 19.03 4.823L19.923 6.201C16.588 8.005 15.936 10.346 15.676 11.822C16.213 11.544 16.916 11.447 17.605 11.511C19.409 11.678 20.831 13.159 20.831 15C20.831 15.9283 20.4623 16.8185 19.8059 17.4749C19.1495 18.1313 18.2593 18.5 17.331 18.5C16.8177 18.4955 16.3103 18.389 15.8386 18.1866C15.3668 17.9841 14.94 17.6899 14.583 17.321Z" />
-      </svg>
-    </div>
-    <div class="ltag-quote__text"><%= content.html_safe %></div>
-    <div class="ltag-quote__mark ltag-quote__mark--end">
-      <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-        <path d="M19.417 6.679C20.447 7.773 21 9 21 10.989C21 14.489 18.543 17.626 14.97 19.177L14.077 17.799C17.412 15.995 18.064 13.654 18.324 12.178C17.787 12.456 17.084 12.553 16.395 12.489C14.591 12.322 13.169 10.841 13.169 9C13.169 8.07174 13.5377 7.1815 14.1941 6.52513C14.8505 5.86875 15.7407 5.5 16.669 5.5C17.1823 5.50449 17.6897 5.61104 18.1614 5.81345C18.6332 6.01586 19.06 6.31008 19.417 6.679ZM9.417 6.679C10.447 7.773 11 9 11 10.989C11 14.489 8.543 17.626 4.97 19.177L4.077 17.799C7.412 15.995 8.064 13.654 8.324 12.178C7.787 12.456 7.084 12.553 6.395 12.489C4.591 12.322 3.169 10.841 3.169 9C3.169 8.07174 3.53775 7.1815 4.19413 6.52513C4.85051 5.86875 5.74074 5.5 6.669 5.5C7.18234 5.50449 7.68967 5.61104 8.16144 5.81344C8.63321 6.01585 9.06001 6.31008 9.417 6.679Z" />
-      </svg>
-    </div>
-  </div>
-  <% if rating %>
-    <div class="ltag-quote__rating" aria-label="<%= rating %> out of 5 stars">
-      <% 5.times do |i| %>
-        <span class="ltag-quote__star<%= ' ltag-quote__star--filled' if i < rating %>">★</span>
-      <% end %>
-    </div>
-  <% end %>
-  <hr class="ltag-quote__divider" />
-  <footer class="ltag-quote__footer">
-    <div class="ltag-quote__author-info">
-      <% if image.present? %>
-        <img class="ltag-quote__avatar" src="<%= image %>" alt="<%= author %>" loading="lazy" />
-      <% end %>
-      <div class="ltag-quote__meta">
-        <span class="ltag-quote__author"><%= author %></span>
-        <% if role.present? %>
-          <span class="ltag-quote__role"><%= role %></span>
-        <% end %>
-        <% if source.present? %>
-          <span class="ltag-quote__source"><%= source %></span>
-        <% end %>
-      </div>
-    </div>
-    <% if link.present? %>
-      <a href="<%= link %>" class="ltag-quote__link" target="_blank" rel="noopener noreferrer"><%= I18n.t("liquid_tags.quote_tag.learn_more") %> &rarr;</a>
+<% modifiers = ["ltag-quote"]
+   modifiers << "ltag-quote--with-avatar" if image.present?
+   modifiers << "ltag-quote--with-rating" if rating
+   modifiers << "ltag-quote--with-source" if source.present? || link.present? %>
+<figure class="<%= modifiers.join(' ') %>">
+  <figcaption class="ltag-quote__header">
+    <% if image.present? %>
+      <img class="ltag-quote__avatar" src="<%= image %>" alt="" loading="lazy" />
     <% end %>
-  </footer>
-</div>
+    <span class="ltag-quote__identity">
+      <span class="ltag-quote__author"><%= author %></span>
+      <% if role.present? %>
+        <span class="ltag-quote__role"><%= role %></span>
+      <% end %>
+      <% if rating %>
+        <span class="ltag-quote__rating" aria-label="<%= rating %> out of 5 stars">
+          <% 5.times do |i| %>
+            <span class="ltag-quote__star<%= ' ltag-quote__star--filled' if i < rating %>" aria-hidden="true">★</span>
+          <% end %>
+        </span>
+      <% end %>
+    </span>
+  </figcaption>
+  <blockquote class="ltag-quote__body">
+    <span class="ltag-quote__mark" aria-hidden="true">“</span>
+    <span class="ltag-quote__text"><%= content.html_safe %></span>
+  </blockquote>
+  <% if source.present? || link.present? %>
+    <footer class="ltag-quote__footer">
+      <% if link.present? %>
+        <a href="<%= link %>" class="ltag-quote__link" target="_blank" rel="noopener noreferrer">
+          <%= source.presence || I18n.t("liquid_tags.quote_tag.learn_more") %>
+          <span aria-hidden="true">↗</span>
+        </a>
+      <% else %>
+        <cite class="ltag-quote__source"><%= source %></cite>
+      <% end %>
+    </footer>
+  <% end %>
+</figure>

--- a/app/views/liquids/_quotes.html.erb
+++ b/app/views/liquids/_quotes.html.erb
@@ -1,0 +1,3 @@
+<div class="ltag-quotes">
+  <%= content.html_safe %>
+</div>

--- a/app/views/pages/_editor_liquid_help.en.html.erb
+++ b/app/views/pages/_editor_liquid_help.en.html.erb
@@ -102,6 +102,11 @@
     <p>Display a testimonial or quote:</p>
     <pre>{% quote author="Jane Doe" role="CTO" rating=5 %}Great product!{% endquote %}</pre>
     <p class="fs-s">Options: <code>author</code> (required), <code>role</code>, <code>image</code>, <code>rating</code> (1-5), <code>source</code>, <code>link</code>.</p>
+    <p>Group several testimonials into responsive columns:</p>
+    <pre>{% quotes %}
+  {% quote author="Jane Doe" rating=5 %}Great product!{% endquote %}
+  {% quote author="John Smith" %}Easy to recommend.{% endquote %}
+{% endquotes %}</pre>
 
     <h4>Offer</h4>
     <p>Create a call-to-action box with a button:</p>

--- a/config/locales/liquid_tags/en.yml
+++ b/config/locales/liquid_tags/en.yml
@@ -168,6 +168,8 @@ en:
       missing_author: "Quote tag requires an author option"
       invalid_rating: "Rating must be between 1 and 5"
       learn_more: "Learn more"
+    quotes_tag:
+      no_args: "The quotes tag does not accept any arguments"
     slide_tag:
       missing_image: "Slide tag requires an image option"
       missing_content: "Slide tag requires at least one of: image, video, or link"

--- a/config/locales/liquid_tags/fr.yml
+++ b/config/locales/liquid_tags/fr.yml
@@ -168,6 +168,8 @@ fr:
       missing_author: "La balise quote nécessite une option author"
       invalid_rating: "La note doit être comprise entre 1 et 5"
       learn_more: "En savoir plus"
+    quotes_tag:
+      no_args: "La balise quotes n'accepte aucun argument"
     slide_tag:
       missing_image: "La balise slide nécessite une option image"
       missing_content: "La balise slide nécessite au moins l'un des éléments suivants : image, video ou link"

--- a/config/locales/liquid_tags/pt.yml
+++ b/config/locales/liquid_tags/pt.yml
@@ -168,6 +168,8 @@ pt:
       missing_author: "A tag quote requer uma opção author"
       invalid_rating: "A avaliação deve estar entre 1 e 5"
       learn_more: "Saiba mais"
+    quotes_tag:
+      no_args: "A tag quotes não aceita argumentos"
     slide_tag:
       missing_image: "A tag slide requer uma opção image"
       missing_content: "A tag slide requer pelo menos um dos seguintes: image, video ou link"

--- a/spec/liquid_tags/quote_tag_spec.rb
+++ b/spec/liquid_tags/quote_tag_spec.rb
@@ -27,12 +27,14 @@ RSpec.describe "Quote liquid tag", type: :liquid_tag do
     it "renders author with avatar image" do
       result = parse('{% quote author="Jane" image="https://example.com/avatar.png" %}Text{% endquote %}').render
       expect(result).to include("ltag-quote__avatar")
+      expect(result).to include("ltag-quote--with-avatar")
       expect(result).to include("https://example.com/avatar.png")
     end
 
     it "renders learn more link" do
       result = parse('{% quote author="Jane" link="https://example.com" %}Text{% endquote %}').render
       expect(result).to include("ltag-quote__link")
+      expect(result).to include("ltag-quote--with-source")
       expect(result).to include('href="https://example.com"')
       expect(result).to include("Learn more")
     end
@@ -50,6 +52,7 @@ RSpec.describe "Quote liquid tag", type: :liquid_tag do
     it "renders star rating" do
       result = parse('{% quote author="Jane" rating=4 %}Good product{% endquote %}').render
       expect(result).to include("ltag-quote__rating")
+      expect(result).to include("ltag-quote--with-rating")
       expect(result).to include("4 out of 5 stars")
       filled_count = result.scan("ltag-quote__star--filled").size
       expect(filled_count).to eq(4)
@@ -73,6 +76,16 @@ RSpec.describe "Quote liquid tag", type: :liquid_tag do
       expect(result).to include("Product Hunt")
     end
 
+    it "uses the source as the external link label" do
+      template = '{% quote author="Jane" source="Customer story" link="https://example.com" %}Nice{% endquote %}'
+      result = parse(template).render
+      link = Nokogiri::HTML.fragment(result).at_css(".ltag-quote__link")
+
+      expect(link.text).to include("Customer story")
+      expect(link["target"]).to eq("_blank")
+      expect(link["rel"]).to eq("noopener noreferrer")
+    end
+
     it "raises error for rating=0" do
       expect do
         parse('{% quote author="Jane" rating=0 %}Bad{% endquote %}')
@@ -92,11 +105,29 @@ RSpec.describe "Quote liquid tag", type: :liquid_tag do
         parse('{% quote role="CTO" %}No author{% endquote %}')
       end.to raise_error(StandardError, /requires an author/)
     end
+
+    it "rejects an invalid avatar URL" do
+      expect do
+        parse('{% quote author="Jane" image="javascript:alert(1)" %}Nope{% endquote %}')
+      end.to raise_error(StandardError, /Invalid URL for 'image'/)
+    end
+
+    it "rejects an invalid external link URL" do
+      expect do
+        parse('{% quote author="Jane" link="javascript:alert(1)" %}Nope{% endquote %}')
+      end.to raise_error(StandardError, /Invalid URL for 'link'/)
+    end
   end
 
   describe "combined options" do
     it "renders a full review with all options" do
-      result = parse('{% quote author="Jane Doe" role="Verified Buyer" image="https://example.com/jane.jpg" rating=5 source="App Store" link="https://example.com" %}Amazing product, 10/10 would recommend!{% endquote %}').render
+      template = <<~LIQUID.squish
+        {% quote author="Jane Doe" role="Verified Buyer" image="https://example.com/jane.jpg"
+          rating=5 source="App Store" link="https://example.com" %}
+          Amazing product, 10/10 would recommend!
+        {% endquote %}
+      LIQUID
+      result = parse(template).render
       expect(result).to include("Jane Doe")
       expect(result).to include("Verified Buyer")
       expect(result).to include("https://example.com/jane.jpg")

--- a/spec/liquid_tags/quote_tag_spec.rb
+++ b/spec/liquid_tags/quote_tag_spec.rb
@@ -12,13 +12,11 @@ RSpec.describe "Quote liquid tag", type: :liquid_tag do
   describe "basic rendering" do
     it "renders a quote with author" do
       result = parse('{% quote author="Jane Doe" %}Great platform!{% endquote %}').render
-      fragment = Nokogiri::HTML.fragment(result)
 
       expect(result).to include('class="ltag-quote"')
       expect(result).to include("ltag-quote__body")
       expect(result).to include("Great platform!")
       expect(result).to include("Jane Doe")
-      expect(fragment.css(".ltag-quote__mark").map(&:text)).to eq(%w[“ ”])
     end
 
     it "renders author with role" do

--- a/spec/liquid_tags/quote_tag_spec.rb
+++ b/spec/liquid_tags/quote_tag_spec.rb
@@ -12,10 +12,13 @@ RSpec.describe "Quote liquid tag", type: :liquid_tag do
   describe "basic rendering" do
     it "renders a quote with author" do
       result = parse('{% quote author="Jane Doe" %}Great platform!{% endquote %}').render
+      fragment = Nokogiri::HTML.fragment(result)
+
       expect(result).to include('class="ltag-quote"')
       expect(result).to include("ltag-quote__body")
       expect(result).to include("Great platform!")
       expect(result).to include("Jane Doe")
+      expect(fragment.css(".ltag-quote__mark").map(&:text)).to eq(%w[“ ”])
     end
 
     it "renders author with role" do

--- a/spec/liquid_tags/quotes_tag_spec.rb
+++ b/spec/liquid_tags/quotes_tag_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe QuotesTag, type: :liquid_tag do
+  before do
+    Liquid::Template.register_tag("quote", QuoteTag)
+    Liquid::Template.register_tag("quotes", described_class)
+  end
+
+  it "renders nested quotes as a collection" do
+    result = Liquid::Template.parse(<<~LIQUID).render
+      {% quotes %}
+        {% quote author="Jane" rating=5 %}First review{% endquote %}
+        {% quote author="John" %}Second review{% endquote %}
+      {% endquotes %}
+    LIQUID
+
+    fragment = Nokogiri::HTML.fragment(result)
+    expect(fragment.at_css(".ltag-quotes")).to be_present
+    expect(fragment.css(".ltag-quote").length).to eq(2)
+    expect(fragment.text).to include("First review", "Second review")
+  end
+
+  it "ignores content other than nested quotes" do
+    result = Liquid::Template.parse(<<~LIQUID).render
+      {% quotes %}
+        This text should not render.
+        {% quote author="Jane" %}Visible review{% endquote %}
+      {% endquotes %}
+    LIQUID
+
+    expect(result).to include("Visible review")
+    expect(result).not_to include("This text should not render")
+  end
+
+  it "rejects arguments" do
+    expect do
+      Liquid::Template.parse("{% quotes columns=3 %}{% endquotes %}")
+    end.to raise_error(StandardError, /does not accept any arguments/)
+  end
+end

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -540,18 +540,18 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
   end
 
   context "when rendering a quote liquid tag through the full pipeline" do
-    it "preserves quote tag HTML structure without converting SVG to code blocks" do
+    it "preserves the quote tag HTML structure" do
       markdown = '{% quote author="Jane Doe" role="CTO" link="https://example.com" %}Great platform!{% endquote %}'
       result = generate_and_parse_markdown(markdown)
+      quote = Nokogiri::HTML.fragment(result).at_css(".ltag-quote")
 
-      expect(result).to include('class="ltag-quote"')
+      expect(quote).to be_present
+      expect(quote["class"].split).to include("ltag-quote--with-source")
       expect(result).to include("ltag-quote__body")
       expect(result).to include("ltag-quote__footer")
       expect(result).to include("Jane Doe")
       expect(result).to include("Great platform!")
-      # SVG quote marks must render as actual SVG, not as escaped code blocks
       expect(result).not_to include("<pre><code>")
-      expect(result).not_to include("&lt;svg")
     end
   end
 


### PR DESCRIPTION
## Summary

- Add a collection wrapper for responsive groups of quotes.
- Support optional attribution details, ratings, avatars, and destination links.
- Refine quote-card layout, imagery, and typography while preserving standalone quote usage.

## Why

A collection-level layout makes testimonial and review sections easier to author and gives optional metadata a consistent visual hierarchy.

## Validation

- `bin/rspec spec/liquid_tags/quote_tag_spec.rb spec/liquid_tags/quotes_tag_spec.rb spec/services/markdown_processor/parser_spec.rb`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786905550&installation_id=139885019&pr_number=23640&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23640&signature=5b22b233e3aa55331c70b6ce70099363de333fa57c4724812393d6d8a82066fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->