### PR TITLE
Use displayed comment count consistently on article show

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -561,7 +561,7 @@ class StoriesController < ApplicationController
     }
 
     # Add discussion forum structured data if article has comments
-    return json_ld unless @article.comments_count.positive?
+    return json_ld unless @comments_count.positive?
 
     # Add main discussion forum posting for the article
     json_ld[:mainEntity] = {
@@ -581,7 +581,7 @@ class StoriesController < ApplicationController
         {
           "@type": "InteractionCounter",
           interactionType: "https://schema.org/CommentAction",
-          userInteractionCount: @article.comments_count
+          userInteractionCount: @comments_count
         },
         {
           "@type": "InteractionCounter",

--- a/spec/requests/articles/articles_show_spec.rb
+++ b/spec/requests/articles/articles_show_spec.rb
@@ -151,6 +151,24 @@ RSpec.describe "ArticlesShow" do
       )
     end
 
+    it "uses displayed comment count when it differs from the stored article counter", :aggregate_failures do
+      comment = create(:comment, commentable: article, user: user)
+      comment.update_column(:score, 0)
+      article.update_columns(comments_count: 0, displayed_comments_count: 1)
+
+      get article.path
+
+      expect(response.body).to include('data-comments-count="1"')
+      expect(response.body).to include(%(id="comment-node-#{comment.id}"))
+      expect(response_json.dig("mainEntity", "interactionStatistic")).to include(
+        {
+          "@type" => "InteractionCounter",
+          "interactionType" => "https://schema.org/CommentAction",
+          "userInteractionCount" => 1
+        },
+      )
+    end
+
     it "caches JSON-LD at view level based on last_comment_at" do
       comment = create(:comment, commentable: article, user: user)
       article.update_column(:comments_count, 1)

--- a/spec/requests/articles/articles_show_spec.rb
+++ b/spec/requests/articles/articles_show_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe "ArticlesShow" do
     end
 
     it "renders DiscussionForumPosting structured data when article has comments" do
-      comment = create(:comment, commentable: article, user: user)
-      article.update_column(:comments_count, 1)
+      create(:comment, commentable: article, user: user)
+      article.update_columns(comments_count: 1, displayed_comments_count: 1)
 
       get article.path
 
@@ -104,7 +104,7 @@ RSpec.describe "ArticlesShow" do
 
     it "renders Comment structured data for article comments" do
       comment = create(:comment, commentable: article, user: user)
-      article.update_column(:comments_count, 1)
+      article.update_columns(comments_count: 1, displayed_comments_count: 1)
 
       get article.path
 
@@ -134,7 +134,7 @@ RSpec.describe "ArticlesShow" do
     it "renders nested comment structure for replies" do
       root_comment = create(:comment, commentable: article, user: user)
       reply_comment = create(:comment, commentable: article, user: user, ancestry: root_comment.id.to_s)
-      article.update_column(:comments_count, 2)
+      article.update_columns(comments_count: 2, displayed_comments_count: 2)
 
       get article.path
 
@@ -170,8 +170,8 @@ RSpec.describe "ArticlesShow" do
     end
 
     it "caches JSON-LD at view level based on last_comment_at" do
-      comment = create(:comment, commentable: article, user: user)
-      article.update_column(:comments_count, 1)
+      create(:comment, commentable: article, user: user)
+      article.update_columns(comments_count: 1, displayed_comments_count: 1)
 
       # First request should generate JSON-LD
       get article.path


### PR DESCRIPTION
## Summary

- use the displayed comment count consistently on article show surfaces
- align discussion JSON-LD comment counts with the article page comment header
- add a regression spec for count drift between displayed comments and the stored article counter

## Testing

- bin/rspec spec/requests/articles/articles_show_spec.rb
- bin/rspec spec/queries/comments/count_spec.rb

Fixes #23646

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787167582&installation_model_id=424141&pr_number=23647&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23647&signature=d1ce10cc25209483e93ce7e4f2c0c21c3d420812351401a9ed9e78c2418448cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->