### PR TITLE
Fix TypeError: top.addSnackbarItem is not a function on Mod Dashboard…

### DIFF
--- a/app/javascript/packs/modCenter.jsx
+++ b/app/javascript/packs/modCenter.jsx
@@ -2,6 +2,10 @@ import { h, render } from 'preact';
 import { ModerationArticles } from '../modCenter/moderationArticles';
 import { addSnackbarItem, Snackbar } from '../Snackbar';
 
+// eslint-disable-next-line no-restricted-globals
+top.addSnackbarItem = addSnackbarItem;
+
+
 let elementLoaded = false;
 
 function loadElement() {


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Exposes `addSnackbarItem` as `top.addSnackbarItem` in `app/javascript/packs/modCenter.jsx`.

When moderators attempt to rate post quality or flag posts on the Mod Dashboard (`/mod`), `actionsPanel.js` invokes `top.addSnackbarItem`. Because `modCenter.jsx` rendered the `<Snackbar />` component but did not attach `addSnackbarItem` to `top`, the action threw `TypeError: top.addSnackbarItem is not a function` and cancelled the rating. 

This PR supersedes #22430: instead of introducing complex cross-context event handlers, this fix directly mirrors the established pattern in `articleSignedIn.jsx` with a clean, single-line global assignment.

## Related Tickets & Documents

- Closes #22427
- Supersedes #22430

## QA Instructions, Screenshots, Recordings

### UI accessibility checklist
- [x] Semantic HTML implemented?
- [x] Keyboard operability supported?
- [x] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [x] Color contrast tested?

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Small 1-line global binding fix in entrypoint pack matching the existing `articleSignedIn.jsx` pattern.
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

