### PR TITLE
Support custom domains and scoping for robots.txt and sitemaps

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -486,6 +486,10 @@ class ApplicationController < ActionController::Base
       return
     end
 
+    if (controller_name == "pages" && action_name == "robots") || controller_name == "sitemaps"
+      return
+    end
+
     main_app_domain = Settings::General.app_domain
     if main_app_domain.present? && request.host&.downcase != main_app_domain.downcase
       redirect_to "#{request.protocol}#{main_app_domain}#{request.fullpath}", allow_other_host: true, status: :moved_permanently

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -112,6 +112,7 @@ class PagesController < ApplicationController
 
   def robots
     # dynamically-generated static page
+    custom_domain_org
     respond_to :text
     set_surrogate_key_header "robots_page"
   end

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -6,6 +6,7 @@ class SitemapsController < ApplicationController
   MAX_OFFSET = 250 * RESULTS_LIMIT
 
   def show
+    @organization = custom_domain_org
     if params[:sitemap].start_with? "sitemap-index"
       sitemap_index
     elsif valid_resource_sitemap?
@@ -23,8 +24,13 @@ class SitemapsController < ApplicationController
 
   def sitemap_index
     set_surrogate_controls(Time.current)
-    @articles_count = Article.published.from_subforem
-      .where("score >= ?", Settings::UserExperience.index_minimum_score).size
+    articles_scope = if @organization
+                       @organization.articles.published.from_subforem
+                     else
+                       Article.published.from_subforem
+                         .where("score >= ?", Settings::UserExperience.index_minimum_score)
+                     end
+    @articles_count = articles_scope.size
     @articles_count = MAX_OFFSET if @articles_count > MAX_OFFSET
     @page_limit = RESULTS_LIMIT
     @view_template = "index"
@@ -35,14 +41,27 @@ class SitemapsController < ApplicationController
 
     case resource
     when "users"
+      return not_found if @organization
       @users = User.order("comments_count DESC")
         .where("score > -1") # Spam mitigation
         .limit(RESULTS_LIMIT).offset(offset).pluck(:username, :profile_updated_at)
     when "posts"
-      @articles = Article.published.from_subforem.order("published_at DESC")
-        .where("score >= ?", Settings::UserExperience.index_minimum_score)
-        .limit(RESULTS_LIMIT).offset(offset).pluck(:path, :last_comment_at)
+      articles_scope = if @organization
+                         @organization.articles.published.from_subforem.order("published_at DESC")
+                       else
+                         Article.published.from_subforem.order("published_at DESC")
+                           .where("score >= ?", Settings::UserExperience.index_minimum_score)
+                       end
+      @articles = if @organization
+                    articles_scope
+                      .limit(RESULTS_LIMIT).offset(offset).pluck(:slug, :last_comment_at)
+                      .map { |slug, last_comment_at| ["/#{slug}", last_comment_at] }
+                  else
+                    articles_scope
+                      .limit(RESULTS_LIMIT).offset(offset).pluck(:path, :last_comment_at)
+                  end
     when "tags" # tags
+      return not_found if @organization
       @tags = Tag.order("hotness_score DESC")
         .where(supported: true)
         .limit(RESULTS_LIMIT).offset(offset).pluck(:name, :updated_at)
@@ -52,6 +71,8 @@ class SitemapsController < ApplicationController
   end
 
   def monthly_sitemap
+    return not_found if @organization
+
     match = params[:sitemap].match(SITEMAP_REGEX)
     not_found unless match && match[:date_string]
     begin

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -393,6 +393,13 @@ module ApplicationHelper
   end
 
   def app_url(uri = nil)
+    custom_org = (defined?(request) && request&.respond_to?(:env) ? request.env["forem.custom_domain_org"] : nil)
+    if custom_org
+      URL.url(uri, custom_org.custom_domain)
+    else
+      URL.url(uri, RequestStore.store[:subforem_domain])
+    end
+  rescue StandardError
     URL.url(uri, RequestStore.store[:subforem_domain])
   end
 

--- a/app/views/pages/robots.text.erb
+++ b/app/views/pages/robots.text.erb
@@ -16,4 +16,8 @@ Disallow: /async_info/base_data
 Disallow: /ahoy/*
 Disallow: /auth_pass/*
 
+<% if (custom_org = request.env["forem.custom_domain_org"]) %>
+Sitemap: <%= URL.url("sitemap-index.xml", custom_org.custom_domain) %>
+<% else %>
 Sitemap: <%= URL.url("sitemap-index.xml") %>
+<% end %>

--- a/app/views/sitemaps/index.xml.erb
+++ b/app/views/sitemaps/index.xml.erb
@@ -11,10 +11,12 @@
         <loc><%= app_url("sitemap-posts.xml") %></loc>
     </sitemap>
   <% end %>
+  <% unless @organization %>
   <sitemap>
       <loc><%= app_url("sitemap-users.xml") %></loc>
   </sitemap>
   <sitemap>
       <loc><%= app_url("sitemap-tags.xml") %></loc>
   </sitemap>
+  <% end %>
 </sitemapindex>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,13 +39,13 @@ Rails.application.routes.draw do
     get "/:org_slug/:slug",
         to: "stories#custom_domain_show",
         constraints: {
-          org_slug: %r{(?!(?:api|assets|packs|rails|r|ahoy|enter|users|p)\z)[^/.]+},
+          org_slug: %r{(?!(?:api|assets|packs|rails|r|ahoy|enter|users|p|robots|sitemap-.+)\z)[^/.]+},
           slug: %r{[^/.]+}
         }
     get "/:slug",
         to: "stories#custom_domain_show",
         constraints: {
-          slug: %r{(?!(?:api|assets|packs|rails|r|ahoy|enter|users|p)\z)[^/.]+}
+          slug: %r{(?!(?:api|assets|packs|rails|r|ahoy|enter|users|p|robots|sitemap-.+)\z)[^/.]+}
         }
     get "/p/:page_suffix", to: "stories#custom_domain_index", as: "custom_domain_organization_custom_page",
                            constraints: { format: /html/ }

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -365,6 +365,21 @@ RSpec.describe "Pages" do
       text = "Sitemap: #{URL.url('sitemap-index.xml')}"
       expect(response.body).to include(text)
     end
+
+    context "when requested on a custom domain organization" do
+      let(:organization) { create(:organization, custom_domain: "blog.mlh.com") }
+
+      before do
+        allow(Settings::General).to receive(:app_domain).and_return("forem.com")
+        FeatureFlag.enable(:org_custom_domain, FeatureFlag::Actor.new(organization))
+      end
+
+      it "points the sitemap to the custom domain sitemap-index.xml" do
+        get "http://blog.mlh.com/robots.txt"
+
+        expect(response.body).to include("Sitemap: http://blog.mlh.com/sitemap-index.xml")
+      end
+    end
   end
 
   describe "GET /report-abuse" do

--- a/spec/requests/sitemaps_spec.rb
+++ b/spec/requests/sitemaps_spec.rb
@@ -168,4 +168,53 @@ RSpec.describe "Sitemaps" do
       end
     end
   end
+
+  context "when requested on a custom domain organization" do
+    let(:organization) { create(:organization, custom_domain: "blog.mlh.com") }
+    let!(:org_article) { create(:article, organization: organization, score: 10) }
+    let!(:other_article) { create(:article, score: 10) }
+
+    before do
+      allow(Settings::General).to receive(:app_domain).and_return("forem.com")
+      FeatureFlag.enable(:org_custom_domain, FeatureFlag::Actor.new(organization))
+    end
+
+    describe "GET /sitemap-index.xml" do
+      it "renders the sitemap index with only the organization's posts sitemap and no users/tags sitemaps" do
+        get "http://blog.mlh.com/sitemap-index.xml"
+
+        expect(response.body).to include("<sitemapindex xmlns=")
+        expect(response.body).to include("http://blog.mlh.com/sitemap-posts.xml")
+        expect(response.body).not_to include("sitemap-users.xml")
+        expect(response.body).not_to include("sitemap-tags.xml")
+      end
+    end
+
+    describe "GET /sitemap-posts.xml" do
+      it "renders the posts sitemap with only the organization's articles using the custom domain paths" do
+        get "http://blog.mlh.com/sitemap-posts.xml"
+
+        expect(response.body).to include("http://blog.mlh.com/#{org_article.slug}")
+        expect(response.body).not_to include(org_article.path)
+        expect(response.body).not_to include(other_article.slug)
+      end
+    end
+
+    describe "GET other resource sitemaps" do
+      it "redirects users sitemap to the main domain" do
+        get "http://blog.mlh.com/sitemap-users.xml"
+        expect(response).to redirect_to("http://forem.com/sitemap-users.xml")
+      end
+
+      it "redirects tags sitemap to the main domain" do
+        get "http://blog.mlh.com/sitemap-tags.xml"
+        expect(response).to redirect_to("http://forem.com/sitemap-tags.xml")
+      end
+
+      it "redirects monthly sitemaps to the main domain" do
+        get "http://blog.mlh.com/sitemap-Mar-2020.xml"
+        expect(response).to redirect_to("http://forem.com/sitemap-Mar-2020.xml")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Goal
Support custom domains (e.g., blog.mlh.com) for organization sitemaps and robots.txt. When accessed on a custom organization domain:
1. robots.txt points to the custom domain's sitemap-index URL (https://blog.mlh.com/sitemap-index.xml).
2. Sitemaps are scoped strictly to the organization's published articles (excluding user and tag sitemaps).
3. The paths referenced inside the organization's sitemaps use canonical custom domain paths (https://blog.mlh.com/article-slug).

## Changes
- config/routes.rb: Exclude robots/sitemap patterns from organization custom domain constraints.
- app/controllers/application_controller.rb: Skip non-profile page redirects for robots/sitemap.
- app/helpers/application_helper.rb: Dynamically use organization domain in app_url helper.
- app/controllers/pages_controller.rb: Call custom_domain_org to resolve org during robots.txt request.
- app/views/pages/robots.text.erb: Point to custom domain sitemap-index if present.
- app/controllers/sitemaps_controller.rb: Filter sitemap index & posts to organization articles and canonical URLs, and redirect non-post sitemaps.
- app/views/sitemaps/index.xml.erb: Exclude users/tags from custom sitemap index.
- spec/requests/pages_spec.rb & spec/requests/sitemaps_spec.rb: Added request tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787236376&installation_model_id=424141&pr_number=23656&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23656&signature=e058dd6e02fe9c6e42c97816f949370e6baa927c950dddfba793eb5e1bb58236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->