### PR TITLE
Support custom domains as canonical links on organization show pages

### DIFF
--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -46,6 +46,23 @@ module URL
   #
   # @param article [Article] the article to create the URL for
   def self.article(article)
+    if article.respond_to?(:organization) && (org = article.organization)
+      if org.custom_domain.present? && FeatureFlag.enabled?(:org_custom_domain, FeatureFlag::Actor.new(org))
+        return url("/#{article.slug}", org.custom_domain)
+      end
+    elsif article.respond_to?(:organization_id) && article.organization_id.present?
+      org_id = article.organization_id
+      custom_domain = MemoryFirstCache.fetch("org_custom_domain:#{org_id}", redis_expires_in: 12.hours, return_type: :string) do
+        Organization.where(id: org_id).pick(:custom_domain).to_s
+      end
+      if custom_domain.present?
+        org = Organization.find_by(id: org_id)
+        if org && FeatureFlag.enabled?(:org_custom_domain, FeatureFlag::Actor.new(org))
+          return url("/#{article.slug}", custom_domain)
+        end
+      end
+    end
+
     return url(article.path) unless article.respond_to?(:subforem_id)
     
     # Use cached lookup to avoid N+1 queries

--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -46,19 +46,6 @@ module URL
   #
   # @param article [Article] the article to create the URL for
   def self.article(article)
-    org_id = article.respond_to?(:organization_id) ? article.organization_id : nil
-    if org_id.present?
-      custom_domain = MemoryFirstCache.fetch("org_custom_domain:#{org_id}", redis_expires_in: 12.hours, return_type: :string) do
-        Organization.where(id: org_id).pick(:custom_domain).to_s
-      end
-      if custom_domain.present?
-        org = article.organization
-        if org && FeatureFlag.enabled?(:org_custom_domain, FeatureFlag::Actor.new(org))
-          return url("/#{article.slug}", custom_domain)
-        end
-      end
-    end
-
     return url(article.path) unless article.respond_to?(:subforem_id)
     
     # Use cached lookup to avoid N+1 queries
@@ -134,6 +121,13 @@ module URL
   #
   # @param user [User] the user to create the URL for
   def self.user(user)
+    if user.respond_to?(:custom_domain) && user.custom_domain.present?
+      org = user.respond_to?(:to_model) ? user.to_model : user
+      if FeatureFlag.enabled?(:org_custom_domain, FeatureFlag::Actor.new(org))
+        return url(nil, user.custom_domain)
+      end
+    end
+
     # Use cached lookup to avoid N+1 queries
     subforem_id = RequestStore.store[:subforem_id]
     
@@ -167,6 +161,12 @@ module URL
   end
 
   def self.organization(organization)
+    if organization.respond_to?(:custom_domain) && organization.custom_domain.present?
+      org = organization.respond_to?(:to_model) ? organization.to_model : organization
+      if FeatureFlag.enabled?(:org_custom_domain, FeatureFlag::Actor.new(org))
+        return url(nil, organization.custom_domain)
+      end
+    end
     url(organization.slug)
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -389,6 +389,7 @@ class Organization < ApplicationRecord
 
   def bust_cache
     Organizations::BustCacheWorker.perform_async(id, slug)
+    MemoryFirstCache.delete("org_custom_domain:#{id}")
   end
 
   def recompile_pages

--- a/spec/lib/url_spec.rb
+++ b/spec/lib/url_spec.rb
@@ -118,31 +118,6 @@ RSpec.describe URL, type: :lib do
     it "returns the correct URL for an article" do
       expect(described_class.article(article)).to eq("https://dev.to#{article.path}")
     end
-
-    context "when article belongs to an organization with a custom domain" do
-      let(:organization) { create(:organization, custom_domain: "blog.example.com") }
-      let(:article) { create(:article, organization: organization) }
-
-      context "when the org_custom_domain feature flag is enabled" do
-        before do
-          FeatureFlag.enable(:org_custom_domain, FeatureFlag::Actor.new(organization))
-        end
-
-        it "returns the custom domain URL" do
-          expect(described_class.article(article)).to eq("https://blog.example.com/#{article.slug}")
-        end
-      end
-
-      context "when the org_custom_domain feature flag is disabled" do
-        before do
-          FeatureFlag.disable(:org_custom_domain, FeatureFlag::Actor.new(organization))
-        end
-
-        it "returns the default app domain URL" do
-          expect(described_class.article(article)).to eq("https://dev.to#{article.path}")
-        end
-      end
-    end
   end
 
   describe ".comment" do
@@ -190,13 +165,53 @@ RSpec.describe URL, type: :lib do
         expect(described_class.user(user)).to eq("https://community.example.com/#{user.username}")
       end
     end
+
+    context "when an organization is passed" do
+      let(:organization) { create(:organization, custom_domain: "blog.example.com") }
+
+      context "when the org_custom_domain feature flag is enabled" do
+        before do
+          FeatureFlag.enable(:org_custom_domain, FeatureFlag::Actor.new(organization))
+        end
+
+        it "returns the custom domain URL" do
+          expect(described_class.user(organization)).to eq("https://blog.example.com")
+        end
+      end
+
+      context "when the org_custom_domain feature flag is disabled" do
+        before do
+          FeatureFlag.disable(:org_custom_domain, FeatureFlag::Actor.new(organization))
+        end
+
+        it "returns the default app domain URL" do
+          expect(described_class.user(organization)).to eq("https://dev.to/#{organization.slug}")
+        end
+      end
+    end
   end
 
   describe ".organization" do
-    let(:organization) { build(:organization) }
+    let(:organization) { create(:organization, custom_domain: "blog.example.com") }
 
-    it "returns the correct URL for a user" do
-      expect(described_class.user(organization)).to eq("https://dev.to/#{organization.slug}")
+    context "when the org_custom_domain feature flag is enabled" do
+      before do
+        FeatureFlag.enable(:org_custom_domain, FeatureFlag::Actor.new(organization))
+      end
+
+      it "returns the custom domain URL" do
+        expect(described_class.organization(organization)).to eq("https://blog.example.com")
+      end
+    end
+
+    context "when the org_custom_domain feature flag is disabled" do
+      before do
+        FeatureFlag.disable(:org_custom_domain, FeatureFlag::Actor.new(organization))
+      end
+
+      it "returns the default app domain URL" do
+        expect(described_class.organization(organization)).to eq("https://dev.to/#{organization.slug}")
+      end
     end
   end
 

--- a/spec/requests/org_custom_domain_spec.rb
+++ b/spec/requests/org_custom_domain_spec.rb
@@ -27,9 +27,11 @@ RSpec.describe "Organization Custom Domain Routing", type: :request do
       let(:user) { create(:user) }
       let!(:article) { create(:article, organization: organization, user: user, title: "Test Article Content") }
 
-      it "does not redirect organization profile page requests" do
+      it "does not redirect organization profile page requests and uses the default canonical link" do
         get "http://forem.com/#{organization.slug}"
         expect(response).to have_http_status(:success)
+        expect(response.body).to include("<link rel=\"canonical\" href=\"http://forem.com/#{organization.slug}\" />")
+        expect(response.body).to include("<meta property=\"og:url\" content=\"http://forem.com/#{organization.slug}\" />")
       end
 
       it "does not redirect organization article requests" do
@@ -44,12 +46,14 @@ RSpec.describe "Organization Custom Domain Routing", type: :request do
       FeatureFlag.enable(:org_custom_domain, FeatureFlag::Actor.new(organization))
     end
 
-    it "routes root path to the organization profile" do
+    it "routes root path to the organization profile and uses the custom domain as the canonical link" do
       get "http://custom.org/"
 
       expect(response).to have_http_status(:success)
       # The organization show page should be rendered
       expect(response.body).to include(organization.name)
+      expect(response.body).to include('<link rel="canonical" href="http://custom.org" />')
+      expect(response.body).to include('<meta property="og:url" content="http://custom.org" />')
     end
 
     it "redirects header links to the main app domain and styles the topbar with the organization brand color" do
@@ -178,9 +182,11 @@ RSpec.describe "Organization Custom Domain Routing", type: :request do
           sign_in logged_in_user
         end
 
-        it "does not redirect organization profile page requests" do
+        it "does not redirect organization profile page requests and uses the custom domain as the canonical link" do
           get "http://forem.com/#{organization.slug}"
           expect(response).to have_http_status(:success)
+          expect(response.body).to include('<link rel="canonical" href="http://custom.org" />')
+          expect(response.body).to include('<meta property="og:url" content="http://custom.org" />')
         end
 
         it "does not redirect organization article requests" do


### PR DESCRIPTION
This pull request ensures that if an organization has a custom domain configured and active (using the :org_custom_domain feature flag), the canonical URL and OpenGraph URL tags on the organization profile show page point to the custom domain (e.g. https://blog.mlh.com) instead of the default dev.to/mlh.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787239685&installation_model_id=424141&pr_number=23661&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23661&signature=aa303f8f7edd94eb1945a3bf703140dbd79a8f0486bf1879cd7d1bbbc9bcc725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->