### PR TITLE
Support custom domains for organization article canonical URLs

### DIFF
--- a/app/decorators/article_decorator.rb
+++ b/app/decorators/article_decorator.rb
@@ -38,7 +38,7 @@ class ArticleDecorator < ApplicationDecorator
   end
 
   def url
-    URL.url(path)
+    URL.article(object)
   end
 
   def title_length_classification

--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -46,6 +46,19 @@ module URL
   #
   # @param article [Article] the article to create the URL for
   def self.article(article)
+    org_id = article.respond_to?(:organization_id) ? article.organization_id : nil
+    if org_id.present?
+      custom_domain = MemoryFirstCache.fetch("org_custom_domain:#{org_id}", redis_expires_in: 12.hours, return_type: :string) do
+        Organization.where(id: org_id).pick(:custom_domain).to_s
+      end
+      if custom_domain.present?
+        org = article.organization
+        if org && FeatureFlag.enabled?(:org_custom_domain, FeatureFlag::Actor.new(org))
+          return url("/#{article.slug}", custom_domain)
+        end
+      end
+    end
+
     return url(article.path) unless article.respond_to?(:subforem_id)
     
     # Use cached lookup to avoid N+1 queries

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -34,13 +34,13 @@
   <!-- This is because of navigation via InstantClick, instantclick.io -->
   <!-- However, the crawled version of the page has the canonical in the head. -->
   <!-- This is confirmed by the canonical url inspector. See https://github.com/forem/forem/issues/9509#issuecomment-732259221. -->
-  <link rel="canonical" href="<%= @article.canonical_url.presence || app_url(@article.path) %>" />
+  <link rel="canonical" href="<%= @article.processed_canonical_url %>" />
   <meta name="description" content="<%= @article.description_and_tags %>">
   <%= meta_keywords_article(@article.cached_tag_list) %>
 <% else %>
   <%= content_for :page_meta do %>
     <link rel="preload" href="/reactions?article_id=<%= @article.id %>" as="fetch" crossorigin="same-origin">
-    <link rel="canonical" href="<%= @article.canonical_url.presence || app_url(@article.path) %>" />
+    <link rel="canonical" href="<%= @article.processed_canonical_url %>" />
     <meta name="description" content="<%= @article.description_and_tags %>">
     <%= meta_keywords_article(@article.cached_tag_list) %>
 

--- a/spec/decorators/article_decorator_spec.rb
+++ b/spec/decorators/article_decorator_spec.rb
@@ -81,6 +81,40 @@ RSpec.describe ArticleDecorator, type: :decorator do
       expected_url = "#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}#{article.path}"
       expect(article.decorate.processed_canonical_url).to eq(expected_url)
     end
+
+    context "when article belongs to an organization with a custom domain" do
+      let(:organization) { create(:organization, custom_domain: "blog.example.com") }
+      let(:article) { create(:article, organization: organization) }
+
+      context "when the org_custom_domain feature flag is enabled" do
+        before do
+          FeatureFlag.enable(:org_custom_domain, FeatureFlag::Actor.new(organization))
+        end
+
+        it "returns the custom domain URL" do
+          article.canonical_url = ""
+          expected_url = "#{ApplicationConfig['APP_PROTOCOL']}blog.example.com/#{article.slug}"
+          expect(article.decorate.processed_canonical_url).to eq(expected_url)
+        end
+
+        it "returns the custom user override canonical URL if present" do
+          article.canonical_url = "http://google.com"
+          expect(article.decorate.processed_canonical_url).to eq("http://google.com")
+        end
+      end
+
+      context "when the org_custom_domain feature flag is disabled" do
+        before do
+          FeatureFlag.disable(:org_custom_domain, FeatureFlag::Actor.new(organization))
+        end
+
+        it "returns the default app domain URL" do
+          article.canonical_url = ""
+          expected_url = "#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}#{article.path}"
+          expect(article.decorate.processed_canonical_url).to eq(expected_url)
+        end
+      end
+    end
   end
 
   describe "#cached_tag_list_array" do

--- a/spec/lib/url_spec.rb
+++ b/spec/lib/url_spec.rb
@@ -118,6 +118,31 @@ RSpec.describe URL, type: :lib do
     it "returns the correct URL for an article" do
       expect(described_class.article(article)).to eq("https://dev.to#{article.path}")
     end
+
+    context "when article belongs to an organization with a custom domain" do
+      let(:organization) { create(:organization, custom_domain: "blog.example.com") }
+      let(:article) { create(:article, organization: organization) }
+
+      context "when the org_custom_domain feature flag is enabled" do
+        before do
+          FeatureFlag.enable(:org_custom_domain, FeatureFlag::Actor.new(organization))
+        end
+
+        it "returns the custom domain URL" do
+          expect(described_class.article(article)).to eq("https://blog.example.com/#{article.slug}")
+        end
+      end
+
+      context "when the org_custom_domain feature flag is disabled" do
+        before do
+          FeatureFlag.disable(:org_custom_domain, FeatureFlag::Actor.new(organization))
+        end
+
+        it "returns the default app domain URL" do
+          expect(described_class.article(article)).to eq("https://dev.to#{article.path}")
+        end
+      end
+    end
   end
 
   describe ".comment" do


### PR DESCRIPTION
This PR updates the article canonical URL rendering logic to support organization custom domains when the `:org_custom_domain` feature flag is enabled.

Specifically:
- Updated `URL.article` to check for active organization custom domains (optimized using `MemoryFirstCache` to prevent N+1 queries) and return the appropriate custom domain URL.
- Updated `ArticleDecorator#url` to delegate to `URL.article`.
- Refactored `app/views/articles/show.html.erb` to use `@article.processed_canonical_url`.
- Added unit and regression tests in `spec/decorators/article_decorator_spec.rb` and `spec/lib/url_spec.rb`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787235852&installation_model_id=424141&pr_number=23654&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23654&signature=4af560ae7c190482ff8b9132eaf8cd41d029c430ad13c1a97a3ddc2eb60fd850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->