### PR TITLE
Handle organization page content errors as validation failures

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -23,7 +23,7 @@ class Page < ApplicationRecord
   validate :validate_slug_uniqueness
 
   before_validation :set_default_template
-  before_save :evaluate_markdown
+  before_validation :evaluate_markdown
   before_save :render_from_page_template, if: :uses_page_template?
 
   after_commit :ensure_uniqueness_of_landinge_page
@@ -102,12 +102,13 @@ class Page < ApplicationRecord
 
   def evaluate_markdown
     if body_markdown.present?
-      source = organization || nil
-      parsed_markdown = MarkdownProcessor::Parser.new(body_markdown, source: source)
-      self.processed_html = parsed_markdown.finalize(link_attributes: link_attributes_for_org)
+      renderer = ContentRenderer.new(body_markdown, source: organization)
+      self.processed_html = renderer.process(link_attributes: link_attributes_for_org).processed_html
     else
       self.processed_html = body_html
     end
+  rescue ContentRenderer::ContentParsingError => e
+    errors.add(:base, ErrorMessages::Clean.call(e.message))
   end
 
   def link_attributes_for_org

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -186,6 +186,19 @@ RSpec.describe Page do
         page.update(body_html: html, body_markdown: "")
         expect(page.processed_html).to eq(html)
       end
+
+      it "adds a validation error when Liquid content cannot be rendered" do
+        organization = create(:organization)
+        other_form = create(:organization_lead_form)
+        page = build(
+          :page,
+          organization: organization,
+          body_markdown: "{% org_lead_form #{other_form.id} %}",
+        )
+
+        expect(page).not_to be_valid
+        expect(page.errors[:base]).to include(I18n.t("liquid_tags.org_lead_form_tag.wrong_organization"))
+      end
     end
   end
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -199,6 +199,26 @@ RSpec.describe Page do
         expect(page).not_to be_valid
         expect(page.errors[:base]).to include(I18n.t("liquid_tags.org_lead_form_tag.wrong_organization"))
       end
+
+      it "preserves descriptive errors from invalid Liquid tag references" do
+        organization = create(:organization)
+        invalid_tags = {
+          "{% podcast /missing-podcast/missing-episode %}" =>
+            I18n.t("liquid_tags.podcast_tag.invalid_podcast_link"),
+          "{% agent_session missing-session %}" =>
+            I18n.t("liquid_tags.agent_session_tag.not_found"),
+          "{% event 999999999 %}" => I18n.t("liquid_tags.event_tag.not_found")
+        }
+
+        aggregate_failures do
+          invalid_tags.each do |body_markdown, error_message|
+            page = build(:page, organization: organization, body_markdown: body_markdown)
+
+            expect(page).not_to be_valid
+            expect(page.errors[:base]).to include(error_message)
+          end
+        end
+      end
     end
   end
 

--- a/spec/requests/organization_pages_spec.rb
+++ b/spec/requests/organization_pages_spec.rb
@@ -48,6 +48,22 @@ RSpec.describe "Organization Pages Controller Backend Protection" do
         expect(page.slug).to eq("#{organization.slug}/readme")
         expect(page.title).to eq("Welcome")
       end
+
+      it "returns a validation error when a lead form belongs to another organization" do
+        other_form = create(:organization_lead_form)
+
+        expect do
+          post organization_pages_path(organization.slug), params: {
+            page: {
+              title: "Welcome",
+              body_markdown: "{% org_lead_form #{other_form.id} %}"
+            }
+          }
+        end.not_to change(Page, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include(I18n.t("liquid_tags.org_lead_form_tag.wrong_organization"))
+      end
     end
 
     context "when creating subsequent pages" do


### PR DESCRIPTION
## Summary

- render organization page Markdown through `ContentRenderer` during validation
- surface Liquid rendering failures as page validation errors instead of unhandled exceptions
- add request coverage for an organization-scoped reference owned by a different organization
- verify descriptive validation errors for invalid podcast, agent-session, and event references

## Why

Organization pages can contain Liquid tags whose references are invalid, missing, unpublished, or outside the current organization. Those tags already provide useful error messages, but page rendering previously ran during `before_save`, allowing expected authoring errors to escape as server errors.

These are still relatively niche invalid-authoring cases, but presenting a useful validation error is better than returning a 500 and reporting an application fault.

The underlying tag restrictions remain unchanged. An invalid page is not persisted, and the editor is rendered with a 422 response and the existing localized error message.

## Testing

- `bin/flox run -- bin/rspec spec/models/page_spec.rb:190 spec/models/page_spec.rb:203 spec/requests/organization_pages_spec.rb:52`
- local Rails reproduction covering invalid podcast, agent-session, and event references
- `git diff --check`
