### PR TITLE
Refactor slides into a native-scroll carousel

### DIFF
--- a/app/assets/stylesheets/ltags/SlidesTag.scss
+++ b/app/assets/stylesheets/ltags/SlidesTag.scss
@@ -40,6 +40,10 @@
   aspect-ratio: 16 / 9;
 }
 
+.ltag-slide__image--embed {
+  border: 0;
+}
+
 .ltag-slide__link {
   display: block;
   position: relative;
@@ -69,16 +73,22 @@
   pointer-events: none;
 }
 
-// Carousel mode
 .ltag-slides--carousel {
   position: relative;
-  overflow: hidden;
+  overflow: visible;
+
+  .ltag-slides__viewport {
+    position: relative;
+  }
 
   .ltag-slides__track {
-    overflow: visible;
-    gap: 0;
-    padding-bottom: 0;
-    transition: transform 0.4s ease;
+    align-items: flex-start;
+    gap: var(--su-4);
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    padding: 0 0 var(--su-2);
+    scroll-behavior: smooth;
+    scrollbar-width: none;
     flex-wrap: nowrap;
 
     &::-webkit-scrollbar {
@@ -87,10 +97,16 @@
   }
 
   .ltag-slide {
-    flex: 0 0 100%;
-    min-width: 100%;
-    border: none;
-    border-radius: 0;
+    flex: 0 0 84%;
+    min-width: 0;
+    background: var(--card-bg);
+  }
+
+  .ltag-slide__image:not(.ltag-slide__image--embed) {
+    aspect-ratio: auto;
+    max-height: 26rem;
+    object-fit: contain;
+    background: var(--card-secondary-bg);
   }
 }
 
@@ -101,54 +117,84 @@
   background: var(--card-bg);
   border: 1px solid var(--card-border);
   border-radius: 50%;
-  width: 40px;
-  height: 40px;
-  font-size: 1.5rem;
-  line-height: 1;
+  width: 44px;
+  height: 44px;
+  padding: 0;
   cursor: pointer;
   color: var(--card-color);
-  display: flex;
+  display: none;
   align-items: center;
   justify-content: center;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   z-index: 2;
+  transition: opacity 0.15s ease, background-color 0.15s ease, color 0.15s ease;
 
   &:hover {
     background: var(--card-color);
     color: var(--card-bg);
   }
-}
 
-.ltag-slides__nav--prev {
-  left: var(--su-3);
-}
+  &:disabled {
+    cursor: default;
+    opacity: 0.35;
+  }
 
-.ltag-slides__nav--next {
-  right: var(--su-3);
-}
+  &:disabled:hover {
+    background: var(--card-bg);
+    color: var(--card-color);
+  }
 
-.ltag-slides__dots {
-  display: flex;
-  justify-content: center;
-  gap: var(--su-2);
-  padding: var(--su-3) 0;
-}
-
-.ltag-slides__dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  border: 1px solid var(--card-color-tertiary);
-  background: transparent;
-  cursor: pointer;
-  padding: 0;
-
-  &:hover {
-    background: var(--card-color-tertiary);
+  svg {
+    width: 24px;
+    height: 24px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
   }
 }
 
-.ltag-slides__dot--active {
+.ltag-slides__nav--prev {
+  left: var(--su-2);
+}
+
+.ltag-slides__nav--next {
+  left: calc(84% - 22px);
+}
+
+.ltag-slides__progress {
+  position: relative;
+  height: 3px;
+  margin-top: var(--su-2);
+  overflow: hidden;
+  border-radius: var(--radius);
+  background: var(--card-border);
+}
+
+.ltag-slides__progress-thumb {
+  position: absolute;
+  inset-block: 0;
+  left: 0;
+  width: 100%;
+  border-radius: inherit;
   background: var(--accent-brand);
-  border-color: var(--accent-brand);
+  transition: left 0.1s linear, width 0.1s linear;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ltag-slides__nav {
+    display: flex;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ltag-slides--carousel .ltag-slides__track {
+    scroll-behavior: auto;
+  }
+
+  .ltag-slides__progress-thumb,
+  .ltag-slides__nav {
+    transition: none;
+  }
 }

--- a/app/assets/stylesheets/ltags/SlidesTag.scss
+++ b/app/assets/stylesheets/ltags/SlidesTag.scss
@@ -134,12 +134,12 @@
     color: var(--card-bg);
   }
 
-  &:disabled {
+  &[aria-disabled='true'] {
     cursor: default;
     opacity: 0.35;
   }
 
-  &:disabled:hover {
+  &[aria-disabled='true']:hover {
     background: var(--card-bg);
     color: var(--card-color);
   }

--- a/app/javascript/initializers/__tests__/initializeSlides.test.js
+++ b/app/javascript/initializers/__tests__/initializeSlides.test.js
@@ -1,0 +1,146 @@
+import { initializeSlides } from '../initializeSlides';
+
+function renderCarousel() {
+  document.body.innerHTML = `
+    <div class="ltag-slides ltag-slides--carousel">
+      <div class="ltag-slides__viewport">
+        <div class="ltag-slides__track" style="column-gap: 16px" tabindex="0">
+          <div class="ltag-slide"></div>
+          <div class="ltag-slide"></div>
+          <div class="ltag-slide"></div>
+        </div>
+        <button class="ltag-slides__nav--prev" disabled></button>
+        <button class="ltag-slides__nav--next" disabled></button>
+      </div>
+      <div class="ltag-slides__progress">
+        <span class="ltag-slides__progress-thumb"></span>
+      </div>
+    </div>
+  `;
+
+  const container = document.querySelector('.ltag-slides');
+  const track = container.querySelector('.ltag-slides__track');
+  const slides = container.querySelectorAll('.ltag-slide');
+
+  Object.defineProperties(track, {
+    clientWidth: { configurable: true, value: 300 },
+    scrollWidth: { configurable: true, value: 900 },
+    scrollLeft: { configurable: true, value: 0, writable: true },
+  });
+  track.scrollTo = jest.fn();
+  slides.forEach((slide) => {
+    slide.getBoundingClientRect = jest.fn(() => ({ width: 240 }));
+  });
+
+  return { container, track, slides };
+}
+
+describe('initializeSlides', () => {
+  beforeEach(() => {
+    window.matchMedia = jest.fn(() => ({ matches: false }));
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    jest.restoreAllMocks();
+  });
+
+  it('initializes card metadata and the scroll controls', () => {
+    const { container, track, slides } = renderCarousel();
+
+    initializeSlides();
+
+    expect(container.dataset.slidesInitialized).toBe('true');
+    expect(slides[1].getAttribute('role')).toBe('group');
+    expect(slides[1].getAttribute('aria-posinset')).toBe('2');
+    expect(slides[1].getAttribute('aria-setsize')).toBe('3');
+    expect(container.querySelector('.ltag-slides__nav--prev').disabled).toBe(
+      true,
+    );
+    expect(container.querySelector('.ltag-slides__nav--next').disabled).toBe(
+      false,
+    );
+    expect(
+      container.querySelector('.ltag-slides__progress-thumb').style.width,
+    ).toBe('33.33333333333333%');
+    expect(track.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('scrolls by one card plus the gap without tracking an index', () => {
+    const { container, track } = renderCarousel();
+    initializeSlides();
+
+    container.querySelector('.ltag-slides__nav--next').click();
+
+    expect(track.scrollTo).toHaveBeenCalledWith({
+      left: 256,
+      behavior: 'smooth',
+    });
+  });
+
+  it('updates disabled controls and progress from the native scroll position', () => {
+    const { container, track } = renderCarousel();
+    initializeSlides();
+    track.scrollLeft = 600;
+
+    track.dispatchEvent(new Event('scroll'));
+
+    expect(container.querySelector('.ltag-slides__nav--prev').disabled).toBe(
+      false,
+    );
+    expect(container.querySelector('.ltag-slides__nav--next').disabled).toBe(
+      true,
+    );
+    expect(
+      container.querySelector('.ltag-slides__progress-thumb').style.left,
+    ).toBe('66.66666666666667%');
+  });
+
+  it('uses instant scrolling when reduced motion is preferred', () => {
+    const { container, track } = renderCarousel();
+    window.matchMedia = jest.fn(() => ({ matches: true }));
+    initializeSlides();
+
+    container.querySelector('.ltag-slides__nav--next').click();
+
+    expect(track.scrollTo).toHaveBeenCalledWith({
+      left: 256,
+      behavior: 'auto',
+    });
+  });
+
+  it('scrolls one card when the track or its controls have keyboard focus', () => {
+    const { container, track } = renderCarousel();
+    initializeSlides();
+    const nextButton = container.querySelector('.ltag-slides__nav--next');
+
+    track.focus();
+    track.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+    );
+
+    nextButton.focus();
+    nextButton.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }),
+    );
+
+    expect(track.scrollTo).toHaveBeenNthCalledWith(1, {
+      left: 256,
+      behavior: 'smooth',
+    });
+    expect(track.scrollTo).toHaveBeenNthCalledWith(2, {
+      left: -256,
+      behavior: 'smooth',
+    });
+  });
+
+  it('does not attach duplicate controls when initialized again', () => {
+    const { container, track } = renderCarousel();
+    initializeSlides();
+    initializeSlides();
+
+    container.querySelector('.ltag-slides__nav--next').click();
+
+    expect(track.scrollTo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/javascript/initializers/__tests__/initializeSlides.test.js
+++ b/app/javascript/initializers/__tests__/initializeSlides.test.js
@@ -54,8 +54,18 @@ describe('initializeSlides', () => {
     expect(slides[1].getAttribute('role')).toBe('group');
     expect(slides[1].getAttribute('aria-posinset')).toBe('2');
     expect(slides[1].getAttribute('aria-setsize')).toBe('3');
+    expect(
+      container
+        .querySelector('.ltag-slides__nav--prev')
+        .getAttribute('aria-disabled'),
+    ).toBe('true');
+    expect(
+      container
+        .querySelector('.ltag-slides__nav--next')
+        .getAttribute('aria-disabled'),
+    ).toBe('false');
     expect(container.querySelector('.ltag-slides__nav--prev').disabled).toBe(
-      true,
+      false,
     );
     expect(container.querySelector('.ltag-slides__nav--next').disabled).toBe(
       false,
@@ -85,12 +95,16 @@ describe('initializeSlides', () => {
 
     track.dispatchEvent(new Event('scroll'));
 
-    expect(container.querySelector('.ltag-slides__nav--prev').disabled).toBe(
-      false,
-    );
-    expect(container.querySelector('.ltag-slides__nav--next').disabled).toBe(
-      true,
-    );
+    expect(
+      container
+        .querySelector('.ltag-slides__nav--prev')
+        .getAttribute('aria-disabled'),
+    ).toBe('false');
+    expect(
+      container
+        .querySelector('.ltag-slides__nav--next')
+        .getAttribute('aria-disabled'),
+    ).toBe('true');
     expect(
       container.querySelector('.ltag-slides__progress-thumb').style.left,
     ).toBe('66.66666666666667%');
@@ -129,9 +143,50 @@ describe('initializeSlides', () => {
       behavior: 'smooth',
     });
     expect(track.scrollTo).toHaveBeenNthCalledWith(2, {
-      left: -256,
+      left: 0,
       behavior: 'smooth',
     });
+  });
+
+  it('keeps a disabled end control focused so arrow keys can reverse', () => {
+    const { container, track } = renderCarousel();
+    initializeSlides();
+    const nextButton = container.querySelector('.ltag-slides__nav--next');
+    nextButton.focus();
+    track.scrollLeft = 600;
+
+    track.dispatchEvent(new Event('scroll'));
+
+    expect(nextButton.getAttribute('aria-disabled')).toBe('true');
+    expect(document.activeElement).toBe(nextButton);
+
+    nextButton.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }),
+    );
+    expect(track.scrollTo).toHaveBeenLastCalledWith({
+      left: 344,
+      behavior: 'smooth',
+    });
+  });
+
+  it('accumulates rapid key presses against a bounded pending target', () => {
+    const { container, track } = renderCarousel();
+    initializeSlides();
+    const nextButton = container.querySelector('.ltag-slides__nav--next');
+    nextButton.focus();
+
+    ['ArrowRight', 'ArrowRight', 'ArrowRight', 'ArrowLeft', 'ArrowLeft'].forEach(
+      (key) => {
+        nextButton.dispatchEvent(
+          new KeyboardEvent('keydown', { key, bubbles: true }),
+        );
+      },
+    );
+
+    expect(track.scrollTo.mock.calls.map(([options]) => options.left)).toEqual([
+      256, 512, 600, 344, 88,
+    ]);
+    expect(document.activeElement).toBe(nextButton);
   });
 
   it('does not attach duplicate controls when initialized again', () => {

--- a/app/javascript/initializers/initializeSlides.js
+++ b/app/javascript/initializers/initializeSlides.js
@@ -10,6 +10,8 @@ function initializeCarousel(container) {
   const progressThumb = container.querySelector(
     '.ltag-slides__progress-thumb',
   );
+  let requestedScrollPosition = null;
+  let requestedScrollReset;
 
   if (
     !track ||
@@ -20,6 +22,12 @@ function initializeCarousel(container) {
   ) {
     return;
   }
+
+  // Existing pages may contain carousel HTML rendered before controls used
+  // aria-disabled. Remove the native attribute so initialization can preserve
+  // focus at either endpoint.
+  previousButton.disabled = false;
+  nextButton.disabled = false;
 
   container.dataset.slidesInitialized = 'true';
   slides.forEach((slide, index) => {
@@ -36,8 +44,11 @@ function initializeCarousel(container) {
       : 1;
     const progress = maximumScroll ? scrollPosition / maximumScroll : 0;
 
-    previousButton.disabled = scrollPosition <= 1;
-    nextButton.disabled = scrollPosition >= maximumScroll - 1;
+    previousButton.setAttribute('aria-disabled', scrollPosition <= 1);
+    nextButton.setAttribute(
+      'aria-disabled',
+      scrollPosition >= maximumScroll - 1,
+    );
     progressThumb.style.width = `${visibleRatio * 100}%`;
     progressThumb.style.left = `${progress * (1 - visibleRatio) * 100}%`;
   };
@@ -49,17 +60,38 @@ function initializeCarousel(container) {
   };
 
   const scrollOneCard = (direction) => {
+    const maximumScroll = Math.max(track.scrollWidth - track.clientWidth, 0);
+    const startingPosition =
+      requestedScrollPosition ??
+      Math.min(Math.max(track.scrollLeft, 0), maximumScroll);
+    requestedScrollPosition = Math.min(
+      Math.max(startingPosition + direction * cardStep(), 0),
+      maximumScroll,
+    );
     const reduceMotion = window.matchMedia?.(
       '(prefers-reduced-motion: reduce)',
     ).matches;
     track.scrollTo({
-      left: track.scrollLeft + direction * cardStep(),
+      left: requestedScrollPosition,
       behavior: reduceMotion ? 'auto' : 'smooth',
     });
+
+    window.clearTimeout(requestedScrollReset);
+    requestedScrollReset = window.setTimeout(() => {
+      requestedScrollPosition = null;
+    }, 1000);
   };
 
-  previousButton.addEventListener('click', () => scrollOneCard(-1));
-  nextButton.addEventListener('click', () => scrollOneCard(1));
+  previousButton.addEventListener('click', () => {
+    if (previousButton.getAttribute('aria-disabled') !== 'true') {
+      scrollOneCard(-1);
+    }
+  });
+  nextButton.addEventListener('click', () => {
+    if (nextButton.getAttribute('aria-disabled') !== 'true') {
+      scrollOneCard(1);
+    }
+  });
   container.addEventListener('keydown', (event) => {
     if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
 

--- a/app/javascript/initializers/initializeSlides.js
+++ b/app/javascript/initializers/initializeSlides.js
@@ -1,0 +1,87 @@
+const CAROUSEL_SELECTOR = '.ltag-slides--carousel';
+
+function initializeCarousel(container) {
+  if (container.dataset.slidesInitialized === 'true') return;
+
+  const track = container.querySelector('.ltag-slides__track');
+  const slides = Array.from(container.querySelectorAll('.ltag-slide'));
+  const previousButton = container.querySelector('.ltag-slides__nav--prev');
+  const nextButton = container.querySelector('.ltag-slides__nav--next');
+  const progressThumb = container.querySelector(
+    '.ltag-slides__progress-thumb',
+  );
+
+  if (
+    !track ||
+    slides.length === 0 ||
+    !previousButton ||
+    !nextButton ||
+    !progressThumb
+  ) {
+    return;
+  }
+
+  container.dataset.slidesInitialized = 'true';
+  slides.forEach((slide, index) => {
+    slide.setAttribute('role', 'group');
+    slide.setAttribute('aria-posinset', index + 1);
+    slide.setAttribute('aria-setsize', slides.length);
+  });
+
+  const updateControls = () => {
+    const maximumScroll = Math.max(track.scrollWidth - track.clientWidth, 0);
+    const scrollPosition = Math.min(Math.max(track.scrollLeft, 0), maximumScroll);
+    const visibleRatio = track.scrollWidth
+      ? Math.min(track.clientWidth / track.scrollWidth, 1)
+      : 1;
+    const progress = maximumScroll ? scrollPosition / maximumScroll : 0;
+
+    previousButton.disabled = scrollPosition <= 1;
+    nextButton.disabled = scrollPosition >= maximumScroll - 1;
+    progressThumb.style.width = `${visibleRatio * 100}%`;
+    progressThumb.style.left = `${progress * (1 - visibleRatio) * 100}%`;
+  };
+
+  const cardStep = () => {
+    const gap = parseFloat(window.getComputedStyle(track).columnGap) || 0;
+    const cardWidth = slides[0].getBoundingClientRect().width;
+    return cardWidth + gap;
+  };
+
+  const scrollOneCard = (direction) => {
+    const reduceMotion = window.matchMedia?.(
+      '(prefers-reduced-motion: reduce)',
+    ).matches;
+    track.scrollTo({
+      left: track.scrollLeft + direction * cardStep(),
+      behavior: reduceMotion ? 'auto' : 'smooth',
+    });
+  };
+
+  previousButton.addEventListener('click', () => scrollOneCard(-1));
+  nextButton.addEventListener('click', () => scrollOneCard(1));
+  container.addEventListener('keydown', (event) => {
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+
+    event.preventDefault();
+    scrollOneCard(event.key === 'ArrowLeft' ? -1 : 1);
+  });
+  track.addEventListener('scroll', updateControls, { passive: true });
+
+  if (typeof ResizeObserver !== 'undefined') {
+    const resizeObserver = new ResizeObserver(() => {
+      if (!container.isConnected) {
+        resizeObserver.disconnect();
+        return;
+      }
+      updateControls();
+    });
+    resizeObserver.observe(track);
+  }
+
+  updateControls();
+}
+
+export function initializeSlides(root = document) {
+  root.querySelectorAll(CAROUSEL_SELECTOR).forEach(initializeCarousel);
+}

--- a/app/javascript/packs/application.jsx
+++ b/app/javascript/packs/application.jsx
@@ -10,6 +10,7 @@ import { createRootFragment } from '../shared/preact/preact-root-fragment';
 import { trackCreateAccountClicks } from '@utilities/ahoy/trackEvents';
 import { showWindowModal, closeWindowModal } from '@utilities/showModal';
 import * as Runtime from '@utilities/runtime';
+import { initializeSlides } from '../initializers/initializeSlides';
 
 Document.prototype.ready = new Promise((resolve) => {
   if (document.readyState !== 'loading') {
@@ -77,6 +78,9 @@ if (document.getElementById('video-player-source')) {
 }
 
 initializePodcastPlayback();
+document.ready.then(() => {
+  initializeSlides();
+});
 InstantClick.on('change', () => {
   if (document.location.pathname.startsWith('/dashboard')) {
     import('./initializers/initializeDashboardSort').then(({ initializeDashboardSort }) => {
@@ -91,6 +95,7 @@ InstantClick.on('change', () => {
   }
 
   initializePodcastPlayback();
+  initializeSlides();
 
   if (window.instgrm?.Embeds?.process) {
     window.instgrm.Embeds.process();

--- a/app/views/liquids/_slide.html.erb
+++ b/app/views/liquids/_slide.html.erb
@@ -16,8 +16,7 @@
   <% elsif video_embed_id.present? %>
     <iframe
       src="https://www.youtube.com/embed/<%= video_embed_id %>"
-      class="ltag-slide__image"
-      style="border:0;"
+      class="ltag-slide__image ltag-slide__image--embed"
       title="<%= title.presence || 'Embedded video' %>"
       allowfullscreen
       loading="lazy">

--- a/app/views/liquids/_slides.html.erb
+++ b/app/views/liquids/_slides.html.erb
@@ -14,7 +14,7 @@
         class="ltag-slides__nav ltag-slides__nav--prev"
         type="button"
         aria-label="<%= I18n.t('liquid_tags.slides_tag.previous') %>"
-        disabled>
+        aria-disabled="true">
         <svg viewBox="0 0 24 24" aria-hidden="true">
           <path d="m15 18-6-6 6-6" />
         </svg>
@@ -23,7 +23,7 @@
         class="ltag-slides__nav ltag-slides__nav--next"
         type="button"
         aria-label="<%= I18n.t('liquid_tags.slides_tag.next') %>"
-        disabled>
+        aria-disabled="true">
         <svg viewBox="0 0 24 24" aria-hidden="true">
           <path d="m9 18 6-6-6-6" />
         </svg>

--- a/app/views/liquids/_slides.html.erb
+++ b/app/views/liquids/_slides.html.erb
@@ -1,43 +1,38 @@
 <div class="ltag-slides<%= ' ltag-slides--carousel' if mode == 'carousel' %>">
-  <div class="ltag-slides__track">
-    <%= content.html_safe %>
+  <div class="ltag-slides__viewport">
+    <div
+      class="ltag-slides__track"
+      <% if mode == "carousel" %>
+        role="region"
+        aria-label="<%= I18n.t('liquid_tags.slides_tag.gallery_label') %>"
+        tabindex="0"
+      <% end %>>
+      <%= content.html_safe %>
+    </div>
+    <% if mode == "carousel" %>
+      <button
+        class="ltag-slides__nav ltag-slides__nav--prev"
+        type="button"
+        aria-label="<%= I18n.t('liquid_tags.slides_tag.previous') %>"
+        disabled>
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="m15 18-6-6 6-6" />
+        </svg>
+      </button>
+      <button
+        class="ltag-slides__nav ltag-slides__nav--next"
+        type="button"
+        aria-label="<%= I18n.t('liquid_tags.slides_tag.next') %>"
+        disabled>
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="m9 18 6-6-6-6" />
+        </svg>
+      </button>
+    <% end %>
   </div>
   <% if mode == "carousel" %>
-    <button class="ltag-slides__nav ltag-slides__nav--prev" aria-label="Previous slide">&#8249;</button>
-    <button class="ltag-slides__nav ltag-slides__nav--next" aria-label="Next slide">&#8250;</button>
-    <div class="ltag-slides__dots"></div>
-    <script>
-      (function() {
-        var container = document.currentScript.closest('.ltag-slides--carousel');
-        var track = container.querySelector('.ltag-slides__track');
-        var slides = track.querySelectorAll('.ltag-slide');
-        var prevBtn = container.querySelector('.ltag-slides__nav--prev');
-        var nextBtn = container.querySelector('.ltag-slides__nav--next');
-        var dotsContainer = container.querySelector('.ltag-slides__dots');
-        var current = 0;
-        var total = slides.length;
-
-        for (var i = 0; i < total; i++) {
-          var dot = document.createElement('button');
-          dot.className = 'ltag-slides__dot' + (i === 0 ? ' ltag-slides__dot--active' : '');
-          dot.setAttribute('aria-label', 'Go to slide ' + (i + 1));
-          dot.dataset.index = i;
-          dot.addEventListener('click', function() { goTo(parseInt(this.dataset.index)); });
-          dotsContainer.appendChild(dot);
-        }
-
-        function goTo(index) {
-          current = ((index % total) + total) % total;
-          track.style.transform = 'translateX(-' + (current * 100) + '%)';
-          var dots = dotsContainer.querySelectorAll('.ltag-slides__dot');
-          for (var i = 0; i < dots.length; i++) {
-            dots[i].classList.toggle('ltag-slides__dot--active', i === current);
-          }
-        }
-
-        prevBtn.addEventListener('click', function() { goTo(current - 1); });
-        nextBtn.addEventListener('click', function() { goTo(current + 1); });
-      })();
-    </script>
+    <div class="ltag-slides__progress" aria-hidden="true">
+      <span class="ltag-slides__progress-thumb"></span>
+    </div>
   <% end %>
 </div>

--- a/app/views/pages/_editor_liquid_help.en.html.erb
+++ b/app/views/pages/_editor_liquid_help.en.html.erb
@@ -115,6 +115,7 @@
   {% slide video="https://youtube.com/watch?v=abc123" %}
 {% endslides %}</pre>
     <p class="fs-s">Each slide needs at least one of: <code>image</code>, <code>video</code>, or <code>link</code>. Optional: <code>title</code>, <code>alt</code>.</p>
+    <p class="fs-s"><code>mode="carousel"</code> presents cards in a swipeable, scroll-snapping strip with optional desktop controls.</p>
 
     <% if @user_approved_liquid_tags.include? UserSubscriptionTag %>
       <h4><%= community_name %> User Subscriptions</h4>

--- a/config/locales/liquid_tags/en.yml
+++ b/config/locales/liquid_tags/en.yml
@@ -173,6 +173,9 @@ en:
       missing_content: "Slide tag requires at least one of: image, video, or link"
     slides_tag:
       invalid_mode: "Slides mode must be 'default' or 'carousel'"
+      gallery_label: Media gallery
+      previous: Previous slide
+      next: Next slide
     org_lead_form_tag:
       not_found: Lead form not found
       inactive: This lead form is no longer active

--- a/config/locales/liquid_tags/fr.yml
+++ b/config/locales/liquid_tags/fr.yml
@@ -173,6 +173,9 @@ fr:
       missing_content: "La balise slide nécessite au moins l'un des éléments suivants : image, video ou link"
     slides_tag:
       invalid_mode: "Le mode slides doit être 'default' ou 'carousel'"
+      gallery_label: Galerie multimédia
+      previous: Diapositive précédente
+      next: Diapositive suivante
     org_lead_form_tag:
       not_found: Formulaire de leads non trouvé
       inactive: Ce formulaire de leads n'est plus actif

--- a/config/locales/liquid_tags/pt.yml
+++ b/config/locales/liquid_tags/pt.yml
@@ -173,6 +173,9 @@ pt:
       missing_content: "A tag slide requer pelo menos um dos seguintes: image, video ou link"
     slides_tag:
       invalid_mode: "O modo slides deve ser 'default' ou 'carousel'"
+      gallery_label: Galeria de mídia
+      previous: Slide anterior
+      next: Próximo slide
     org_lead_form_tag:
       not_found: Formulário de leads não encontrado
       inactive: Este formulário de leads não está mais ativo

--- a/spec/liquid_tags/slides_tag_spec.rb
+++ b/spec/liquid_tags/slides_tag_spec.rb
@@ -55,9 +55,9 @@ RSpec.describe "Slides and Slide liquid tags", type: :liquid_tag do
       next_button = fragment.at_css(".ltag-slides__nav--next")
 
       expect(previous_button.name).to eq("button")
-      expect(previous_button["disabled"]).not_to be_nil
+      expect(previous_button["aria-disabled"]).to eq("true")
       expect(next_button.name).to eq("button")
-      expect(next_button["disabled"]).not_to be_nil
+      expect(next_button["aria-disabled"]).to eq("true")
     end
 
     it "renders a progress rail without index dots or inline scripting" do

--- a/spec/liquid_tags/slides_tag_spec.rb
+++ b/spec/liquid_tags/slides_tag_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Slides and Slide liquid tags", type: :liquid_tag do
   end
 
   describe "basic rendering" do
-    it "renders a carousel with slides" do
+    it "renders a gallery with slides" do
       result = parse('{% slides %}{% slide image="https://example.com/1.jpg" %}{% slide image="https://example.com/2.jpg" %}{% endslides %}').render
       expect(result).to include('class="ltag-slides"')
       expect(result).to include("ltag-slides__track")
@@ -32,6 +32,38 @@ RSpec.describe "Slides and Slide liquid tags", type: :liquid_tag do
     it "defaults alt to empty string" do
       result = parse('{% slides %}{% slide image="https://example.com/photo.jpg" %}{% endslides %}').render
       expect(result).to include('alt=""')
+    end
+  end
+
+  describe "carousel mode" do
+    subject(:result) do
+      parse('{% slides mode="carousel" %}{% slide image="https://example.com/1.jpg" %}{% slide image="https://example.com/2.jpg" %}{% endslides %}').render
+    end
+
+    it "renders an accessible native scroll region" do
+      fragment = Nokogiri::HTML.fragment(result)
+      track = fragment.at_css(".ltag-slides__track")
+
+      expect(track["role"]).to eq("region")
+      expect(track["aria-label"]).to eq("Media gallery")
+      expect(track["tabindex"]).to eq("0")
+    end
+
+    it "renders stable previous and next controls" do
+      fragment = Nokogiri::HTML.fragment(result)
+      previous_button = fragment.at_css(".ltag-slides__nav--prev")
+      next_button = fragment.at_css(".ltag-slides__nav--next")
+
+      expect(previous_button.name).to eq("button")
+      expect(previous_button["disabled"]).not_to be_nil
+      expect(next_button.name).to eq("button")
+      expect(next_button["disabled"]).not_to be_nil
+    end
+
+    it "renders a progress rail without index dots or inline scripting" do
+      expect(result).to include("ltag-slides__progress-thumb")
+      expect(result).not_to include("ltag-slides__dots")
+      expect(result).not_to include("<script")
     end
   end
 


### PR DESCRIPTION
## Summary

- Replace index-driven slides with a native horizontal scroll strip and visible next-card affordance.
- Add scroll snapping, a progress rail, keyboard support, and desktop navigation controls.
- Preserve focus at endpoints and make repeated key input deterministic.

## Why

The scroll-based interaction accommodates mixed media sizes, works naturally with touch input, and remains usable when JavaScript is unavailable.

## Validation

- `yarn jest app/javascript/initializers/__tests__/initializeSlides.test.js --runInBand`
- `bin/rspec spec/liquid_tags/slides_tag_spec.rb`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786905551&installation_id=139885019&pr_number=23641&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23641&signature=a280273d88e89a3f324e01ad589376016a7015ad87eb7df174d2be0ef165354f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->