### PR TITLE
Avoid filtering organization teams by role

### DIFF
--- a/app/liquid_tags/org_team_tag.rb
+++ b/app/liquid_tags/org_team_tag.rb
@@ -19,7 +19,7 @@ class OrgTeamTag < LiquidTagBase
   end
 
   def render(_context)
-    users = build_query
+    users = @organization.active_users
       .order(Arel.sql("users.badge_achievements_count DESC NULLS LAST, users.id ASC"))
       .limit(@limit)
 
@@ -33,7 +33,6 @@ class OrgTeamTag < LiquidTagBase
 
   def parse_options(option_tokens)
     @limit = DEFAULT_LIMIT
-    @role = "all"
 
     option_tokens.each do |token|
       match = token.match(OPTION_REGEXP)
@@ -54,23 +53,9 @@ class OrgTeamTag < LiquidTagBase
   end
 
   def parse_role(value)
+    # Keep accepting existing markup without exposing membership roles in public output.
     unless VALID_ROLES.include?(value)
       raise StandardError, I18n.t("liquid_tags.org_team_tag.invalid_role")
-    end
-
-    @role = value
-  end
-
-  def build_query
-    case @role
-    when "admins"
-      @organization.users.joins(:organization_memberships)
-        .where(organization_memberships: { organization_id: @organization.id, type_of_user: "admin" })
-    when "members"
-      @organization.users.joins(:organization_memberships)
-        .where(organization_memberships: { organization_id: @organization.id, type_of_user: "member" })
-    else
-      @organization.active_users
     end
   end
 end

--- a/spec/liquid_tags/org_team_tag_spec.rb
+++ b/spec/liquid_tags/org_team_tag_spec.rb
@@ -107,28 +107,14 @@ RSpec.describe OrgTeamTag, type: :liquid_tag do
       user
     end
 
-    it "shows only admins with role=admins" do
-      liquid = parse_tag("#{organization.slug} role=admins")
-      rendered = liquid.render
-      expect(rendered).to include(admin_user.username)
-      expect(rendered).not_to include(member_user.username)
-      expect(rendered).not_to include(guest_user.username)
-    end
+    it "does not expose membership roles through filtering" do
+      %w[admins members all].each do |role|
+        rendered = parse_tag("#{organization.slug} role=#{role}").render
 
-    it "shows only members (non-admin, non-guest) with role=members" do
-      liquid = parse_tag("#{organization.slug} role=members")
-      rendered = liquid.render
-      expect(rendered).to include(member_user.username)
-      expect(rendered).not_to include(admin_user.username)
-      expect(rendered).not_to include(guest_user.username)
-    end
-
-    it "shows all active users with role=all" do
-      liquid = parse_tag("#{organization.slug} role=all")
-      rendered = liquid.render
-      expect(rendered).to include(admin_user.username)
-      expect(rendered).to include(member_user.username)
-      expect(rendered).to include(guest_user.username)
+        expect(rendered).to include(admin_user.username)
+        expect(rendered).to include(member_user.username)
+        expect(rendered).to include(guest_user.username)
+      end
     end
 
     it "defaults to all active users" do


### PR DESCRIPTION
## Summary

- Render active organization users regardless of the accepted `role` option.
- Keep existing `role=...` markup valid so saved organization pages continue to render.

## Why

The public organization-team tag could otherwise be used to distinguish administrators from other members. Returning the same active-user list avoids that theoretical enumeration path without changing the tag's public shape.

## Impact

Existing tags remain valid. The `role` option no longer narrows the rendered team.

## Testing

- `bin/rspec spec/liquid_tags/org_team_tag_spec.rb` through the Flox environment (15 examples, 0 failures)
- `git diff --check`
- Ruby syntax check
