### PR TITLE
Treat duplicate lead submissions as successful

### DIFF
--- a/app/controllers/lead_submissions_controller.rb
+++ b/app/controllers/lead_submissions_controller.rb
@@ -18,6 +18,12 @@ class LeadSubmissionsController < ApplicationController
     end
 
     if current_user
+      existing_submission = form.lead_submissions.find_by(user: current_user)
+      if existing_submission
+        render_success(existing_submission)
+        return
+      end
+
       snapshot = LeadSubmission.snapshot_from_user(current_user)
       submission = form.lead_submissions.build(snapshot.merge(user: current_user))
     else
@@ -30,7 +36,7 @@ class LeadSubmissionsController < ApplicationController
     end
 
     if submission.save
-      render json: { success: true }
+      render_success(submission)
     else
       render json: { success: false, error: submission.errors.full_messages.first }, status: :unprocessable_entity
     end
@@ -42,5 +48,11 @@ class LeadSubmissionsController < ApplicationController
 
   def anonymous_submission_params
     params.permit(:name, :email, :company, :job_title)
+  end
+
+  def render_success(submission)
+    response = { success: true }
+    response[:submitted_at] = submission.created_at.iso8601 if submission.user_id?
+    render json: response
   end
 end

--- a/app/controllers/lead_submissions_controller.rb
+++ b/app/controllers/lead_submissions_controller.rb
@@ -37,8 +37,16 @@ class LeadSubmissionsController < ApplicationController
 
     if submission.save
       render_success(submission)
+    elsif current_user && (existing_submission = form.lead_submissions.find_by(user: current_user))
+      render_success(existing_submission)
     else
       render json: { success: false, error: submission.errors.full_messages.first }, status: :unprocessable_entity
+    end
+  rescue ActiveRecord::RecordNotUnique
+    if current_user && (existing_submission = form.lead_submissions.find_by(user: current_user))
+      render_success(existing_submission)
+    else
+      raise
     end
   rescue ActiveRecord::RecordNotFound
     render json: { success: false, error: I18n.t("lead_submissions.not_found") }, status: :not_found

--- a/app/views/liquids/_org_lead_form.html.erb
+++ b/app/views/liquids/_org_lead_form.html.erb
@@ -57,7 +57,7 @@
       return response.json();
     }).then(function(data) {
       if (data.success) {
-        markFormSubmitted(button, new Date().toISOString());
+        markFormSubmitted(button, data.submitted_at);
       } else {
         button.textContent = data.error || '<%= I18n.t("liquid_tags.org_lead_form_tag.error") %>';
         button.disabled = false;

--- a/spec/liquid_tags/org_lead_form_tag_spec.rb
+++ b/spec/liquid_tags/org_lead_form_tag_spec.rb
@@ -38,6 +38,13 @@ RSpec.describe OrgLeadFormTag, type: :liquid_tag do
       expect(rendered).to include(I18n.t("liquid_tags.org_lead_form_tag.field_company"))
       expect(rendered).to include(I18n.t("liquid_tags.org_lead_form_tag.field_job_title"))
     end
+
+    it "marks successful submissions with the server timestamp" do
+      liquid = parse_tag(lead_form.id.to_s)
+      rendered = liquid.render
+
+      expect(rendered).to include("markFormSubmitted(button, data.submitted_at)")
+    end
   end
 
   context "when given an invalid form ID" do

--- a/spec/requests/lead_submissions_spec.rb
+++ b/spec/requests/lead_submissions_spec.rb
@@ -21,16 +21,20 @@ RSpec.describe "LeadSubmissions" do
         expect(submission.name).to eq(user.name)
         expect(submission.email).to eq(user.email)
         expect(submission.username).to eq(user.username)
+        expect(parsed["submitted_at"]).to eq(submission.created_at.iso8601)
       end
 
-      it "prevents duplicate submissions" do
-        create(:lead_submission, organization_lead_form: lead_form, user: user)
+      it "treats duplicate submissions as successful" do
+        existing_submission = create(:lead_submission, organization_lead_form: lead_form, user: user)
 
-        post "/lead_submissions", params: { organization_lead_form_id: lead_form.id }, as: :json
+        expect do
+          post "/lead_submissions", params: { organization_lead_form_id: lead_form.id }, as: :json
+        end.not_to change(LeadSubmission, :count)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:ok)
         parsed = response.parsed_body
-        expect(parsed["success"]).to be false
+        expect(parsed["success"]).to be true
+        expect(parsed["submitted_at"]).to eq(existing_submission.created_at.iso8601)
       end
 
       it "rejects submissions to inactive forms" do

--- a/spec/requests/lead_submissions_spec.rb
+++ b/spec/requests/lead_submissions_spec.rb
@@ -37,6 +37,35 @@ RSpec.describe "LeadSubmissions" do
         expect(parsed["submitted_at"]).to eq(existing_submission.created_at.iso8601)
       end
 
+      it "treats duplicate submissions as successful when save returns false due to uniqueness validation" do
+        existing_submission = create(:lead_submission, organization_lead_form: lead_form, user: user)
+
+        allow_any_instance_of(LeadSubmission).to receive(:save) do |instance|
+          instance.errors.add(:user_id, "has already been taken")
+          false
+        end
+
+        post "/lead_submissions", params: { organization_lead_form_id: lead_form.id }, as: :json
+
+        expect(response).to have_http_status(:ok)
+        parsed = response.parsed_body
+        expect(parsed["success"]).to be true
+        expect(parsed["submitted_at"]).to eq(existing_submission.created_at.iso8601)
+      end
+
+      it "treats duplicate submissions as successful when ActiveRecord::RecordNotUnique is raised" do
+        existing_submission = create(:lead_submission, organization_lead_form: lead_form, user: user)
+
+        allow_any_instance_of(LeadSubmission).to receive(:save).and_raise(ActiveRecord::RecordNotUnique.new("Duplicate entry"))
+
+        post "/lead_submissions", params: { organization_lead_form_id: lead_form.id }, as: :json
+
+        expect(response).to have_http_status(:ok)
+        parsed = response.parsed_body
+        expect(parsed["success"]).to be true
+        expect(parsed["submitted_at"]).to eq(existing_submission.created_at.iso8601)
+      end
+
       it "rejects submissions to inactive forms" do
         lead_form.update!(active: false)
 


### PR DESCRIPTION
## Summary

- treat repeated signed-in lead form submissions as idempotent successes
- return the persisted submission timestamp for new and existing submissions
- reuse the existing disabled “Submitted” UI instead of showing a 422 validation message
- add request and Liquid-tag regression coverage

## Why

The signed-in lead form checks for an existing submission asynchronously. A user can submit before that check finishes, causing the duplicate validation response to be displayed on the button as `User You have already submitted this form.` The error path re-enables the button, so repeated clicks can eventually trigger the lead submission rate limit.

Returning the existing submission as a successful idempotent response lets the client converge on the intended submitted state even when that check races with a click.

## User impact

Users who already submitted a lead form will see the existing disabled **Submitted** state and original submission date. They will no longer see the validation error or be invited to retry the same submission.

## Validation

- `bin/flox run -- bin/rspec spec/requests/lead_submissions_spec.rb spec/liquid_tags/org_lead_form_tag_spec.rb spec/requests/rack_attack_lead_submissions_spec.rb`
  - 16 examples, 0 failures
- live authenticated Flox check:
  - initial POST: 200
  - duplicate POST: 200
  - both responses returned the same timestamp
  - `/lead_submissions/check` returned the same timestamp
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787249954&installation_model_id=424141&pr_number=23664&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23664&signature=ee96cedbb119352bff45a9456248e66915d5e3788110c0838aa6d5a4a3f189ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->