### PR TITLE
Stabilize order-dependent and asynchronous specs

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -178,6 +178,7 @@ RSpec.describe ApplicationHelper do
   end
 
   describe "#release_adjusted_cache_key" do
+    before { ForemInstance.instance_variable_set(:@deployed_at, nil) }
     after { ForemInstance.instance_variable_set(:@deployed_at, nil) }
 
     it "does nothing when RELEASE_FOOTPRINT is not set" do

--- a/spec/liquid_tags/github_tag/github_readme_tag_spec.rb
+++ b/spec/liquid_tags/github_tag/github_readme_tag_spec.rb
@@ -71,7 +71,9 @@ RSpec.describe GithubTag::GithubReadmeTag, type: :liquid_tag, vcr: true do
     end
 
     it "renders a repository with a missing README" do
-      allow_any_instance_of(Github::OauthClient).to receive(:readme).and_raise(Github::Errors::NotFound) # rubocop:disable RSpec/AnyInstance
+      github_client = Github::OauthClient.new(access_token: "token")
+      allow(Github::OauthClient).to receive(:new).and_return(github_client)
+      allow(github_client).to receive(:readme).and_raise(Github::Errors::NotFound)
 
       VCR.use_cassette("github_client_repository") do
         template = generate_tag(url_repository).render

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -147,9 +147,9 @@ RSpec.describe ApplicationMailer do
         allow(Rails.env).to receive(:development?).and_return(true)
       end
 
-      it "adds :3000 port to domain" do
+      it "adds the development port to domain" do
         email.deliver_now
-        expect(email.body.encoded).to include("#{subforem.domain}:3000")
+        expect(email.body.encoded).to include("#{subforem.domain}:#{URL.dev_port}")
       end
     end
   end

--- a/spec/mailers/devise_mailer_spec.rb
+++ b/spec/mailers/devise_mailer_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe DeviseMailer, type: :mailer do
     end
 
     context "when domain already includes port number" do
-      let!(:subforem) { create(:subforem, domain: "dev.example.com:3000") }
+      let!(:subforem) { create(:subforem, domain: "dev.example.com:#{URL.dev_port}") }
       let(:user_with_subforem) { create(:user, onboarding_subforem_id: subforem.id) }
 
       before do
@@ -229,11 +229,10 @@ RSpec.describe DeviseMailer, type: :mailer do
         allow(Rails.env).to receive(:development?).and_return(true)
       end
 
-      it "doesn't add :3000 port twice" do
+      it "doesn't add the development port twice" do
         email = described_class.confirmation_instructions(user_with_subforem, "token")
-        # Should not have :3000:3000 in the body
-        expect(email.body.to_s).not_to include(":3000:3000")
-        expect(email.body.to_s).to include("dev.example.com:3000")
+        expect(email.body.to_s).not_to include(":#{URL.dev_port}:#{URL.dev_port}")
+        expect(email.body.to_s).to include("dev.example.com:#{URL.dev_port}")
       end
     end
 

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -120,6 +120,8 @@ RSpec.describe Email, type: :model do
       end
 
       it "enqueues a job to EnqueueCustomBatchSendWorker as before" do
+        allow(User).to receive(:maximum).with(:id).and_return(5000)
+
         email.update(status: "active")
         email.deliver_to_users
 

--- a/spec/models/settings/user_experience_spec.rb
+++ b/spec/models/settings/user_experience_spec.rb
@@ -1,6 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Settings::UserExperience do
+  before { described_class.clear_cache }
+  after { described_class.clear_cache }
+
   describe "validating hex string format" do
     it "allows 3 character hex strings" do
       expect do

--- a/spec/requests/rack_attack_ai_chats_spec.rb
+++ b/spec/requests/rack_attack_ai_chats_spec.rb
@@ -27,16 +27,18 @@ RSpec.describe "Rack::Attack AI Chats Throttling", type: :request do
     end
 
     it "throttles POST requests to /ai_chats to 10 per minute per IP" do
-      # Make 10 successful requests
-      10.times do
-        post "/ai_chats", params: { message: "hello", chat_context: "editor" }, headers: headers
-        expect(response).not_to have_http_status(:too_many_requests)
-      end
+      freeze_time do
+        # Make 10 successful requests
+        10.times do
+          post "/ai_chats", params: { message: "hello", chat_context: "editor" }, headers: headers
+          expect(response).not_to have_http_status(:too_many_requests)
+        end
 
-      # The 11th request should be throttled
-      post "/ai_chats", params: { message: "hello", chat_context: "editor" }, headers: headers
-      expect(response).to have_http_status(:too_many_requests)
-      expect(response.body).to include("Retry later")
+        # The 11th request should be throttled
+        post "/ai_chats", params: { message: "hello", chat_context: "editor" }, headers: headers
+        expect(response).to have_http_status(:too_many_requests)
+        expect(response.body).to include("Retry later")
+      end
 
       # Advance time to allow requests again
       travel 1.minute + 1.second do

--- a/spec/system/comments/like_button_state_after_reply_spec.rb
+++ b/spec/system/comments/like_button_state_after_reply_spec.rb
@@ -15,10 +15,9 @@ RSpec.describe "Like button and tooltip after replying", js: true do
     # Open reply form on the parent comment and submit a reply
     within "#comment-node-#{parent_comment.id}" do
       find(".toggle-reply-form").click
+      find(".c-autocomplete textarea[id*='textarea-for']").set("Thanks!")
+      click_on("Submit")
     end
-
-    find(:xpath, "//textarea[contains(@id, 'textarea-for')]").set("Thanks!")
-    click_button("Submit")
 
     # Parent comment should no longer be in the `replying` state
     within "#comment-node-#{parent_comment.id}" do

--- a/spec/system/comments/user_views_a_comment_spec.rb
+++ b/spec/system/comments/user_views_a_comment_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe "Viewing a comment", js: true do
     ENV["DESYNC_TIMEZONE"] = "true"
     mock_user_tz = ActiveSupport::TimeZone[Zonebie.random_timezone].tzinfo.name
     ENV["TZ"] = mock_user_tz
+    page.driver.browser.page.command("Emulation.setTimezoneOverride", timezoneId: mock_user_tz)
   end
 
   after do
     ENV["TZ"] = Time.zone.tzinfo.name
     ENV["DESYNC_TIMEZONE"] = nil
-    Capybara.current_session.quit
     Timecop.return
   end
 

--- a/spec/system/notifications/notifications_page_spec.rb
+++ b/spec/system/notifications/notifications_page_spec.rb
@@ -1,6 +1,14 @@
 require "rails_helper"
 
 RSpec.describe "Notifications page", js: true do
+  # Ahoy persists the click event asynchronously to the navigation Capybara
+  # waits on, so poll for it before asserting; on timeout the count
+  # expectation below reports the miss.
+  def wait_for_ahoy_event
+    deadline = Capybara::Helpers.monotonic_time + Capybara.default_max_wait_time
+    sleep 0.05 until Ahoy::Event.exists? || Capybara::Helpers.monotonic_time >= deadline
+  end
+
   let(:alex) { create(:user) }
   let(:leslie) { create(:user) }
 
@@ -102,6 +110,7 @@ RSpec.describe "Notifications page", js: true do
         click_link("the welcome thread")
 
         expect(page).to have_current_path("/welcome")
+        wait_for_ahoy_event
         expect(Ahoy::Event.count).to eq(1)
       end
     end

--- a/spec/workers/page_view_rollup_worker_spec.rb
+++ b/spec/workers/page_view_rollup_worker_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe PageViewRollupWorker, type: :worker do
   include_examples "#enqueues_on_correct_queue", "low_priority"
 
   describe "#perform" do
-    it "rollups five month ago" do
-      Time.freeze do
+    it "rolls up one year ago" do
+      Timecop.freeze do
         one_year_ago = 1.year.ago
         worker.perform
         expect(PageViewRollup).to have_received(:rollup).with(one_year_ago)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Stabilizes a focused set of order-dependent and asynchronous specs without changing production behavior.

The changes:

- reset cached or global state around examples that previously leaked across randomized order
- control time, generated IDs, URL ports, and external-client behavior instead of relying on ambient state
- synchronize system specs with the specific DOM or persisted analytics state they assert
- make the Rack::Attack and page-view rollup examples deterministic around time boundaries

The intended effect is fewer intermittent CI failures from these examples. This does not add retries or broaden wait times globally.

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

Test-only change; there are no UI changes to review.

Validation performed with retries disabled:

- all 11 changed spec files together: 193 examples, 0 failures
- 19 historical randomized seeds: 171 example executions, 0 failures
- four-worker endurance run of the two newly isolated offenders: 350 example executions, 0 failures over 15 minutes
- complete four-worker RSpec run: 13,518 examples with one pressure-sensitive failure in an unchanged comment-edit system spec; that example passed in an unloaded control run
- zero RuboCop offenses on added lines
- `git diff --check`

### UI accessibility checklist

Not applicable; no UI or production code changed.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why:
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

None.
