### PR TITLE
Allow organization cover image removal

### DIFF
--- a/app/controllers/organization_settings_controller.rb
+++ b/app/controllers/organization_settings_controller.rb
@@ -77,19 +77,21 @@ class OrganizationSettingsController < ApplicationController
     )
   end
 
-
   def organization_params
     permitted = params.require(:organization).permit(
       :name, :summary, :tag_line, :slug, :url, :proof, :profile_image,
       :location, :company_size, :tech_stack, :email, :story,
       :bg_color_hex, :text_color_hex, :twitter_username, :github_username,
       :cta_button_text, :cta_button_url, :cta_body_markdown,
-      :cover_image,
+      :cover_image, :remove_cover_image,
       social_links: Organization::SOCIAL_LINK_PLATFORMS,
       header_cta: [:text, :url, links: [:text, :url, :logo_url]],
     )
 
-    permitted.delete(:cover_image) unless FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[@organization])
+    unless FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[@organization])
+      permitted.delete(:cover_image)
+      permitted.delete(:remove_cover_image)
+    end
 
     result = permitted.to_h
     result.transform_values! do |value|

--- a/app/views/organization_settings/edit.html.erb
+++ b/app/views/organization_settings/edit.html.erb
@@ -153,7 +153,6 @@
 
       <%= form_for @organization, url: organization_settings_path(@organization.slug), method: :patch, html: { id: "org-settings-form", class: "grid gap-6", multipart: true } do |f| %>
 
-
       <%# ── Profile details ── %>
       <div id="section-profile" class="crayons-card crayons-card--content-rows">
         <h2><%= t("views.settings.org.admin.details") %></h2>
@@ -186,6 +185,10 @@
               <% if @organization.cover_image_url.present? %>
                 <div class="mb-2">
                   <img src="<%= @organization.cover_image_url %>" alt="<%= t("views.organizations.cover_image_alt", org: @organization.name) %>" style="max-width: 100%; max-height: 150px; object-fit: cover;" class="radius-default" />
+                </div>
+                <div class="crayons-field crayons-field--checkbox mb-2">
+                  <%= f.check_box :remove_cover_image, class: "crayons-checkbox" %>
+                  <%= f.label :remove_cover_image, t("views.organization_settings.page.remove_cover_image"), class: "crayons-field__label" %>
                 </div>
               <% end %>
               <%= f.file_field :cover_image, accept: "image/*", class: "crayons-card crayons-card--secondary p-3 flex items-center flex-1 w-100" %>

--- a/config/locales/views/organizations/en.yml
+++ b/config/locales/views/organizations/en.yml
@@ -6,6 +6,7 @@ en:
         heading: Fully Customizable Organization Page
         cover_image: Cover image
         cover_image_hint: "Recommended aspect ratio: 8:1 (e.g. 1600×200 or 2400×300)"
+        remove_cover_image: Remove cover image
         readme: Page content (Markdown)
         readme_placeholder: "Use Markdown and Liquid tags to customize your org page.\n\nExample:\n{% org_team your-org-slug %}\n{% org_team your-org-slug role=admins limit=5 %}\n{% org_posts your-org-slug %}\n{% org_posts your-org-slug limit=5 sort=reactions min_reactions=10 since=30d %}\n{% org_lead_form 42 %}"
         default_notice: "Your page is currently using the default layout."

--- a/config/locales/views/organizations/fr.yml
+++ b/config/locales/views/organizations/fr.yml
@@ -6,6 +6,7 @@ fr:
         heading: Page d'organisation entièrement personnalisable
         cover_image: Image de couverture
         cover_image_hint: "Format recommandé : 8:1 (par ex. 1600×200 ou 2400×300)"
+        remove_cover_image: Supprimer l’image de couverture
         readme: Contenu de la page (Markdown)
         readme_placeholder: "Utilisez Markdown et les balises Liquid pour personnaliser votre page d'organisation.\n\nExemple :\n{% org_team votre-slug-org %}\n{% org_team votre-slug-org role=admins limit=5 %}\n{% org_posts votre-slug-org %}\n{% org_posts votre-slug-org limit=5 sort=reactions min_reactions=10 since=30d %}\n{% org_lead_form 42 %}"
         default_notice: "Votre page utilise actuellement la mise en page par défaut."

--- a/config/locales/views/organizations/pt.yml
+++ b/config/locales/views/organizations/pt.yml
@@ -6,6 +6,7 @@ pt:
         heading: Página de organização totalmente personalizável
         cover_image: Imagem de capa
         cover_image_hint: "Proporção recomendada: 8:1 (ex. 1600×200 ou 2400×300)"
+        remove_cover_image: Remover imagem de capa
         readme: Conteúdo da página (Markdown)
         readme_placeholder: "Use Markdown e tags Liquid para personalizar a página da sua organização.\n\nExemplo:\n{% org_team slug-da-org %}\n{% org_team slug-da-org role=admins limit=5 %}\n{% org_posts slug-da-org %}\n{% org_posts slug-da-org limit=5 sort=reactions min_reactions=10 since=30d %}\n{% org_lead_form 42 %}"
         default_notice: "Sua página está usando o layout padrão."

--- a/spec/requests/organization_settings_spec.rb
+++ b/spec/requests/organization_settings_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe "OrganizationSettings" do
           expect(response.body).to include("Showcase")
         end
       end
+
+      it "shows the remove cover image control when a cover image exists" do
+        FeatureFlag.add(:org_readme)
+        FeatureFlag.enable(:org_readme, FeatureFlag::Actor[organization])
+        organization.update!(cover_image: fixture_file_upload("800x600.png", "image/png"))
+
+        get "/#{organization.slug}/settings"
+
+        expect(response.body).to include("organization_remove_cover_image")
+      end
     end
 
     context "when signed in as non-admin member" do
@@ -60,6 +70,40 @@ RSpec.describe "OrganizationSettings" do
 
   describe "PATCH /:slug/settings" do
     before { sign_in user }
+
+    context "when org_readme is enabled" do
+      before do
+        FeatureFlag.add(:org_readme)
+        FeatureFlag.enable(:org_readme, FeatureFlag::Actor[organization])
+      end
+
+      it "removes an existing cover image" do
+        organization.update!(cover_image: fixture_file_upload("800x600.png", "image/png"))
+
+        patch "/#{organization.slug}/settings", params: {
+          organization: { remove_cover_image: "1" }
+        }
+
+        expect(organization.reload.cover_image).to be_blank
+      end
+    end
+
+    context "when org_readme is disabled" do
+      before do
+        FeatureFlag.add(:org_readme)
+        FeatureFlag.disable(:org_readme, FeatureFlag::Actor[organization])
+      end
+
+      it "does not remove a cover image" do
+        organization.update!(cover_image: fixture_file_upload("800x600.png", "image/png"))
+
+        patch "/#{organization.slug}/settings", params: {
+          organization: { remove_cover_image: "1" }
+        }
+
+        expect(organization.reload.cover_image).to be_present
+      end
+    end
 
     it "updates organization profile fields" do
       patch "/#{organization.slug}/settings", params: {


### PR DESCRIPTION
## What changed

- show a **Remove cover image** checkbox when an organization has a cover image and `org_readme` is enabled
- permit CarrierWave's `remove_cover_image` attribute only when the feature is enabled
- add English, French, and Portuguese translations
- add request coverage for the control, successful removal, and disabled-feature protection

## Why

Organization cover images are optional, but organization admins could only upload or replace them. This uses CarrierWave's existing removal support so an organization can return to the no-cover state.

Closes #23658

## Verification

- `bin/flox run -- bin/rspec spec/requests/organization_settings_spec.rb` — 14 examples, 0 failures
- `bin/flox run -- bundle exec rubocop spec/requests/organization_settings_spec.rb --only RSpec/NestedGroups` — no offenses
- `bin/flox run -- bundle exec i18n-tasks health` — no missing translations or inconsistent interpolations; existing repository unused-key/normalization baseline remains
- Paseo browser verification — control is labeled and displayed with an existing image; checking it and saving removes the image and control and shows the normal success notice

The ERB linter executable is not installed in the current bundle, so the view was validated through request coverage and the browser flow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787238098&installation_model_id=424141&pr_number=23659&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23659&signature=fa3ec5615efe285b8452d1ae92ae0da35141a8ae438f016adb75f440e9fe41dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->