### PR TITLE
Restore tagged RSpec retries and retry diagnostics

### DIFF
--- a/spec/lib/r_spec_retry_policy_spec.rb
+++ b/spec/lib/r_spec_retry_policy_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe RSpecRetryPolicy do
+  describe "retry options" do
+    it "retries JavaScript examples without the global exception filter" do
+      expect(described_class::JS_OPTIONS).to eq(retry: 3, exceptions_to_retry: [])
+    end
+
+    it "retries explicitly flaky examples without the global exception filter" do
+      expect(described_class::FLAKY_OPTIONS).to eq(retry: 5, exceptions_to_retry: [])
+    end
+  end
+
+  describe ".compose_callbacks" do
+    it "runs every callback in order with the RSpec example group context" do
+      callback_host = Class.new do
+        attr_reader :events
+
+        def initialize
+          @events = []
+        end
+      end.new
+      example = Object.new
+      first_callback = proc { |received_example| events << [:first, received_example] }
+      second_callback = proc { |received_example| events << [:second, received_example] }
+
+      callback = described_class.compose_callbacks(first_callback, nil, second_callback)
+      callback_host.instance_exec(example, &callback)
+
+      expect(callback_host.events).to eq([[:first, example], [:second, example]])
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,6 +38,7 @@ require "fakeredis/rspec"
 require "pundit/matchers"
 require "pundit/rspec"
 require "sidekiq/testing"
+require_relative "support/rspec_retry_policy"
 require "test_prof/factory_prof/nate_heckler"
 require "validate_url/rspec_matcher"
 require "webmock/rspec"
@@ -104,14 +105,15 @@ RSpec.configure do |config|
   config.default_retry_count = 3
   config.exceptions_to_retry = [PGConnectionBadMatcher]
 
-  # To solve cascading failures across the whole file after a DB connection drop, 
+  # To solve cascading failures across the whole file after a DB connection drop,
   # we force a reconnection on exception.
-  config.retry_callback = proc do |ex|
-    if ex.exception && PGConnectionBadMatcher === ex.exception
-      puts "Retrying due to PG::ConnectionBad. Reconnecting to the database."
-      ActiveRecord::Base.connection_pool.disconnect!
-    end
+  reconnect_database = proc do |ex|
+    next unless ex.exception && (PGConnectionBadMatcher === ex.exception) # rubocop:disable Style/CaseEquality
+
+    puts "Retrying due to PG::ConnectionBad. Reconnecting to the database."
+    ActiveRecord::Base.connection_pool.disconnect!
   end
+  config.retry_callback = RSpecRetryPolicy.compose_callbacks(config.retry_callback, reconnect_database)
 
   config.use_transactional_fixtures = true
   config.fixture_paths = [Rails.root.join("spec/fixtures")]
@@ -192,7 +194,7 @@ RSpec.configure do |config|
   end
 
   config.around(:each, :flaky) do |ex|
-    ex.run_with_retry retry: 5
+    ex.run_with_retry(**RSpecRetryPolicy::FLAKY_OPTIONS)
   end
 
   config.around(:each, :throttle) do |example|
@@ -326,4 +328,3 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
-

--- a/spec/support/initializers/ci_csv_formatter.rb
+++ b/spec/support/initializers/ci_csv_formatter.rb
@@ -89,7 +89,7 @@ RSpec.configure do |config|
   config.verbose_retry = true
   config.display_try_failure_messages = true
   config.around :each, :js do |ex|
-    ex.run_with_retry retry: 3
+    ex.run_with_retry(**RSpecRetryPolicy::JS_OPTIONS)
   end
 
   # None of the rspec formatter hooks are invoked in the case of a retry, so the only way to get data

--- a/spec/support/rspec_retry_policy.rb
+++ b/spec/support/rspec_retry_policy.rb
@@ -1,0 +1,16 @@
+module RSpecRetryPolicy
+  # Tagged retries must opt out of the global PG-only filter so their retry counts take effect.
+  NO_EXCEPTION_FILTER = [].freeze
+  JS_OPTIONS = { retry: 3, exceptions_to_retry: NO_EXCEPTION_FILTER }.freeze
+  FLAKY_OPTIONS = { retry: 5, exceptions_to_retry: NO_EXCEPTION_FILTER }.freeze
+
+  module_function
+
+  def compose_callbacks(*callbacks)
+    active_callbacks = callbacks.compact
+
+    proc do |example|
+      active_callbacks.each { |callback| instance_exec(example, &callback) }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Restore the intended retry behavior for `:js` and `:flaky` examples by explicitly opting those tagged retries out of the global PG-only exception filter.
- Compose retry callbacks so CI retry diagnostics and the existing `PG::ConnectionBad` reconnection both run.
- Add focused regression coverage for the tagged retry policies and callback composition.

## Why

[#23643](https://github.com/forem/forem/pull/23643) made existing RSpec CSV and JUnit diagnostics available after failed CI jobs. Those artifacts exposed two configuration interactions:

1. `config.exceptions_to_retry = [PGConnectionBadMatcher]` also filters the explicit `retry: 3` and `retry: 5` wrappers. Non-PG browser failures therefore stop after their first attempt.
2. The later PG reconnect assignment replaces the CSV formatter retry callback, so intermediate retry failures are not retained in the CSV.

The new policy options preserve the PG-only global default while restoring the established behavior of explicitly tagged JavaScript and flaky examples. Callback composition preserves both existing responsibilities.

## Public-data provenance

This diagnosis used only information visible to a normal OSS contributor in the public Forem repository: public GitHub Actions job logs and failure artifacts retained by #23643, downloaded with ordinary contributor read access.

No maintainer-only GitHub data, Blacksmith internals, private telemetry, or other privileged Forem access was used.

Public examples that informed the diagnosis include:

- [A Ferrum timeout in a `:js` editor example with no recorded retry](https://github.com/forem/forem/actions/runs/29795330673)
- [The recurring SurveyMailer host-context failure](https://github.com/forem/forem/actions/runs/29830388348)

## Validation

- Focused regression specs for retry options and callback composition
- Isolated behavioral check against `rspec-retry` 0.6.2: non-PG `:js` and `:flaky` examples each retried and passed; both callbacks ran in order
- Focused RuboCop checks
- Ruby syntax checks for all changed Ruby files
- `git diff --check`

The full Rails spec was not run locally because this worktree does not have the repository bundle installed; PR CI will provide the full integration run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787235937&installation_model_id=424141&pr_number=23655&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23655&signature=12c15edc51a9413976043ee082f116f17612bc860e2d1bbb4dc7c94531c28040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->