### PR TITLE
Bust org edge cache when organization pages are saved

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -158,7 +158,13 @@ class Page < ApplicationRecord
   end
 
   def bust_cache
-    Pages::BustCacheWorker.perform_async(slug, organization_id)
+    # Keep the historical single-arg form for non-org pages so the
+    # until_executing unique-job lock digest stays stable and jobs coalesce.
+    if organization_id
+      Pages::BustCacheWorker.perform_async(slug, organization_id)
+    else
+      Pages::BustCacheWorker.perform_async(slug)
+    end
   end
 
   def validate_redirect_to_url

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -158,7 +158,7 @@ class Page < ApplicationRecord
   end
 
   def bust_cache
-    Pages::BustCacheWorker.perform_async(slug)
+    Pages::BustCacheWorker.perform_async(slug, organization_id)
   end
 
   def validate_redirect_to_url

--- a/app/services/edge_cache/bust_page.rb
+++ b/app/services/edge_cache/bust_page.rb
@@ -1,11 +1,22 @@
 module EdgeCache
   class BustPage
-    def self.call(slug)
+    def self.call(slug, organization: nil)
       return unless slug
 
       cache_bust = EdgeCache::Bust.new
       cache_bust.call("/page/#{slug}")
       cache_bust.call("/#{slug}")
+
+      return unless organization
+
+      # Organization pages are served from the org profile URLs (the readme
+      # renders at /:slug, custom pages at /:slug/:suffix, and both again on
+      # the org's custom domain). All of those responses carry the org's
+      # surrogate key, so purge by key rather than enumerating every URL.
+      EdgeCache::PurgeByKey.call(
+        organization.record_key,
+        fallback_paths: "/#{organization.slug}",
+      )
     end
   end
 end

--- a/app/workers/pages/bust_cache_worker.rb
+++ b/app/workers/pages/bust_cache_worker.rb
@@ -1,9 +1,10 @@
 module Pages
   class BustCacheWorker < BustCacheBaseWorker
-    def perform(slug)
+    def perform(slug, organization_id = nil)
       return if slug.blank?
 
-      EdgeCache::BustPage.call(slug)
+      organization = Organization.find_by(id: organization_id) if organization_id
+      EdgeCache::BustPage.call(slug, organization: organization)
     end
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -193,8 +193,17 @@ RSpec.describe Page do
     let(:page) { create(:page) }
 
     it "triggers cache busting on save" do
-      sidekiq_assert_enqueued_with(job: Pages::BustCacheWorker, args: [page.slug]) do
+      sidekiq_assert_enqueued_with(job: Pages::BustCacheWorker, args: [page.slug, nil]) do
         page.save
+      end
+    end
+
+    it "passes the organization id to the cache bust worker for organization pages" do
+      organization = create(:organization)
+      org_page = create(:page, organization: organization, slug: "#{organization.slug}/readme")
+
+      sidekiq_assert_enqueued_with(job: Pages::BustCacheWorker, args: [org_page.slug, organization.id]) do
+        org_page.save
       end
     end
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe Page do
     let(:page) { create(:page) }
 
     it "triggers cache busting on save" do
-      sidekiq_assert_enqueued_with(job: Pages::BustCacheWorker, args: [page.slug, nil]) do
+      sidekiq_assert_enqueued_with(job: Pages::BustCacheWorker, args: [page.slug]) do
         page.save
       end
     end

--- a/spec/requests/organization_pages_spec.rb
+++ b/spec/requests/organization_pages_spec.rb
@@ -92,6 +92,14 @@ RSpec.describe "Organization Pages Controller Backend Protection" do
       expect(readme_page.slug).to eq("#{organization.slug}/readme")
     end
 
+    it "enqueues an edge cache bust for the page and its organization" do
+      sidekiq_assert_enqueued_with(job: Pages::BustCacheWorker, args: [readme_page.slug, organization.id]) do
+        patch update_organization_page_path(organization.slug, readme_page), params: {
+          page: { title: "Updated Showcase Title" }
+        }
+      end
+    end
+
     it "fails and returns 422 if the updated slug suffix is invalid" do
       patch update_organization_page_path(organization.slug, custom_page), params: {
         page: { title: "New Title", slug_suffix: "!!!" }

--- a/spec/services/edge_cache/bust_page_spec.rb
+++ b/spec/services/edge_cache/bust_page_spec.rb
@@ -25,4 +25,30 @@ RSpec.describe EdgeCache::BustPage, type: :service do
       expect(cache_bust).to have_received(:call).with(path).once
     end
   end
+
+  context "when an organization is given" do
+    let(:organization) { create(:organization) }
+    let(:slug) { "#{organization.slug}/readme" }
+
+    before do
+      allow(EdgeCache::PurgeByKey).to receive(:call)
+    end
+
+    it "purges the organization's surrogate key with a profile path fallback", :aggregate_failures do
+      described_class.call(slug, organization: organization)
+
+      paths.each do |path|
+        expect(cache_bust).to have_received(:call).with(path).once
+      end
+      expect(EdgeCache::PurgeByKey).to have_received(:call)
+        .with(organization.record_key, fallback_paths: "/#{organization.slug}")
+        .once
+    end
+
+    it "does not purge by key when no organization is given" do
+      described_class.call(slug)
+
+      expect(EdgeCache::PurgeByKey).not_to have_received(:call)
+    end
+  end
 end

--- a/spec/workers/pages/bust_cache_worker_spec.rb
+++ b/spec/workers/pages/bust_cache_worker_spec.rb
@@ -14,9 +14,22 @@ RSpec.describe Pages::BustCacheWorker, type: :worker do
     end
 
     it "busts the cache" do
-      allow(EdgeCache::BustPage).to receive(:call).with(page_slug)
+      allow(EdgeCache::BustPage).to receive(:call).with(page_slug, organization: nil)
       worker.perform(page_slug)
-      expect(EdgeCache::BustPage).to have_received(:call).with(page_slug)
+      expect(EdgeCache::BustPage).to have_received(:call).with(page_slug, organization: nil)
+    end
+
+    it "passes the organization to the cache buster when an organization id is given" do
+      organization = create(:organization)
+      allow(EdgeCache::BustPage).to receive(:call)
+      worker.perform(page_slug, organization.id)
+      expect(EdgeCache::BustPage).to have_received(:call).with(page_slug, organization: organization)
+    end
+
+    it "busts the cache without an organization when the organization no longer exists" do
+      allow(EdgeCache::BustPage).to receive(:call)
+      worker.perform(page_slug, Organization.maximum(:id).to_i + 1)
+      expect(EdgeCache::BustPage).to have_received(:call).with(page_slug, organization: nil)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Organization pages (#23634) render at the org profile URLs — the readme at `/:org_slug`, custom pages at `/:org_slug/:suffix`, and both again on the org's custom domain — but `Page#bust_cache` only busted `/page/:slug` and `/:slug`. Since org page slugs are `{org_slug}/{suffix}`, saving a page from `/:org_slug/settings/pages/:id/edit` busted the custom-page path but left the org profile page (where the readme actually renders) and all custom-domain responses stale at the edge until natural expiry.

This threads the page's organization through the existing bust chain:

- `Page#bust_cache` passes `organization_id` to `Pages::BustCacheWorker`
- The worker accepts an optional `organization_id` (backward-compatible with already-enqueued jobs) and looks up the org
- `EdgeCache::BustPage` keeps the existing path busts and, for org pages, additionally purges the organization's surrogate key via `EdgeCache::PurgeByKey` (with `/:org_slug` as the non-Fastly fallback path)

All org page responses are tagged with `organization.record_key` in `StoriesController`, so a single key purge covers the readme URL, custom-page URLs, query-param variants, and custom-domain URLs — the same pattern used for user profiles and billboards. Because it lives in the model callback, it covers every save path: the org settings pages UI (create/update/destroy), the readme sync in `OrganizationSettingsController`, and admin edits of org-owned pages.

## Added tests?

- [x] Yes

- Model: `Page#bust_cache` enqueues the worker with the organization id (and `nil` for non-org pages)
- Worker: passes the org to the buster, handles missing/deleted orgs
- Service: purges the org surrogate key with the profile path fallback
- Request (regression): `PATCH /:slug/settings/pages/:id` enqueues the bust with the org id

## [Forem core team only] How will this change be communicated?

- [x] No announcement needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787236797&installation_model_id=424141&pr_number=23657&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23657&signature=758f0a392f5d70b3cbc8e70974a90056ce65c8429b07bb40bfa13aad383098bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->