### PR TITLE
Stabilize confirmed CI failure modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
     needs: [build]
     timeout-minutes: 20
     env:
+      CYPRESS_INSTALL_BINARY: "0"
       KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
       KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
       KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}

--- a/spec/requests/insights_spec.rb
+++ b/spec/requests/insights_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Insights", type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
   let(:user) { create(:user) }
   let(:algolia_service_instance) { instance_double(AlgoliaInsightsService) }
 
@@ -26,39 +28,43 @@ RSpec.describe "Insights", type: :request do
       before { sign_in user }
 
       it "processes the insight and tracks the event", :aggregate_failures do
-        post "/insights", params: valid_params
+        freeze_time do
+          post "/insights", params: valid_params
 
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to include("Insight processed")
-        expect(algolia_service_instance).to have_received(:track_event).with(
-          "click",
-          "Result Clicked",
-          user.id.to_s, # Coerced to string
-          "12345",
-          "Article_production",
-          Time.current.to_i * 1000, # Converted to integer
-          "abcdef123456",
-          [1]
-        )
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("Insight processed")
+          expect(algolia_service_instance).to have_received(:track_event).with(
+            "click",
+            "Result Clicked",
+            user.id.to_s, # Coerced to string
+            "12345",
+            "Article_production",
+            Time.current.to_i * 1000, # Converted to integer
+            "abcdef123456",
+            [1],
+          )
+        end
       end
     end
 
     context "when user is not signed in" do
       it "processes the insight without a user ID", :aggregate_failures do
-        post "/insights", params: valid_params
+        freeze_time do
+          post "/insights", params: valid_params
 
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to include("Insight processed")
-        expect(algolia_service_instance).to have_received(:track_event).with(
-          "click",
-          "Result Clicked",
-          nil, # No user ID
-          "12345",
-          "Article_production",
-          Time.current.to_i * 1000, # Converted to integer
-          "abcdef123456",
-          [1]
-        )
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("Insight processed")
+          expect(algolia_service_instance).to have_received(:track_event).with(
+            "click",
+            "Result Clicked",
+            nil, # No user ID
+            "12345",
+            "Article_production",
+            Time.current.to_i * 1000, # Converted to integer
+            "abcdef123456",
+            [1],
+          )
+        end
       end
     end
 

--- a/spec/services/user_query_executor_spec.rb
+++ b/spec/services/user_query_executor_spec.rb
@@ -137,7 +137,6 @@ RSpec.describe UserQueryExecutor do
 
   describe "error handling" do
     it "handles timeout errors" do
-      user_query.update!(max_execution_time_ms: 1)
       allow_any_instance_of(UserQueryExecutor).to receive(:execute_with_timeout).and_raise(PG::QueryCanceled.new("timeout"))
 
       executor = UserQueryExecutor.new(user_query)


### PR DESCRIPTION
## Summary

- Freeze time around the Insights request assertions so the request and expectation cannot cross a one-second boundary.
- Keep the mocked `UserQueryExecutor` timeout example on safe database session timeouts.
- Skip Cypress binary installation in RSpec shards while retaining the JavaScript build.

## Why

Public GitHub Actions failure artifacts exposed three unrelated CI failure modes:

- The Insights request spec differed from the controller timestamp by exactly one second when the request crossed a clock boundary.
- The mocked user-query timeout example configured a 1 ms statement timeout and a 2 ms idle-in-transaction timeout. The connection could close before cleanup restored its settings, causing the global cache cleanup hook to fail.
- An RSpec shard failed before running tests when the Cypress binary download failed during `javascript:build`.

The Cypress setting is scoped to the RSpec job. It does not change Cypress or end-to-end jobs.

## Impact

This changes only tests and CI setup. Production behavior is unchanged.

## Public-data provenance

The diagnosis used only public GitHub Actions logs and failure artifacts available to a normal OSS contributor:

- https://github.com/forem/forem/actions/runs/30377855231
- https://github.com/forem/forem/actions/runs/30298233849
- https://github.com/forem/forem/actions/runs/30384093578

No maintainer-only data or private CI telemetry was used.

## Validation

- Focused request and service specs: 35 examples, 0 failures, 1 existing pending example
- `CI=true CYPRESS_INSTALL_BINARY=0 bin/rails javascript:build`
- Focused RuboCop checks for the changed Insights block
- Workflow YAML parse
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787855702&installation_model_id=424141&pr_number=23684&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23684&signature=fdd6d9fcbfae18c481de39d7c3dc970bd28b401ae3b445283ceb196ad43b5f89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->