### PR TITLE
Retain RSpec diagnostic artifacts after CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,10 @@ jobs:
         if: failure()
         with:
           name: rspec-artifacts-${{ matrix.ci_node_index }}
-          path: tmp/capybara
+          path: |
+            tmp/capybara
+            tmp/csvs
+            tmp/rspec*.xml
       - name: Rename folder
         run: if [ -d "coverage/simplecov" ]; then mv coverage/simplecov coverage/simplecov-${{ matrix.ci_node_index }}; fi
       - name: Upload test coverage result


### PR DESCRIPTION
## Summary

- Retain retry CSV output and JUnit XML reports in failed RSpec job artifacts.
- Keep the existing browser artifacts and shard-specific artifact names.

## Why

These files are already generated during CI, but were unavailable after a workflow completed. Retaining them makes it easier to distinguish recurring flaky examples from regressions on unrelated changes.

## Impact

This does not change retry behavior or test outcomes. It only expands the files included in the existing failure artifact.

## Validation

- Parsed `.github/workflows/ci.yml` with Ruby's YAML parser.
- `git diff --check`

Closes #23642

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786907792&installation_id=139885019&pr_number=23643&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23643&signature=c827830254ccb1d04078a31f1b913bb7b097c9bdbf0424b2931f5eaef31cca03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->