### PR TITLE
Style Devise mailer action links as brand CTA buttons

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -9,7 +9,7 @@
     <p style="margin: 24px 0;">
       <%= link_to "Confirm my account",
                   confirmation_url(@resource, confirmation_token: @token, host: @subforem_domain),
-                  style: "display: inline-block; background: #{Settings::UserExperience.primary_brand_color_hex}; color: #ffffff; padding: 12px 24px; border-radius: 8px; font-weight: bold; text-decoration: none; font-size: 16px;" %>
+                  style: "display: inline-block; background: #{Settings::UserExperience.primary_brand_color_hex(subforem_id: @subforem_id)}; color: #ffffff; padding: 12px 24px; border-radius: 8px; font-weight: bold; text-decoration: none; font-size: 16px;" %>
     </p>
   </div>
 <% end %>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -2,7 +2,7 @@
   <%= render partial: "creator_confirmation_instructions", locals: { url: confirmation_url(@resource, confirmation_token: @token, host: @subforem_domain) } %>
 <% else %>
   <div style="font-size: 16px; line-height: 24px; color: #202121;">
-    <p>Welcome<%= " #{@name}" unless @name.include?("http") %>!</p>
+    <p>Welcome<%= " #{@name}" if @name.present? && !@name.include?("http") %>!</p>
 
     <p>You can confirm your account email through the link below:</p>
 

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,9 +1,15 @@
 <% if @user.creator? %>
   <%= render partial: "creator_confirmation_instructions", locals: { url: confirmation_url(@resource, confirmation_token: @token, host: @subforem_domain) } %>
 <% else %>
-  <p>Welcome<%= " #{@name}" unless @name.include?("http") %>!</p>
+  <div style="font-size: 16px; line-height: 24px; color: #202121;">
+    <p>Welcome<%= " #{@name}" unless @name.include?("http") %>!</p>
 
-  <p>You can confirm your account email through the link below:</p>
+    <p>You can confirm your account email through the link below:</p>
 
-  <p><%= link_to "Confirm my account", confirmation_url(@resource, confirmation_token: @token, host: @subforem_domain) %></p>
+    <p style="margin: 24px 0;">
+      <%= link_to "Confirm my account",
+                  confirmation_url(@resource, confirmation_token: @token, host: @subforem_domain),
+                  style: "display: inline-block; background: #{Settings::UserExperience.primary_brand_color_hex}; color: #ffffff; padding: 12px 24px; border-radius: 8px; font-weight: bold; text-decoration: none; font-size: 16px;" %>
+    </p>
+  </div>
 <% end %>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,6 @@
-<% if @user.creator? %>
-  <%= render partial: "creator_confirmation_instructions", locals: { url: confirmation_url(@resource, confirmation_token: @token, host: @subforem_domain) } %>
+<% user = @user || @resource %>
+<% if user&.creator? %>
+  <%= render partial: "creator_confirmation_instructions", locals: { url: confirmation_url(@resource, { confirmation_token: @token, host: @subforem_domain }.compact) } %>
 <% else %>
   <div style="font-size: 16px; line-height: 24px; color: #202121;">
     <p>Welcome<%= " #{@name}" if @name.present? && !@name.include?("http") %>!</p>
@@ -8,7 +9,7 @@
 
     <p style="margin: 24px 0;">
       <%= link_to "Confirm my account",
-                  confirmation_url(@resource, confirmation_token: @token, host: @subforem_domain),
+                  confirmation_url(@resource, { confirmation_token: @token, host: @subforem_domain }.compact),
                   style: "display: inline-block; background: #{Settings::UserExperience.primary_brand_color_hex(subforem_id: @subforem_id)}; color: #ffffff; padding: 12px 24px; border-radius: 8px; font-weight: bold; text-decoration: none; font-size: 16px;" %>
     </p>
   </div>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -12,7 +12,7 @@
   <p style="margin: 24px 0;">
     <%= link_to t("devise.mailer.invitation_instructions.accept"),
                 accept_invitation_url(@resource, invitation_token: @token),
-                style: "display: inline-block; background: #{Settings::UserExperience.primary_brand_color_hex}; color: #ffffff; padding: 12px 24px; border-radius: 8px; font-weight: bold; text-decoration: none; font-size: 16px;" %>
+                style: "display: inline-block; background: #{Settings::UserExperience.primary_brand_color_hex(subforem_id: @subforem_id)}; color: #ffffff; padding: 12px 24px; border-radius: 8px; font-weight: bold; text-decoration: none; font-size: 16px;" %>
   </p>
 
   <% if @resource.invitation_due_at %>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,27 +1,29 @@
+<div style="font-size: 16px; line-height: 24px; color: #202121;">
+  <% if @message.present? %>
+    <%= Markdown.new(@message).to_html.html_safe %>
+  <% else %>
+    <p><%= t("devise.mailer.invitation_instructions.hello") %></p>
 
-<% if @message.present? %>
-  <%= Markdown.new(@message).to_html.html_safe %>
-<% else %>
-  <p><%= t("devise.mailer.invitation_instructions.hello") %></p>
+    <p><%= t("devise.mailer.invitation_instructions.someone_invited_you", community_name: Settings::Community.community_name, url: root_url) %></p>
 
-  <p><%= t("devise.mailer.invitation_instructions.someone_invited_you", community_name: Settings::Community.community_name, url: root_url) %></p>
-
-  <p><%= t("devise.mailer.invitation_instructions.accept_instructions") %>:</p>
-
-<% end %>
-
-<p><%= link_to t("devise.mailer.invitation_instructions.accept"),
-               accept_invitation_url(@resource, invitation_token: @token),
-               style: "color:white; background: #{Settings::UserExperience.primary_brand_color_hex}; border-radius: 8px; padding: 10px 20px; font-size: 1.33em; display: inline-block; margin: 8px 0; text-decoration: none; font-weight: bold;" %></p>
-
-<% if @resource.invitation_due_at %>
-  <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :"devise.mailer.invitation_instructions.accept_until_format")) %></p>
-<% end %>
-
-<div class="style: font-size: 0.9em">
-  <% if @footnote.present? %>
-    <%= Markdown.new(@footnote).to_html.html_safe %>
+    <p><%= t("devise.mailer.invitation_instructions.accept_instructions") %>:</p>
   <% end %>
 
-  <p><%= t("devise.mailer.invitation_instructions.ignore") %></p>
+  <p style="margin: 24px 0;">
+    <%= link_to t("devise.mailer.invitation_instructions.accept"),
+                accept_invitation_url(@resource, invitation_token: @token),
+                style: "display: inline-block; background: #{Settings::UserExperience.primary_brand_color_hex}; color: #ffffff; padding: 12px 24px; border-radius: 8px; font-weight: bold; text-decoration: none; font-size: 16px;" %>
+  </p>
+
+  <% if @resource.invitation_due_at %>
+    <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :"devise.mailer.invitation_instructions.accept_until_format")) %></p>
+  <% end %>
+
+  <div style="font-size: 14px; color: #7d7d7d; margin-top: 24px;">
+    <% if @footnote.present? %>
+      <%= Markdown.new(@footnote).to_html.html_safe %>
+    <% end %>
+
+    <p><%= t("devise.mailer.invitation_instructions.ignore") %></p>
+  </div>
 </div>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -6,7 +6,7 @@
   <p style="margin: 24px 0;">
     <%= link_to "Change my password",
                 edit_password_url(@resource, reset_password_token: @token),
-                style: "display: inline-block; background: #{Settings::UserExperience.primary_brand_color_hex}; color: #ffffff; padding: 12px 24px; border-radius: 8px; font-weight: bold; text-decoration: none; font-size: 16px;" %>
+                style: "display: inline-block; background: #{Settings::UserExperience.primary_brand_color_hex(subforem_id: @subforem_id)}; color: #ffffff; padding: 12px 24px; border-radius: 8px; font-weight: bold; text-decoration: none; font-size: 16px;" %>
   </p>
 
   <p style="font-size: 14px; color: #7d7d7d; margin-top: 24px;">If you didn't request this, please ignore this email.</p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,14 @@
-<p>Hello <%= @resource.email %>!</p>
+<div style="font-size: 16px; line-height: 24px; color: #202121;">
+  <p>Hello <%= @resource.email %>!</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+  <p>Someone has requested a link to change your password. You can do this through the link below.</p>
 
-<p><%= link_to "Change my password", edit_password_url(@resource, reset_password_token: @token) %></p>
+  <p style="margin: 24px 0;">
+    <%= link_to "Change my password",
+                edit_password_url(@resource, reset_password_token: @token),
+                style: "display: inline-block; background: #{Settings::UserExperience.primary_brand_color_hex}; color: #ffffff; padding: 12px 24px; border-radius: 8px; font-weight: bold; text-decoration: none; font-size: 16px;" %>
+  </p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+  <p style="font-size: 14px; color: #7d7d7d; margin-top: 24px;">If you didn't request this, please ignore this email.</p>
+  <p style="font-size: 14px; color: #7d7d7d;">Your password won't change until you access the link above and create a new one.</p>
+</div>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,7 +1,13 @@
-<p>Hello <%= @resource.email %>!</p>
+<div style="font-size: 16px; line-height: 24px; color: #202121;">
+  <p>Hello <%= @resource.email %>!</p>
 
-<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+  <p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
 
-<p>Click the link below to unlock your account:</p>
+  <p>Click the link below to unlock your account:</p>
 
-<p><%= link_to "Unlock my account", unlock_url(@resource, unlock_token: @token) %></p>
+  <p style="margin: 24px 0;">
+    <%= link_to "Unlock my account",
+                unlock_url(@resource, unlock_token: @token),
+                style: "display: inline-block; background: #{Settings::UserExperience.primary_brand_color_hex}; color: #ffffff; padding: 12px 24px; border-radius: 8px; font-weight: bold; text-decoration: none; font-size: 16px;" %>
+  </p>
+</div>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -8,6 +8,6 @@
   <p style="margin: 24px 0;">
     <%= link_to "Unlock my account",
                 unlock_url(@resource, unlock_token: @token),
-                style: "display: inline-block; background: #{Settings::UserExperience.primary_brand_color_hex}; color: #ffffff; padding: 12px 24px; border-radius: 8px; font-weight: bold; text-decoration: none; font-size: 16px;" %>
+                style: "display: inline-block; background: #{Settings::UserExperience.primary_brand_color_hex(subforem_id: @subforem_id)}; color: #ffffff; padding: 12px 24px; border-radius: 8px; font-weight: bold; text-decoration: none; font-size: 16px;" %>
   </p>
 </div>


### PR DESCRIPTION
## Summary
Updates the default Devise email templates (`reset_password_instructions`, `confirmation_instructions`, `unlock_instructions`, and `invitation_instructions`) to style action links into prominent Call-To-Action (CTA) buttons matching Forem's primary brand color settings (`Settings::UserExperience.primary_brand_color_hex`).

## Changes
- **reset_password_instructions.html.erb**: Formatted 'Change my password' link as a prominent brand CTA button and wrapped body content in structured email typography with muted disclaimers.
- **confirmation_instructions.html.erb**: Formatted 'Confirm my account' link as a brand CTA button for standard user confirmation flows.
- **unlock_instructions.html.erb**: Formatted 'Unlock my account' link as a brand CTA button.
- **invitation_instructions.html.erb**: Standardized acceptance CTA button layout and fixed invalid HTML `class` attribute.

## Verification
- Ran `bundle exec rspec spec/mailers/devise_mailer_spec.rb` (33 examples, 0 failures).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787853033&installation_model_id=424141&pr_number=23683&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23683&signature=6e8c4e075c9de4dc95dfbf0963e95715b73dfedfa203c1fab730ddaab9f73238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->