### PR TITLE
Add LiveCodes liquid tag

### DIFF
--- a/app/liquid_tags/livecodes_tag.rb
+++ b/app/liquid_tags/livecodes_tag.rb
@@ -1,0 +1,66 @@
+class LivecodesTag < LiquidTagBase
+  PARTIAL = "liquids/livecodes".freeze
+
+  # Matches:
+  #   https://livecodes.io
+  #   https://livecodes.io?x=...            (no slash)
+  #   https://livecodes.io/?x=...
+  #   https://livecodes.io/?js=...&css=...  (any number of params)
+  #   https://v49.livecodes.io/?x=...       (version subdomain)
+  #   https://next.livecodes.io/?x=...      (named subdomain)
+  #   https://livecodes.io/#config=code/... (hash config)
+  REGISTRY_REGEXP =
+    %r{\Ahttps://(?:[a-zA-Z0-9-]{1,20}\.)?livecodes\.io(?:/?|/?\?[^\s#]*|/?\#\S*)\z}
+
+  # height must be 3-4 digits (100..9999 px)
+  OPTION_REGEXP = /\Aheight=(?<height>\d{3,4})\z/
+  DEFAULT_HEIGHT = 400
+
+  def initialize(_tag_name, input, _parse_context)
+    super
+    # strip_tags first (it HTML-encodes entities in its output),
+    # THEN decode entities so "&amp;" becomes "&" in the URL.
+    stripped_input = CGI.unescape_html(strip_tags(input)).strip
+    url, *options = stripped_input.split
+    @src = parsed_src(url)
+    @height = parsed_height(options)
+  end
+
+  def render(_context)
+    ApplicationController.render(
+      partial: PARTIAL,
+      locals: {
+        src: @src,
+        height: "#{@height}px"
+      },
+    )
+  end
+
+  private
+
+  def parsed_src(url)
+    unless url&.match?(REGISTRY_REGEXP)
+      raise StandardError, I18n.t("liquid_tags.livecodes_tag.invalid_livecodes_url")
+    end
+
+    url
+  end
+
+  def parsed_height(options)
+    height = DEFAULT_HEIGHT
+
+    options.each do |option|
+      match = option.match(OPTION_REGEXP)
+      unless match
+        raise StandardError, I18n.t("liquid_tags.livecodes_tag.invalid_option", option: option)
+      end
+
+      height = match[:height].to_i
+    end
+
+    height
+  end
+end
+
+Liquid::Template.register_tag("livecodes", LivecodesTag)
+UnifiedEmbed.register(LivecodesTag, regexp: LivecodesTag::REGISTRY_REGEXP)

--- a/app/views/liquids/_livecodes.html.erb
+++ b/app/views/liquids/_livecodes.html.erb
@@ -1,0 +1,10 @@
+<iframe
+  loading="lazy"
+  src="<%= src %>"
+  style="height: <%= height %>; width: 100%; border: 1px solid rgba(0, 0, 0, 0.35); border-radius: 8px;"
+  title="LiveCodes Playground"
+  scrolling="no"
+  sandbox="allow-same-origin allow-scripts allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-presentation"
+  allowtransparency="true"
+  allowfullscreen>
+</iframe>

--- a/app/views/pages/_editor_liquid_help.en.html.erb
+++ b/app/views/pages/_editor_liquid_help.en.html.erb
@@ -23,6 +23,7 @@
       <li class="ml-4">Instagram</li>
       <li class="ml-4">JSFiddle</li>
       <li class="ml-4">JSitor</li>
+      <li class="ml-4">LiveCodes</li>
       <li class="ml-4">Loom</li>
       <li class="ml-4">Lovable</li>
       <li class="ml-4">Kotlin</li>

--- a/app/views/pages/_editor_liquid_help.fr.html.erb
+++ b/app/views/pages/_editor_liquid_help.fr.html.erb
@@ -23,6 +23,7 @@
       <li class="ml-4">Instagram</li>
       <li class="ml-4">JSFiddle</li>
       <li class="ml-4">JSitor</li>
+      <li class="ml-4">LiveCodes</li>
       <li class="ml-4">Loom</li>
       <li class="ml-4">Lovable</li>
       <li class="ml-4">Kotlin</li>

--- a/app/views/pages/_editor_liquid_help.pt.html.erb
+++ b/app/views/pages/_editor_liquid_help.pt.html.erb
@@ -23,6 +23,7 @@
       <li class="ml-4">Instagram</li>
       <li class="ml-4">JSFiddle</li>
       <li class="ml-4">JSitor</li>
+      <li class="ml-4">LiveCodes</li>
       <li class="ml-4">Loom</li>
       <li class="ml-4">Lovable</li>
       <li class="ml-4">Kotlin</li>

--- a/app/views/pages/_supported_url_embeds_list.en.html.erb
+++ b/app/views/pages/_supported_url_embeds_list.en.html.erb
@@ -15,6 +15,7 @@
   <li class="ml-4">JSFiddle</li>
   <li class="ml-4">JSitor</li>
   <li class="ml-4">Kotlin</li>
+  <li class="ml-4">LiveCodes</li>
   <li class="ml-4">Loom</li>
   <li class="ml-4">Medium</li>
   <li class="ml-4">Mux</li>

--- a/app/views/pages/_supported_url_embeds_list.fr.html.erb
+++ b/app/views/pages/_supported_url_embeds_list.fr.html.erb
@@ -16,6 +16,7 @@
   <li class="ml-4">Instagram</li>
   <li class="ml-4">JSFiddle</li>
   <li class="ml-4">JSitor</li>
+  <li class="ml-4">LiveCodes</li>
   <li class="ml-4">Loom</li>
   <li class="ml-4">Kotlin</li>
   <li class="ml-4">Medium</li>

--- a/app/views/pages/_supported_url_embeds_list.pt.html.erb
+++ b/app/views/pages/_supported_url_embeds_list.pt.html.erb
@@ -16,6 +16,7 @@
   <li class="ml-4">Instagram</li>
   <li class="ml-4">JSFiddle</li>
   <li class="ml-4">JSitor</li>
+  <li class="ml-4">LiveCodes</li>
   <li class="ml-4">Loom</li>
   <li class="ml-4">Kotlin</li>
   <li class="ml-4">Medium</li>

--- a/config/locales/liquid_tags/en.yml
+++ b/config/locales/liquid_tags/en.yml
@@ -62,6 +62,9 @@ en:
       no_source_found: No source found
     listing_tag:
       invalid_url_or_slug: Invalid URL or slug. Listing not found.
+    livecodes_tag:
+      invalid_livecodes_url: Invalid LiveCodes URL
+      invalid_option: "Invalid option: %{option}. Supported options: height (e.g. height=500)"
     lovable_tag:
       invalid_url: Invalid Lovable URL
     loom_tag:

--- a/config/locales/liquid_tags/fr.yml
+++ b/config/locales/liquid_tags/fr.yml
@@ -62,6 +62,9 @@ fr:
       no_source_found: Aucune source trouvée
     listing_tag:
       invalid_url_or_slug: URL ou slug non valide. Liste non trouvée.
+    livecodes_tag:
+      invalid_livecodes_url: URL LiveCodes non valide
+      invalid_option: "Option non valide : %{option}. Options prises en charge : height (ex. height=500)"
     lovable_tag:
       invalid_url: URL Lovable non valide
     loom_tag:

--- a/config/locales/liquid_tags/pt.yml
+++ b/config/locales/liquid_tags/pt.yml
@@ -62,6 +62,9 @@ pt:
       no_source_found: Nenhuma fonte encontrada
     listing_tag:
       invalid_url_or_slug: URL ou slug inválido. Anúncio não encontrado.
+    livecodes_tag:
+      invalid_livecodes_url: URL do LiveCodes inválida
+      invalid_option: "Opção inválida: %{option}. Opções suportadas: height (ex.: height=500)"
     lovable_tag:
       invalid_url: URL do Lovable inválida
     loom_tag:

--- a/spec/liquid_tags/livecodes_tag_spec.rb
+++ b/spec/liquid_tags/livecodes_tag_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe LivecodesTag, type: :liquid_tag do
+  describe "#render" do
+    let(:valid_urls) do
+      [
+        "https://livecodes.io/?x=id/abc123",
+        "https://v49.livecodes.io/?x=id/abc123",
+        "https://next.livecodes.io/?x=id/abc123",
+        "https://livecodes.io/?template=react",
+        "https://livecodes.io/?js=console.log(1)&css=body{}&theme=light",
+        "https://livecodes.io?x=id/abc123",
+        "https://livecodes.io",
+        "https://livecodes.io/#config=code/N4IgLglmA2CmIC4QFUB2kawCYAIAKATgPYBWsAxmCADQhawDO5BEADpEaoiDSABawAhlm4AeALawwgnOT6CCDKQF4AOigAqAMQC0ADnU4A9AD5VqCVJmpBktSABuEWAHdWRAmEPlOYWOnsXCCwwPmV6J3JYHSCQvmocCFQoCEFoHSY02GUARgA6AAZDU14%2BMHFoAEEwMEVuaEFUAHN7f28GhgZ7dV5pJoZEAG0AXVpBSggHWABRLCgPbnEFAGsAV1ZeJYI1jYRQBubVwSb4JDKK3h90fyoz2GhoIhAAX1oGMABPOER9xqajk7ccidS6%2BG7cF5vZhsW6-Q7HU4gEiCByCJgsdig67oCGvEDvL6MARSAYIEZQjFgUnkkDAhiERhSCG0VjEKKdDzU0a01bvIjiADKUkgzVJwDxEHE7k8Yrxn1YjB%2BcsYVJ%2BIAO-wR3HljGhmNoVz8OKQkMcsEUEE43AALABOXpEIjQMUgfyCABGcBESDS0F440gUyBnAYTvgb2kYF5QMeShEz2eQA",
+      ]
+    end
+
+    let(:invalid_urls) do
+      [
+        "https://livecodes.io.evil.com/?x=id/abc123",
+        "https://evil.com/https://livecodes.io/?x=id/abc123",
+        "http://livecodes.io/?x=id/abc123",
+        "https://livecodesxio/?x=id/abc123",
+      ]
+    end
+
+    def generate_new_liquid(input)
+      Liquid::Template.register_tag("livecodes", described_class)
+      Liquid::Template.parse("{% livecodes #{input} %}")
+    end
+
+    it "renders an iframe for all valid URL patterns" do
+      valid_urls.each do |url|
+        rendered = generate_new_liquid(url).render
+        expect(rendered).to include("<iframe")
+        # ERB HTML-escapes "&" → "&amp;" in attributes, so we compare
+        # against the escaped form.
+        escaped_url = url.gsub("&", "&amp;")
+        expect(rendered).to include(escaped_url)
+      end
+    end
+
+    it "does not modify the URL" do
+      url = "https://livecodes.io/?x=id/abc123"
+      rendered = generate_new_liquid(url).render
+      expect(rendered).not_to include("embed=true")
+    end
+
+    it "uses the default height when none is given" do
+      rendered = generate_new_liquid(valid_urls.first).render
+      expect(rendered).to include("height: 400px")
+    end
+
+    it "accepts a height option" do
+      rendered = generate_new_liquid("#{valid_urls.first} height=500").render
+      expect(rendered).to include("height: 500px")
+    end
+
+    it "raises an error for invalid URLs" do
+      invalid_urls.each do |url|
+        expect { generate_new_liquid(url).render }.to raise_error(StandardError)
+      end
+    end
+
+    it "raises an error for invalid options" do
+      expect { generate_new_liquid("#{valid_urls.first} height=abc").render }
+        .to raise_error(StandardError)
+      expect { generate_new_liquid("#{valid_urls.first} width=500").render }
+        .to raise_error(StandardError)
+    end
+
+    it "decodes HTML-encoded ampersands in the URL" do
+      rendered = generate_new_liquid("https://livecodes.io/?js=x&amp;css=y&amp;theme=light").render
+      # ERB re-encodes "&" as "&amp;" in the attribute (correct HTML),
+      # but it must not be double-encoded as "&amp;amp;"
+      expect(rendered).to include("js=x&amp;css=y&amp;theme=light")
+      expect(rendered).not_to include("&amp;amp;")
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds a liquid tag for embedding [LiveCodes](https://livecodes.io) playgrounds.
LiveCodes is a free, [open-source](https://github.com/live-codes/livecodes) (MIT-licensed), [client-side](https://livecodes.io/docs/why#client-side) code playground that supports [90+ languages and frameworks](https://livecodes.io/docs/why#language-support).
Projects can be [shared](https://livecodes.io/docs/features/share), [exported](https://livecodes.io/docs/features/export), [deployed](https://livecodes.io/docs/features/deploy) and [embedded](https://livecodes.io/docs/features/embeds) in web pages.
See [docs](https://livecodes.io/docs/) for details.

Both syntaxes are supported:

    {% livecodes https://livecodes.io/?x=id/iu7h5b4bdfw %}
    {% embed https://livecodes.io/?x=id/iu7h5b4bdfw %}

Implementation details:

- `LivecodesTag` validates the URL against an anchored regexp that only accepts the `livecodes.io` host, including versioned [permanent URLs](https://livecodes.io/docs/features/permanent-url) (e.g. `https://v49.livecodes.io/?x=...`) which pin the app version to avoid breaking changes.
- Registered with `UnifiedEmbed` so the generic `{% embed %}` syntax works.
- The iframe partial is `sandbox`ed, `loading="lazy"`, and follows the pattern of the existing partials.

Security notes: LiveCodes runs all user code and compilers client-side in sandboxed iframes with a unique origin; embedded playgrounds have no access to the embedding page or its cookies/localStorage.

Disclosure: I am the author/maintainer of LiveCodes.

## Related Tickets & Documents

Closes #23650

## QA Instructions, Screenshots, Recordings

1. Create a new post and add a [share URL](https://livecodes.io/docs/features/share) like this:

       {% embed https://livecodes.io/?x=id/iu7h5b4bdfw %}

2. Save the post — an interactive playground iframe should render, showing the embedded (not full-app) LiveCodes UI.
3. Repeat with the named syntax `{% livecodes ... %}` and with a versioned URL (`https://v49.livecodes.io/?x=... %}`): both should render. Named syntax allows specifying height (`https://livecodes.io/?x=... height=600 %}`)
4. Try an invalid URL such as `{% embed https://livecodes.io.evil.com/?x=abc %}`: embedding should fail.
5. The playground can be [configured](https://livecodes.io/docs/configuration/configuration-object) using URL [query params](https://livecodes.io/docs/configuration/query-params) (`https://livecodes.io/?template=react&theme=light`).

<img width="2240" height="1400" alt="image" src="https://github.com/user-attachments/assets/1be552e2-0850-4c5b-bc88-0204c6fc7fa6" />

## Added/updated tests?

- [x] Yes. `spec/liquid_tags/livecodes_tag_spec.rb` covers valid URLs, versioned permanent URLs, and rejection of invalid hosts.
- [ ] No


## [optional] Are there any post deployment tasks we need to perform?

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787542330&installation_model_id=424141&pr_number=23673&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23673&signature=e96c5879992e32204b5d84bf2ce80292227b4f38142c2ea4dcc84799c9e6d229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->