### PR TITLE
Fill DEV profile fields with MLH info on signup

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -186,3 +186,6 @@ SMTP_AUTHENTICATION=
 
 # Disable simplecov coverage testing when running rspec locally
 COVERAGE="false"
+
+# MLH API URL override (optional)
+MLH_API_BASE_URL=

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -41,6 +41,7 @@ module Authentication
       # These variables need to be set outside of the scope of the
       # transaction in order to be used after the transaction is completed.
       log_to_datadog = false
+      new_mlh_identity = false
       id_provider, authed_user = nil
 
       ActiveRecord::Base.transaction do
@@ -65,11 +66,14 @@ module Authentication
         # A newly linked mlh identity puts the MLH Core user id (its uid) into
         # User#trackable_payload, so surface a user_updated to the DEV → Core
         # sync — which keys off profile_updated_at.
-        user.profile_updated_at = Time.current if new_identity && identity.provider == "mlh"
+        new_mlh_identity = new_identity && identity.provider == "mlh"
+        user.profile_updated_at = Time.current if new_mlh_identity
 
         user.save!
         authed_user = user
       end
+
+      Users::PrefillMlhProfileWorker.perform_async(authed_user.id) if new_mlh_identity
 
       if log_to_datadog
         # Notify DataDog if a new identity was successfully created.

--- a/app/services/authentication/providers/mlh.rb
+++ b/app/services/authentication/providers/mlh.rb
@@ -25,12 +25,19 @@ module Authentication
       def new_user_data
         {
           email: info.email.to_s,
-          name: info.name
+          name: info.name,
+          username: Users::UsernameGenerator.call([user_nickname])
         }
       end
 
       def existing_user_data
         {}
+      end
+
+      # MLH has no nickname, so seed username generation from the email
+      # local-name so we don't end up with a random string
+      def user_nickname
+        info.email.to_s.split("@").first.to_s
       end
 
       protected

--- a/app/services/mlh/api_client.rb
+++ b/app/services/mlh/api_client.rb
@@ -1,0 +1,62 @@
+module Mlh
+  # Thin transport for authenticated MLH v4 API calls.
+  #
+  # MLH_API_BASE_URL may be set to override the default API URL.
+  class ApiClient
+    Error = Class.new(StandardError)
+    RecoverableError = Class.new(Error)
+    ClientError = Class.new(Error)
+
+    DEFAULT_BASE_URL = "https://api.mlh.com".freeze
+    TIMEOUT_SECONDS = 10
+    OPEN_TIMEOUT_SECONDS = 5
+    RECOVERABLE_STATUSES = [408, 429].freeze
+
+    # @param access_token [String] a MLH OAuth access token
+    def initialize(access_token)
+      @access_token = access_token
+    end
+
+    # @param path [String] an endpoint path with optional query string
+    # @return [Hash] the parsed response body
+    # @raise [ArgumentError] when no access token was given
+    # @raise [RecoverableError] on a timeout / connection failure / 5xx
+    # @raise [ClientError] on a permanent 4xx response or an unparseable body
+    def get(path)
+      raise ArgumentError, "access_token is required" if access_token.blank?
+
+      url = "#{base_url}#{path}"
+      response = Faraday.get(url) do |req|
+        req.headers["Authorization"] = "Bearer #{access_token}"
+        req.options.timeout = TIMEOUT_SECONDS
+        req.options.open_timeout = OPEN_TIMEOUT_SECONDS
+      end
+      return JSON.parse(response.body) if response.success?
+
+      raise_for_status(url, response.status)
+    rescue Faraday::Error => e
+      fail_with(RecoverableError, url, "#{e.class}: #{e.message}")
+    rescue JSON::ParserError
+      fail_with(ClientError, url, "unparseable response body")
+    end
+
+    private
+
+    attr_reader :access_token
+
+    def raise_for_status(url, status)
+      recoverable = status >= 500 || RECOVERABLE_STATUSES.include?(status)
+      error_class = recoverable ? RecoverableError : ClientError
+      fail_with(error_class, url, "HTTP #{status}")
+    end
+
+    def fail_with(error_class, url, reason)
+      Rails.logger.error("[Mlh::ApiClient] GET #{url} failed: #{reason}")
+      raise error_class, reason
+    end
+
+    def base_url
+      (ApplicationConfig["MLH_API_BASE_URL"].presence || DEFAULT_BASE_URL).chomp("/")
+    end
+  end
+end

--- a/app/services/mlh/profile_mapper.rb
+++ b/app/services/mlh/profile_mapper.rb
@@ -1,0 +1,75 @@
+module Mlh
+  # Maps a MLH v4 user payload to usable Forem profile attributes.
+  class ProfileMapper
+    LOCATION_MAX_LENGTH = 100
+
+    # Some fields are stored in Forem as ProfileFields rather than in Profile,
+    # so we need to look them up by label. These may change depending on how
+    # this Forem instance is configured.
+    WORK_LABEL = "Work".freeze
+    EDUCATION_LABEL = "Education".freeze
+    PRONOUNS_LABEL = "Pronouns".freeze
+
+    def self.call(...)
+      new(...).call
+    end
+
+    # @param payload [Hash] a parsed /v4/users/me response
+    def initialize(payload)
+      @payload = payload.to_h
+    end
+
+    # @return [Hash] Usable values keyed by Profile field or ProfileField
+    #   attribute name
+    def call
+      { "location" => location }.merge(profile_fields).compact_blank
+    end
+
+    private
+
+    attr_reader :payload
+
+    # Values for ProfileFields that are configured, keyed by attribute name
+    def profile_fields
+      values = {
+        WORK_LABEL => work,
+        EDUCATION_LABEL => education,
+        PRONOUNS_LABEL => pronouns
+      }
+      ProfileField
+        .where(label: values.keys)
+        .pluck(:label, :attribute_name)
+        .to_h { |label, attribute_name| [attribute_name, values[label]] }
+    end
+
+    def location
+      address = payload["address"]
+      return if address.blank?
+
+      parts = [address["city"], address["state"], address["country_code"]].compact_blank
+      parts.join(", ").truncate(LOCATION_MAX_LENGTH).presence
+    end
+
+    def work
+      current_first(payload["professional_experience"])&.dig("title").presence
+    end
+
+    def education
+      enrollment = current_first(payload["education"])
+      return if enrollment.blank?
+
+      [enrollment["school_name"], enrollment["major"]].compact_blank.join(", ").presence
+    end
+
+    def pronouns
+      payload.dig("profile", "pronouns").presence
+    end
+
+    # MLH returns history, not a single record. Prefer whatever the user marked
+    # as current, otherwise fall back to the first entry.
+    def current_first(collection)
+      records = Array.wrap(collection).select { |record| record.is_a?(Hash) }
+      records.detect { |record| record["current"] } || records.first
+    end
+  end
+end

--- a/app/services/mlh/user_profile.rb
+++ b/app/services/mlh/user_profile.rb
@@ -1,0 +1,37 @@
+module Mlh
+  # Fetches the authenticated user's MLH profile from the v4 API. Fields are
+  # mapped to Forem profile attributes via Mlh::ProfileMapper by default.
+  class UserProfile
+    PROFILE_PATH = "/v4/users/me".freeze
+    EXPAND_FIELDS = %w[address education professional_experience].freeze
+
+    def self.call(...)
+      new(...).call
+    end
+
+    # @param access_token [String] the MLH OAuth access token
+    # @param mapper [#call, nil] wraps the response payload; defaults to
+    #   Mlh::ProfileMapper. Pass nil to return the raw payload.
+    def initialize(access_token, mapper: Mlh::ProfileMapper)
+      @access_token = access_token
+      @mapper = mapper
+    end
+
+    # @return [Hash, nil] mapped profile attributes, or nil on an empty response
+    # @raise [ArgumentError] when there is no token to fetch with
+    # @raise [Mlh::ApiClient::Error] propagated from the fetch
+    def call
+      payload = Mlh::ApiClient.new(@access_token).get(path)
+      return if payload.blank?
+
+      @mapper ? @mapper.call(payload) : payload
+    end
+
+    private
+
+    def path
+      expansions = EXPAND_FIELDS.map { |field| "expand[]=#{field}" }.join("&")
+      [PROFILE_PATH, expansions].join("?")
+    end
+  end
+end

--- a/app/workers/users/prefill_mlh_profile_worker.rb
+++ b/app/workers/users/prefill_mlh_profile_worker.rb
@@ -1,0 +1,35 @@
+module Users
+  # Fills in profile details from MLH. Does not overwrite set fields.
+  class PrefillMlhProfileWorker
+    include Sidekiq::Job
+    sidekiq_options queue: :medium_priority, retry: 3, lock: :until_executing, on_conflict: :replace
+
+    def perform(user_id)
+      user = User.find_by(id: user_id)
+      return unless user
+
+      identity = user.identities.find_by(provider: "mlh")
+      return if identity&.token.blank?
+
+      mapped = Mlh::UserProfile.call(identity.token)
+      return if mapped.blank?
+
+      attributes = assignable_attributes(user, mapped)
+      return if attributes.blank?
+
+      Users::Update.call(user, profile: attributes)
+    rescue Mlh::ApiClient::ClientError
+      # Do not retry unrecoverable client errors
+      nil
+    end
+
+    private
+
+    # Filter out fields that already have values
+    def assignable_attributes(user, mapped)
+      profile = user.profile || user.create_profile
+
+      mapped.select { |attribute, _value| profile.public_send(attribute).blank? }
+    end
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -76,7 +76,7 @@ MLH_OMNIAUTH_SETUP = lambda do |env|
     strategy_class.prepend(OmniAuth::Strategies::MlhCallbackUrlOverride)
   end
 
-  env["omniauth.strategy"].options[:scope] = "user:read:email user:read:phone user:read:profile user:read:demographics public offline_access mlh:read:user"
+  env["omniauth.strategy"].options[:scope] = "user:read:email user:read:phone user:read:profile user:read:demographics user:read:education user:read:employment user:read:address public offline_access mlh:read:user"
   env["omniauth.strategy"].options[:client_id] = Settings::Authentication.mlh_key
   env["omniauth.strategy"].options[:client_secret] = Settings::Authentication.mlh_secret
   env["omniauth.strategy"].options[:provider_ignores_state] = true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -838,9 +838,7 @@ RSpec.describe User do
         when :facebook, :google_oauth2
           expect(new_user.username).to match(/fname_lname_\S*\z/)
         when :mlh
-          # users.mlh_username is intentionally never written, so the
-          # username is generator-random
-          expect(new_user.username).to match(/\A[a-z]{12}\z/)
+          expect(new_user.username).to eq("mlh")
         else
           expect(new_user.username).to eq("valid_username")
         end
@@ -861,7 +859,7 @@ RSpec.describe User do
         when :facebook, :google_oauth2
           expect(new_user.username).to match(/fname_lname_\S*\z/)
         when :mlh
-          expect(new_user.username).to match(/\A[a-z]{12}\z/)
+          expect(new_user.username).to eq("mlh")
         else
           expect(new_user.username).to eq("invalidusername")
         end
@@ -879,17 +877,9 @@ RSpec.describe User do
         mock_username(provider_name, banished_name)
 
         create(:banished_user, username: provider_username(provider_name))
-        if provider_name == :mlh
-          # MLH usernames are generator-random (mlh_username is never
-          # written), so the banished-username guard cannot match
-          expect do
-            user_from_authorization_service(provider_name, nil, "navbar_basic")
-          end.not_to raise_error
-        else
-          expect do
-            user_from_authorization_service(provider_name, nil, "navbar_basic")
-          end.to raise_error(ActiveRecord::RecordInvalid, /Username has been banished./)
-        end
+        expect do
+          user_from_authorization_service(provider_name, nil, "navbar_basic")
+        end.to raise_error(ActiveRecord::RecordInvalid, /Username has been banished./)
       end
     end
 

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -976,5 +976,22 @@ RSpec.describe Authentication::Authenticator, type: :service do
 
       expect(user.reload.profile_updated_at).to be < 1.year.ago
     end
+
+    it "enqueues the profile prefill when a new mlh identity is linked" do
+      user = create(:user, email: auth_payload.info.email)
+
+      expect do
+        described_class.call(auth_payload, current_user: user)
+      end.to change(Users::PrefillMlhProfileWorker.jobs, :size).by(1)
+    end
+
+    it "does not enqueue the profile prefill when the mlh identity already exists" do
+      user = create(:user, email: auth_payload.info.email)
+      described_class.call(auth_payload, current_user: user)
+
+      expect do
+        described_class.call(auth_payload, current_user: user)
+      end.not_to change(Users::PrefillMlhProfileWorker.jobs, :size)
+    end
   end
 end

--- a/spec/services/authentication/providers/mlh_spec.rb
+++ b/spec/services/authentication/providers/mlh_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Authentication::Providers::Mlh, type: :service do
       uid: "123456",
       info: {
         email: "test@example.com",
-        nickname: "mlhuser",
         name: "MLH User"
       },
       extra: {
@@ -37,9 +36,24 @@ RSpec.describe Authentication::Providers::Mlh, type: :service do
   end
 
   describe "#new_user_data" do
-    it "maps email and name, leaving users.mlh_username untouched" do
+    it "maps email, name, and username, leaving users.mlh_username untouched" do
       data = provider.new_user_data
-      expect(data).to eq(email: "test@example.com", name: "MLH User")
+      expect(data).to eq(email: "test@example.com", name: "MLH User", username: "test")
+    end
+
+    it "generates a unique username" do
+      create(:user, username: "test")
+
+      expect(provider.new_user_data[:username]).not_to eq("test")
+      expect(provider.new_user_data[:username]).to start_with("test")
+    end
+  end
+
+  describe "#user_nickname" do
+    it "derives the nickname from the email" do
+      auth_payload.info.nickname = nil
+
+      expect(provider.user_nickname).to eq("test")
     end
   end
 

--- a/spec/services/mlh/api_client_spec.rb
+++ b/spec/services/mlh/api_client_spec.rb
@@ -1,0 +1,123 @@
+require "rails_helper"
+
+RSpec.describe Mlh::ApiClient, type: :service do
+  let(:access_token) { "mlh-access-token" }
+  let(:path) { "/v4/users/me" }
+  let(:url) { "https://api.mlh.com/v4/users/me" }
+
+  before do
+    allow(ApplicationConfig).to receive(:[]).and_call_original
+    allow(ApplicationConfig).to receive(:[]).with("MLH_API_BASE_URL").and_return(nil)
+  end
+
+  describe "#get" do
+    it "returns the parsed body on success" do
+      stub_request(:get, url)
+        .to_return(status: 200, body: { "id" => "abc" }.to_json,
+                   headers: { "Content-Type" => "application/json" })
+
+      expect(described_class.new(access_token).get(path)).to eq("id" => "abc")
+    end
+
+    it "authenticates with the access token" do
+      stub_request(:get, url)
+        .with(headers: { "Authorization" => "Bearer #{access_token}" })
+        .to_return(status: 200, body: "{}", headers: { "Content-Type" => "application/json" })
+
+      described_class.new(access_token).get(path)
+
+      expect(WebMock).to have_requested(:get, url)
+        .with(headers: { "Authorization" => "Bearer #{access_token}" })
+    end
+
+    it "raises ArgumentError without a token" do
+      expect { described_class.new(nil).get(path) }.to raise_error(ArgumentError)
+
+      expect(WebMock).not_to have_requested(:get, url)
+    end
+
+    it "raises a terminal ClientError when the token is rejected" do
+      stub_request(:get, url).to_return(status: 401, body: "")
+
+      expect { described_class.new(access_token).get(path) }
+        .to raise_error(Mlh::ApiClient::ClientError)
+    end
+
+    it "raises a RecoverableError on a 5xx" do
+      stub_request(:get, url).to_return(status: 500, body: "")
+
+      expect { described_class.new(access_token).get(path) }
+        .to raise_error(Mlh::ApiClient::RecoverableError)
+    end
+
+    it "raises a RecoverableError on a timeout" do
+      stub_request(:get, url).to_timeout
+
+      expect { described_class.new(access_token).get(path) }
+        .to raise_error(Mlh::ApiClient::RecoverableError)
+    end
+
+    [408, 429].each do |status|
+      it "raises a RecoverableError on a #{status}" do
+        stub_request(:get, url).to_return(status: status, body: "")
+
+        expect { described_class.new(access_token).get(path) }
+          .to raise_error(Mlh::ApiClient::RecoverableError)
+      end
+    end
+
+    it "raises a terminal ClientError on a 404" do
+      stub_request(:get, url).to_return(status: 404, body: "")
+
+      expect { described_class.new(access_token).get(path) }
+        .to raise_error(Mlh::ApiClient::ClientError)
+    end
+
+    it "raises a ClientError when the response is not JSON" do
+      stub_request(:get, url).to_return(status: 200, body: "<html>nope</html>")
+
+      expect { described_class.new(access_token).get(path) }
+        .to raise_error(Mlh::ApiClient::ClientError)
+    end
+
+    describe "terminal failure handing" do
+      before { allow(Rails.logger).to receive(:error) }
+
+      it "logs when token is rejected" do
+        stub_request(:get, url).to_return(status: 401, body: "")
+
+        suppress(Mlh::ApiClient::Error) { described_class.new(access_token).get(path) }
+
+        expect(Rails.logger).to have_received(:error).with(/Mlh::ApiClient.*HTTP 401/)
+      end
+
+      it "logs an unparseable body" do
+        stub_request(:get, url).to_return(status: 200, body: "<html>nope</html>")
+
+        suppress(Mlh::ApiClient::Error) { described_class.new(access_token).get(path) }
+
+        expect(Rails.logger).to have_received(:error).with(/Mlh::ApiClient.*unparseable/)
+      end
+
+      it "does not log the access token" do
+        stub_request(:get, url).to_return(status: 401, body: "")
+
+        suppress(Mlh::ApiClient::Error) { described_class.new(access_token).get(path) }
+
+        expect(Rails.logger).not_to have_received(:error).with(/#{access_token}/)
+      end
+    end
+
+    it "targets a local MLH Core when MLH_API_BASE_URL is set" do
+      local_url = "http://host.docker.internal:3001/v4/users/me"
+      allow(ApplicationConfig).to receive(:[]).with("MLH_API_BASE_URL")
+        .and_return("http://host.docker.internal:3001")
+      stub_request(:get, local_url).to_return(status: 200, body: "{}",
+                                              headers: { "Content-Type" => "application/json" })
+
+      described_class.new(access_token).get(path)
+
+      expect(WebMock).to have_requested(:get, local_url)
+    end
+  end
+end

--- a/spec/services/mlh/profile_mapper_spec.rb
+++ b/spec/services/mlh/profile_mapper_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe Mlh::ProfileMapper, type: :service do
+  # Mirrors a /v4/users/me response
+  let(:payload) do
+    {
+      "address" => {
+        "line1" => "1 Example Street", "city" => "Brooklyn", "state" => "NY",
+        "postal_code" => "11201", "country" => "United States of America", "country_code" => "US"
+      },
+      "education" => [
+        { "current" => true, "school_name" => "Acadia University", "major" => "Computer Science" },
+      ],
+      "professional_experience" => [
+        { "current" => true, "title" => "Software Engineer", "type" => "Full-Time" },
+      ],
+      "profile" => { "pronouns" => "she/her" }
+    }
+  end
+
+  # ProfileMapper resolves fields by label, so those fields must exist
+  before do
+    group = create(:profile_field_group, name: "Basic")
+    { "Work" => "work", "Education" => "education", "Pronouns" => "pronouns" }.each do |label, attribute_name|
+      create(:profile_field, label: label, profile_field_group: group).update!(attribute_name: attribute_name)
+    end
+    Profile.refresh_attributes!
+  end
+
+  after { Profile.refresh_attributes! }
+
+  describe ".call" do
+    it "maps location and the configured fields by attribute_name" do
+      expect(described_class.call(payload)).to eq(
+        "location" => "Brooklyn, NY, US",
+        "work" => "Software Engineer",
+        "education" => "Acadia University, Computer Science",
+        "pronouns" => "she/her",
+      )
+    end
+
+    it "omits fields this Forem has not configured" do
+      ProfileField.where(label: %w[Work Pronouns]).find_each(&:destroy)
+
+      expect(described_class.call(payload).keys).to contain_exactly("location", "education")
+    end
+
+    it "leaves the street address out of location" do
+      expect(described_class.call(payload)["location"]).not_to include("1 Example Street")
+    end
+
+    it "prefers current records over past ones" do
+      payload["education"] = [
+        { "current" => false, "school_name" => "Past University", "major" => "History" },
+        { "current" => true, "school_name" => "Acadia University", "major" => "Computer Science" },
+      ]
+
+      expect(described_class.call(payload)["education"]).to eq("Acadia University, Computer Science")
+    end
+
+    it "falls back to the first record when none is current" do
+      payload["education"] = [{ "current" => false, "school_name" => "Past University" }]
+
+      expect(described_class.call(payload)["education"]).to eq("Past University")
+    end
+
+    it "drops blank values" do
+      payload["profile"] = { "pronouns" => "" }
+      payload["professional_experience"] = []
+
+      expect(described_class.call(payload).keys).to contain_exactly("location", "education")
+    end
+
+    it "returns an empty hash for an empty payload" do
+      expect(described_class.call({})).to eq({})
+    end
+
+    it "builds location from whichever address parts are present" do
+      payload["address"] = { "city" => "Brooklyn", "state" => nil, "country_code" => "US" }
+
+      expect(described_class.call(payload)["location"]).to eq("Brooklyn, US")
+    end
+
+    it "keeps location within the length Forem validates" do
+      payload["address"] = { "city" => "a" * 200, "country_code" => "US" }
+
+      expect(described_class.call(payload)["location"].length).to be <= described_class::LOCATION_MAX_LENGTH
+    end
+  end
+end

--- a/spec/services/mlh/user_profile_spec.rb
+++ b/spec/services/mlh/user_profile_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe Mlh::UserProfile, type: :service do
+  let(:access_token) { "mlh-access-token" }
+
+  before do
+    allow(ApplicationConfig).to receive(:[]).and_call_original
+    # Local env may have this overriden; return nil so that stubs work
+    allow(ApplicationConfig).to receive(:[]).with("MLH_API_BASE_URL").and_return(nil)
+  end
+
+  describe ".call" do
+    it "maps the payload to profile attributes by default",
+       vcr: { cassette_name: "mlh_user_profile" } do
+      result = described_class.call(access_token)
+
+      expect(result["location"]).to eq("Brooklyn, NY, US")
+      expect(result).not_to have_key("email")
+    end
+
+    it "returns the raw payload when mapping is disabled",
+       vcr: { cassette_name: "mlh_user_profile" } do
+      payload = described_class.new(access_token, mapper: nil).call
+
+      expect(payload["email"]).to eq("mlh-user@example.com")
+      expect(payload.dig("education", 0, "school_name")).to eq("Acadia University")
+    end
+
+    it "requests /v4/users/me with the expandable fields" do
+      url = "https://api.mlh.com/v4/users/me" \
+            "?expand[]=address&expand[]=education&expand[]=professional_experience"
+      stub_request(:get, url).to_return(status: 200, body: "{}",
+                                        headers: { "Content-Type" => "application/json" })
+
+      described_class.call(access_token)
+
+      expect(WebMock).to have_requested(:get, url)
+    end
+
+    it "raises ArgumentError when there is no token to fetch with" do
+      expect { described_class.call(nil) }.to raise_error(ArgumentError)
+    end
+
+    it "propagates a fetch error" do
+      client = instance_double(Mlh::ApiClient)
+      allow(Mlh::ApiClient).to receive(:new).and_return(client)
+      allow(client).to receive(:get).and_raise(Mlh::ApiClient::RecoverableError)
+
+      expect { described_class.call(access_token) }.to raise_error(Mlh::ApiClient::RecoverableError)
+    end
+  end
+end

--- a/spec/support/fixtures/vcr_cassettes/mlh_user_profile.yml
+++ b/spec/support/fixtures/vcr_cassettes/mlh_user_profile.yml
@@ -1,0 +1,43 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.mlh.com/v4/users/me?expand%5B%5D=address&expand%5B%5D=education&expand%5B%5D=professional_experience
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.9.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"created_at": 1765033681, "updated_at": 1784812643, "id": "00000000-0000-0000-0000-000000000001",
+        "first_name": "Alex", "last_name": "Johnson", "time_zone": null, "email":
+        "mlh-user@example.com", "phone_number": null, "suspended": false, "address":
+        {"created_at": 1784812643, "updated_at": 1784812643, "id": "00000000-0000-0000-0000-000000000002",
+        "nickname": null, "line1": "1 Example Street", "line2": null, "line3": null,
+        "city": "Brooklyn", "state": "NY", "postal_code": "11201", "country": "United
+        States of America", "country_code": "US"}, "profile": {"created_at": 1765033718,
+        "updated_at": 1784812643, "country_of_residence": "US", "race_or_ethnicity": "Caucasian",
+        "gender": "female", "pronouns": "she/her", "newsletter_subscriptions": [], "topic_subscriptions":
+        [], "age": null, "birthdate": null, "dietary_preferences": null, "clothing_sizes":
+        null, "custom_fields": {"not_a_student": "2026-07-23T13:15:58Z", "tos_accepted_at":
+        "2025-12-06T15:08:53.020Z", "no_work_experience": "2026-07-23T13:15:54Z",
+        "privacy_policy_accepted_at": "2025-12-06T15:08:53.020Z"}}, "professional_experience":
+        [{"created_at": 1784816638, "updated_at": 1784816638, "id": "00000000-0000-0000-0000-000000000004",
+        "title": "Software Engineer", "current": true, "company": "00000000-0000-0000-0000-000000000005",
+        "type": "Full-Time", "start_date": 1717171200, "end_date": 1816272000, "unsafe_this_will_change_employer_name":
+        "Example Corp"}], "education": [{"created_at": 1784816573, "updated_at": 1784816573,
+        "id": "00000000-0000-0000-0000-000000000003", "current": true, "major": "Computer
+        Science", "school_name": "Acadia University", "school_type": "university",
+        "start_date": 1693497600, "end_date": null}]}'
+    http_version:
+  recorded_at: Thu, 23 Jul 2026 14:00:00 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/omniauth_helpers.rb
+++ b/spec/support/omniauth_helpers.rb
@@ -191,7 +191,6 @@ module OmniauthHelpers
       info: {
         email: "mlh@example.com",
         name: "MLH User",
-        nickname: "mlhuser",
         image: "https://dummyimage.com/400x400.jpg",
       },
       credentials: {

--- a/spec/workers/users/prefill_mlh_profile_worker_spec.rb
+++ b/spec/workers/users/prefill_mlh_profile_worker_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe Users::PrefillMlhProfileWorker, type: :worker do
+  let(:worker) { subject }
+  let(:user) { create(:user) }
+  let(:mapped) { { "location" => "Brooklyn, NY, US" } }
+
+  before do
+    omniauth_mock_mlh_payload
+    create(:identity, user: user, provider: "mlh", token: "mlh-access-token")
+    allow(Mlh::UserProfile).to receive(:call).and_return(mapped)
+  end
+
+  include_examples "#enqueues_on_correct_queue", "medium_priority", 1
+
+  describe "#perform" do
+    it "fills in fields from MLH data" do
+      worker.perform(user.id)
+
+      expect(user.profile.reload.location).to eq("Brooklyn, NY, US")
+    end
+
+    it "fetches with the token stored on the identity" do
+      worker.perform(user.id)
+
+      expect(Mlh::UserProfile).to have_received(:call).with("mlh-access-token")
+    end
+
+    it "does not overwrite a field that already has a value" do
+      user.profile.update!(location: "Somewhere else")
+
+      worker.perform(user.id)
+
+      expect(user.profile.reload.location).to eq("Somewhere else")
+    end
+
+    context "with a configured profile field" do
+      let(:mapped) { super().merge("education" => "Acadia University") }
+
+      before do
+        group = create(:profile_field_group, name: "Basic")
+        create(:profile_field, label: "Education", profile_field_group: group).update!(attribute_name: "education")
+        Profile.refresh_attributes!
+      end
+
+      after { Profile.refresh_attributes! }
+
+      it "sets the profile field value" do
+        worker.perform(user.id)
+
+        expect(user.profile.reload.education).to eq("Acadia University")
+      end
+
+      it "does not overwrite a field that already has a value" do
+        user.profile.update!(education: "Existing school")
+
+        worker.perform(user.id)
+
+        expect(user.profile.reload.education).to eq("Existing school")
+      end
+    end
+
+    it "does nothing when the user is gone" do
+      expect { worker.perform(User.maximum(:id).to_i + 1) }.not_to raise_error
+    end
+
+    it "does nothing without an MLH identity" do
+      other_user = create(:user)
+
+      other_user.identities.destroy_all
+      worker.perform(other_user.id)
+
+      expect(Mlh::UserProfile).not_to have_received(:call)
+    end
+
+    it "makes no changes when MLH returns no fields" do
+      allow(Mlh::UserProfile).to receive(:call).and_return({})
+
+      expect { worker.perform(user.id) }.not_to change { user.profile.reload.location }
+    end
+
+    it "swallows a terminal ClientError so Sidekiq does not retry" do
+      allow(Mlh::UserProfile).to receive(:call).and_raise(Mlh::ApiClient::ClientError)
+
+      expect { worker.perform(user.id) }.not_to raise_error
+      expect(user.profile.reload.location).to be_blank
+    end
+
+    it "lets a RecoverableError propagate so Sidekiq retries" do
+      allow(Mlh::UserProfile).to receive(:call).and_raise(Mlh::ApiClient::RecoverableError)
+
+      expect { worker.perform(user.id) }.to raise_error(Mlh::ApiClient::RecoverableError)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This change prefills user profile data from MLH when an identity is linked, i.e. on OAuth registration. Specifically,
1. Since MLH does not provide a nickname, the suggested username is derived from the local-part of the user's email address. Previously, a random string was generated since the username was blank.
2. The scopes `user:read:education`, `user:read:employment`, and `user:read:address` are added to the MLH OAuth strategy, since these correspond to profile data we can use.
3. After an identity is created in `Authentication::Authenticator#call`, an worker is enqueued that:
    - fetches the user profile data with expansions from the MLH API
    - maps MLH fields to Forem profile fields (currently only `location`), with support for ProfileFields looked up by label: Work, Education, and Pronouns, if configured on the Forem instance.
    - fills in the corresponding fields if they are unassigned

## Related Tickets & Documents

[DEV-3339 (Jira)](https://mlhacks.atlassian.net/browse/DEV-3339)

## QA Instructions, Screenshots, Recordings

This can be tested by creating a new Forem account with the MLH provider and confirming that profile fields set in MyMLH are used on Forem. MyMLH should prompt the user to enter data for the requested scopes if not already filled.

### UI accessibility checklist
N/A

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?
None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787767452&installation_model_id=424141&pr_number=23677&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23677&signature=e03825043854a19d9b9a29ed656bc5e1cdded9cffd21b7c55c62d57b79cecb4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->