### PR TITLE
Add organization page reordering

### DIFF
--- a/app/controllers/organization_pages_controller.rb
+++ b/app/controllers/organization_pages_controller.rb
@@ -59,6 +59,7 @@ class OrganizationPagesController < ApplicationController
     end
 
     if @page.save
+      Pages::BustCacheWorker.perform_async(@page.slug)
       flash[:settings_notice] = I18n.t("views.organization_settings.pages.updated")
       redirect_to organization_pages_path(@organization.slug)
     else
@@ -74,7 +75,7 @@ class OrganizationPagesController < ApplicationController
 
   def reorder
     if reorder_page(params[:direction].to_s)
-      Pages::BustCacheWorker.perform_async(@page.slug, @organization.id)
+      Pages::BustCacheWorker.perform_async(@page.slug)
       flash[:settings_notice] = I18n.t("views.organization_settings.pages.reordered")
     end
 

--- a/app/controllers/organization_pages_controller.rb
+++ b/app/controllers/organization_pages_controller.rb
@@ -1,10 +1,12 @@
 class OrganizationPagesController < ApplicationController
   include OrganizationAdminScoped
   before_action :check_pages_feature
-  before_action :set_page, only: %i[edit update destroy]
+  before_action :set_page, only: %i[edit update destroy reorder]
+  before_action :validate_reorder_direction, only: :reorder
 
   def index
-    @pages = @organization.pages.order(:created_at)
+    @pages = @organization.ordered_pages
+    @showcase_page = @pages.first
   end
 
   def new
@@ -15,6 +17,7 @@ class OrganizationPagesController < ApplicationController
     is_first_page = !@organization.pages.exists?
     @page = @organization.pages.build(page_params)
     @page.template = "full_within_layout"
+    @page.position = (@organization.pages.maximum(:position) || -1) + 1
     
     if is_first_page
       @page.slug = "#{@organization.slug}/readme"
@@ -69,6 +72,15 @@ class OrganizationPagesController < ApplicationController
     redirect_to organization_pages_path(@organization.slug)
   end
 
+  def reorder
+    if reorder_page(params[:direction].to_s)
+      Pages::BustCacheWorker.perform_async(@page.slug, @organization.id)
+      flash[:settings_notice] = I18n.t("views.organization_settings.pages.reordered")
+    end
+
+    redirect_to organization_pages_path(@organization.slug)
+  end
+
   def preview
     renderer = ContentRenderer.new(params[:body_markdown].to_s, source: @organization, user: current_user)
     result = renderer.process
@@ -89,5 +101,52 @@ class OrganizationPagesController < ApplicationController
 
   def page_params
     params.require(:page).permit(:title, :body_markdown, :description)
+  end
+
+  def showcase_page?(page)
+    page == @organization.main_page
+  end
+
+  def reorder_page(direction)
+    return false if showcase_page?(@page)
+
+    Page.transaction do
+      pages = ordered_custom_pages
+      current_index = pages.index { |page| page.id == @page.id }
+      adjacent_index = adjacent_index_for(current_index, direction)
+      next false unless adjacent_index&.between?(0, pages.length - 1)
+
+      normalize_positions(pages)
+      swap_positions(pages, current_index, adjacent_index)
+      true
+    end
+  end
+
+  def ordered_custom_pages
+    @organization.ordered_pages.where.not(id: @organization.main_page.id).lock.to_a
+  end
+
+  def adjacent_index_for(current_index, direction)
+    current_index && (current_index + (direction == "up" ? -1 : 1))
+  end
+
+  def normalize_positions(pages)
+    pages.each_with_index do |page, index|
+      update_position(page, index + 1) unless page.position == index + 1
+    end
+  end
+
+  def swap_positions(pages, current_index, adjacent_index)
+    update_position(pages.fetch(current_index), adjacent_index + 1)
+    update_position(pages.fetch(adjacent_index), current_index + 1)
+  end
+
+  def update_position(page, position)
+    # Ordering does not affect page validity or rendered Markdown, so avoid recompiling page content.
+    page.update_columns(position: position, updated_at: Time.current)
+  end
+
+  def validate_reorder_direction
+    head :unprocessable_entity unless %w[up down].include?(params[:direction].to_s)
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -186,8 +186,12 @@ class Organization < ApplicationRecord
     main_page.present?
   end
 
+  def ordered_pages
+    pages.order(:position, :created_at, :id)
+  end
+
   def main_page
-    pages.order(:created_at).first
+    ordered_pages.first
   end
 
   def social_link(platform)

--- a/app/views/organization_pages/index.html.erb
+++ b/app/views/organization_pages/index.html.erb
@@ -15,11 +15,12 @@
       <p class="color-base-60 fs-s mt-1"><%= t("views.organization_settings.pages.order_help") %></p>
       <div class="grid gap-4 mt-4">
         <% custom_pages = @pages.reject { |page| page == @showcase_page } %>
+        <% custom_index_map = custom_pages.each_with_index.to_h %>
         <% @pages.each do |page| %>
           <% 
             is_showcase = page == @showcase_page
             suffix = page.slug.split("/").last
-            custom_index = custom_pages.index(page)
+            custom_index = custom_index_map[page]
           %>
           <div class="crayons-card crayons-card--secondary p-4 flex items-start justify-between gap-4">
             <div class="flex-1">
@@ -48,7 +49,7 @@
                                 params: { direction: "up" },
                                 class: "crayons-btn crayons-btn--secondary crayons-btn--xs",
                                 form: { class: "inline-block" },
-                                disabled: custom_index.zero?,
+                                disabled: custom_index&.zero?,
                                 title: t("views.organization_settings.pages.move_up"),
                                 aria: { label: t("views.organization_settings.pages.move_up_title", title: page.title) } %>
                   <%= button_to "↓",

--- a/app/views/organization_pages/index.html.erb
+++ b/app/views/organization_pages/index.html.erb
@@ -12,11 +12,14 @@
   <% if @pages.any? %>
     <div class="crayons-card crayons-card--content-rows">
       <h2><%= t("views.organization_settings.pages.your_pages") %></h2>
+      <p class="color-base-60 fs-s mt-1"><%= t("views.organization_settings.pages.order_help") %></p>
       <div class="grid gap-4 mt-4">
+        <% custom_pages = @pages.reject { |page| page == @showcase_page } %>
         <% @pages.each do |page| %>
           <% 
-            is_showcase = page.slug.end_with?("/readme")
+            is_showcase = page == @showcase_page
             suffix = page.slug.split("/").last
+            custom_index = custom_pages.index(page)
           %>
           <div class="crayons-card crayons-card--secondary p-4 flex items-start justify-between gap-4">
             <div class="flex-1">
@@ -35,6 +38,30 @@
               <p class="fs-s color-base-60 mb-0"><%= page.description %></p>
             </div>
             <div class="flex gap-2 shrink-0">
+              <% if is_showcase %>
+                <span class="color-base-60 fs-s self-center mr-2"><%= t("views.organization_settings.pages.pinned_first") %></span>
+              <% else %>
+                <div class="flex gap-1" role="group" aria-label="<%= t("views.organization_settings.pages.reorder", title: page.title) %>">
+                  <%= button_to "↑",
+                                reorder_organization_page_path(@organization.slug, page),
+                                method: :patch,
+                                params: { direction: "up" },
+                                class: "crayons-btn crayons-btn--secondary crayons-btn--xs",
+                                form: { class: "inline-block" },
+                                disabled: custom_index.zero?,
+                                title: t("views.organization_settings.pages.move_up"),
+                                aria: { label: t("views.organization_settings.pages.move_up_title", title: page.title) } %>
+                  <%= button_to "↓",
+                                reorder_organization_page_path(@organization.slug, page),
+                                method: :patch,
+                                params: { direction: "down" },
+                                class: "crayons-btn crayons-btn--secondary crayons-btn--xs",
+                                form: { class: "inline-block" },
+                                disabled: custom_index == custom_pages.length - 1,
+                                title: t("views.organization_settings.pages.move_down"),
+                                aria: { label: t("views.organization_settings.pages.move_down_title", title: page.title) } %>
+                </div>
+              <% end %>
               <%= link_to t("views.organization_settings.pages.edit"), edit_organization_page_path(@organization.slug, page), class: "crayons-btn crayons-btn--secondary crayons-btn--xs" %>
               <%= button_to t("views.organization_settings.lead_forms.delete"), organization_page_path(@organization.slug, page), method: :delete, data: { confirm: t("views.organization_settings.pages.confirm_delete") }, class: "crayons-btn crayons-btn--danger crayons-btn--xs" %>
             </div>

--- a/app/views/organization_settings/edit.html.erb
+++ b/app/views/organization_settings/edit.html.erb
@@ -309,9 +309,9 @@
 
           <div class="grid gap-3 mt-4">
             <% if @organization.pages.any? %>
-              <% @organization.pages.order(:created_at).each do |page| %>
+              <% @organization.ordered_pages.each do |page| %>
                 <% 
-                  is_showcase = page.slug.end_with?("/readme")
+                  is_showcase = page == @organization.main_page
                   suffix = page.slug.split("/").last
                 %>
                 <div class="crayons-card crayons-card--secondary p-3 flex items-center justify-between gap-3">

--- a/app/views/organizations/_header.html.erb
+++ b/app/views/organizations/_header.html.erb
@@ -250,7 +250,7 @@
   <% if @organization.main_page.present? && FeatureFlag.enabled?(:org_readme, FeatureFlag::Actor[@organization]) %>
     <%
       is_custom_domain = request.env["forem.custom_domain_org"].present?
-      org_pages = @organization.pages.order(:created_at).to_a
+      org_pages = @organization.ordered_pages.to_a
       showcase_page = org_pages.find { |page| page.slug&.end_with?("/readme") } || org_pages.first
       custom_pages = org_pages.reject { |page| page == showcase_page }
       

--- a/app/views/organizations/_header.html.erb
+++ b/app/views/organizations/_header.html.erb
@@ -251,7 +251,7 @@
     <%
       is_custom_domain = request.env["forem.custom_domain_org"].present?
       org_pages = @organization.ordered_pages.to_a
-      showcase_page = org_pages.find { |page| page.slug&.end_with?("/readme") } || org_pages.first
+      showcase_page = @organization.main_page
       custom_pages = org_pages.reject { |page| page == showcase_page }
       
       showcase_path = is_custom_domain ? "/" : "/#{@organization.slug}"

--- a/config/locales/views/organizations/en.yml
+++ b/config/locales/views/organizations/en.yml
@@ -25,6 +25,7 @@ en:
         created: Page created successfully.
         updated: Page updated successfully.
         deleted: Page deleted successfully.
+        reordered: Page order updated.
         confirm_delete: Are you sure you want to delete this page?
         showcase: Showcase
         showcase_hint: This is the default Showcase landing page.
@@ -40,6 +41,13 @@ en:
         description_placeholder: Short description for SEO and sharing...
         cancel: Cancel
         your_pages: Your Pages
+        order_help: Use the arrows to set the order of custom tabs. Showcase always stays first.
+        pinned_first: Pinned first
+        reorder: "Reorder %{title}"
+        move_up: Move up
+        move_down: Move down
+        move_up_title: "Move %{title} up"
+        move_down_title: "Move %{title} down"
       header_cta:
         heading: Header CTA Button
         description: Add a call-to-action button to your organization's page header. You can create a simple button or a dropdown with multiple links.

--- a/config/locales/views/organizations/fr.yml
+++ b/config/locales/views/organizations/fr.yml
@@ -25,6 +25,7 @@ fr:
         created: Page créée avec succès.
         updated: Page mise à jour avec succès.
         deleted: Page supprimée avec succès.
+        reordered: Ordre des pages mis à jour.
         confirm_delete: Êtes-vous sûr de vouloir supprimer cette page ?
         showcase: Showcase
         showcase_hint: Il s'agit de la page d'accueil Showcase par défaut.
@@ -40,6 +41,13 @@ fr:
         description_placeholder: Courte description pour le référencement (SEO) et le partage...
         cancel: Annuler
         your_pages: Vos pages
+        order_help: Utilisez les flèches pour définir l'ordre des onglets personnalisés. Showcase reste toujours en premier.
+        pinned_first: Épinglé en premier
+        reorder: "Réorganiser %{title}"
+        move_up: Déplacer vers le haut
+        move_down: Déplacer vers le bas
+        move_up_title: "Déplacer %{title} vers le haut"
+        move_down_title: "Déplacer %{title} vers le bas"
       header_cta:
         heading: Bouton CTA de l'en-tête
         description: "Ajoutez un bouton d'appel à l'action dans l'en-tête de la page de votre organisation. Vous pouvez créer un bouton simple ou un menu déroulant avec plusieurs liens."

--- a/config/locales/views/organizations/pt.yml
+++ b/config/locales/views/organizations/pt.yml
@@ -25,6 +25,7 @@ pt:
         created: Página criada com sucesso.
         updated: Página atualizada com sucesso.
         deleted: Página excluída com sucesso.
+        reordered: Ordem das páginas atualizada.
         confirm_delete: Tem certeza que deseja excluir esta página?
         showcase: Showcase
         showcase_hint: Esta é a página Showcase padrão.
@@ -40,6 +41,13 @@ pt:
         description_placeholder: Breve descrição para SEO e compartilhamento...
         cancel: Cancelar
         your_pages: Suas páginas
+        order_help: Use as setas para definir a ordem das guias personalizadas. Showcase permanece sempre em primeiro lugar.
+        pinned_first: Fixado em primeiro
+        reorder: "Reordenar %{title}"
+        move_up: Mover para cima
+        move_down: Mover para baixo
+        move_up_title: "Mover %{title} para cima"
+        move_down_title: "Mover %{title} para baixo"
       header_cta:
         heading: Botão CTA do Cabeçalho
         description: "Adicione um botão de chamada para ação no cabeçalho da página da sua organização. Você pode criar um botão simples ou um menu suspenso com vários links."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -443,6 +443,8 @@ Rails.application.routes.draw do
     post "/:slug/settings/pages", to: "organization_pages#create"
     get "/:slug/settings/pages/:id/edit", to: "organization_pages#edit", as: :edit_organization_page
     patch "/:slug/settings/pages/:id", to: "organization_pages#update", as: :update_organization_page
+    patch "/:slug/settings/pages/:id/reorder", to: "organization_pages#reorder",
+                                                 as: :reorder_organization_page
     delete "/:slug/settings/pages/:id", to: "organization_pages#destroy", as: :organization_page
     post "/:slug/settings/pages/preview", to: "organization_pages#preview", as: :organization_pages_preview
     get "/:slug/settings/lead_forms", to: "organization_lead_forms#index", as: :organization_lead_forms

--- a/db/migrate/20260728160000_add_position_to_pages.rb
+++ b/db/migrate/20260728160000_add_position_to_pages.rb
@@ -1,0 +1,5 @@
+class AddPositionToPages < ActiveRecord::Migration[8.0]
+  def change
+    add_column :pages, :position, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_20_160000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_28_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -1297,6 +1297,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_20_160000) do
     t.boolean "landing_page", default: false, null: false
     t.bigint "organization_id"
     t.bigint "page_template_id"
+    t.integer "position", default: 0, null: false
     t.text "processed_html"
     t.string "redirect_to_url"
     t.string "slug"

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -508,12 +508,12 @@ RSpec.describe Organization do
   end
 
   describe "#ordered_pages" do
-    it "orders pages by position and uses creation order as a stable fallback" do
-      first_page = create(:page, organization: organization, position: 1)
-      second_page = create(:page, organization: organization, position: 2)
-      moved_page = create(:page, organization: organization, position: 0)
+    it "orders pages by position and uses creation order as a stable fallback when positions are equal" do
+      first_page = create(:page, organization: organization, position: 0, created_at: 2.hours.ago)
+      second_page = create(:page, organization: organization, position: 0, created_at: 1.hour.ago)
+      promoted_page = create(:page, organization: organization, position: -1, created_at: Time.current)
 
-      expect(organization.ordered_pages).to eq([moved_page, first_page, second_page])
+      expect(organization.ordered_pages).to eq([promoted_page, first_page, second_page])
     end
   end
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -507,6 +507,16 @@ RSpec.describe Organization do
     end
   end
 
+  describe "#ordered_pages" do
+    it "orders pages by position and uses creation order as a stable fallback" do
+      first_page = create(:page, organization: organization, position: 1)
+      second_page = create(:page, organization: organization, position: 2)
+      moved_page = create(:page, organization: organization, position: 0)
+
+      expect(organization.ordered_pages).to eq([moved_page, first_page, second_page])
+    end
+  end
+
   describe "#flipper_id" do
     it "returns a string with Organization prefix and id" do
       expect(organization.flipper_id).to eq("Organization;#{organization.id}")

--- a/spec/requests/organization_pages_spec.rb
+++ b/spec/requests/organization_pages_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe "Organization Pages Controller Backend Protection" do
     end
 
     it "moves a custom page up while keeping Showcase first" do
-      sidekiq_assert_enqueued_with(job: Pages::BustCacheWorker, args: [second_page.slug, organization.id]) do
+      sidekiq_assert_enqueued_with(job: Pages::BustCacheWorker, args: [second_page.slug]) do
         patch reorder_organization_page_path(organization.slug, second_page), params: { direction: "up" }
       end
 

--- a/spec/requests/organization_pages_spec.rb
+++ b/spec/requests/organization_pages_spec.rb
@@ -121,6 +121,45 @@ RSpec.describe "Organization Pages Controller Backend Protection" do
     end
   end
 
+  describe "PATCH /:slug/settings/pages/:id/reorder" do
+    before { FeatureFlag.enable(:org_readme, FeatureFlag::Actor[organization]) }
+
+    let!(:readme_page) do
+      create(:page, organization: organization, slug: "#{organization.slug}/showcase",
+                    template: "full_within_layout")
+    end
+    let!(:first_page) do
+      create(:page, organization: organization, slug: "#{organization.slug}/first",
+                    template: "full_within_layout")
+    end
+    let!(:second_page) do
+      create(:page, organization: organization, slug: "#{organization.slug}/second",
+                    template: "full_within_layout")
+    end
+
+    it "moves a custom page up while keeping Showcase first" do
+      sidekiq_assert_enqueued_with(job: Pages::BustCacheWorker, args: [second_page.slug, organization.id]) do
+        patch reorder_organization_page_path(organization.slug, second_page), params: { direction: "up" }
+      end
+
+      expect(response).to redirect_to(organization_pages_path(organization.slug))
+      expect(organization.ordered_pages.ids).to eq([readme_page.id, second_page.id, first_page.id])
+    end
+
+    it "does not move the Showcase page" do
+      patch reorder_organization_page_path(organization.slug, readme_page), params: { direction: "down" }
+
+      expect(response).to redirect_to(organization_pages_path(organization.slug))
+      expect(organization.ordered_pages.first).to eq(readme_page)
+    end
+
+    it "rejects an unsupported direction" do
+      patch reorder_organization_page_path(organization.slug, second_page), params: { direction: "sideways" }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
   describe "POST /:slug/settings/pages/preview" do
     before { FeatureFlag.enable(:org_readme, FeatureFlag::Actor[organization]) }
 


### PR DESCRIPTION
## What changed

- Persist an explicit display position for organization pages.
- Add accessible move-up and move-down controls to the custom page manager.
- Keep the Showcase page pinned first while allowing custom tabs to be reordered.
- Use the same ordering for the page manager, organization settings, and public organization navigation.
- Purge the organization cache after a successful reorder.

## Why

Organization page tabs were ordered only by creation time, so organization admins could not adjust their navigation after creating pages. This adds a deliberately small, server-rendered ordering flow without introducing a drag-and-drop library or additional frontend dependency.

Existing page order remains stable until an admin uses the controls. The first/main page is treated as Showcase by identity, which also supports organizations whose Showcase uses a customized slug.

## Validation

- `bin/rspec spec/requests/organization_pages_spec.rb spec/requests/organization_settings_spec.rb spec/requests/stories_index_spec.rb spec/models/organization_spec.rb` — 197 examples, 0 failures
- Focused organization page request specs — 13 examples, 0 failures
- Manually verified that reordering updates the public organization tabs and that Showcase remains pinned first

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787851629&installation_model_id=424141&pr_number=23682&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23682&signature=d2b342d9b251e97861bfae8f5beb050abfe05d801925e0aab6e009dc3cb562e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->