### PR TITLE
Report RSpec retries that recover CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,14 @@ jobs:
           bin/rails javascript:build
 
       - name: RSpec
+        id: rspec
         run: bin/knapsack_pro_rspec
+      - name: Upload recovered RSpec retries
+        uses: actions/upload-artifact@v4
+        if: ${{ steps.rspec.outcome == 'success' && hashFiles('tmp/rspec-retries/*.csv') != '' }}
+        with:
+          name: rspec-retries-${{ matrix.ci_node_index }}
+          path: tmp/rspec-retries
       - name: Upload RSpec artifacts
         uses: actions/upload-artifact@v4
         if: failure()

--- a/spec/lib/r_spec_retry_csv_report_spec.rb
+++ b/spec/lib/r_spec_retry_csv_report_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+require "tmpdir"
+require_relative "../support/rspec_retry_csv_report"
+
+RSpec.describe RSpecRetryCsvReport do
+  describe ".write" do
+    it "does not create a report when no examples were retried" do
+      Dir.mktmpdir do |directory|
+        report = described_class.write(rows: [], suite_status: :passed, suite_runtime: 1.25, directory: directory)
+
+        expect(report).to be_nil
+        expect(Dir.children(directory)).to be_empty
+      end
+    end
+
+    it "writes only retry rows with the final suite result" do
+      retry_row = [
+        "retried example",
+        "./spec/example_spec.rb:10",
+        :failed,
+        "07-28-2026",
+        "12-00-00.000",
+        0.5,
+        "failure",
+        "backtrace",
+        1,
+      ]
+
+      Dir.mktmpdir do |directory|
+        report = described_class.write(
+          rows: [retry_row],
+          suite_status: :passed,
+          suite_runtime: 2.5,
+          directory: directory,
+          timestamp: Time.utc(2026, 7, 28, 12),
+          process_id: 123,
+        )
+        csv = CSV.read(report, headers: true)
+
+        expect(csv.headers).to eq(described_class::HEADERS)
+        expect(csv.first.fields.first(9)).to eq(retry_row.map(&:to_s))
+        expect(csv.first["Suite Status"]).to eq("passed")
+        expect(csv.first["Suite Run Time"]).to eq("2.5")
+      end
+    end
+  end
+end

--- a/spec/support/initializers/ci_csv_formatter.rb
+++ b/spec/support/initializers/ci_csv_formatter.rb
@@ -3,11 +3,10 @@ return unless ENV["CI"]
 require "csv"
 require "rspec/retry"
 require "singleton"
+require_relative "../rspec_retry_csv_report"
 
 class CSVFormatter
   RSpec::Core::Formatters.register self, :example_passed, :example_failed, :example_pending, :close
-  HEADERS = ["Description", "File", "Status", "Start Date", "Start Time", "Run Time", "Exception",
-             "Backtrace", "Retry #", "Suite Status", "Suite Run Time", "Travis URL", "Travis Branch"].freeze
 
   def initialize(_output)
     @rows = []
@@ -63,13 +62,16 @@ class CSVFormatter
 
     suite_runtime = (Time.zone.now - @suite_start_time).round(3)
 
-    with_headers = { write_headers: true, headers: HEADERS }
+    retry_rows = RSpecRetryFormatterHelper.instance.rows
+    with_headers = { write_headers: true, headers: RSpecRetryCsvReport::HEADERS }
     CSV.open(csv_filename, "w", **with_headers) do |csv|
-      (@rows + RSpecRetryFormatterHelper.instance.rows).each do |row|
+      (@rows + retry_rows).each do |row|
         row += [@suite_status, suite_runtime, ENV.fetch("TRAVIS_BUILD_WEB_URL", nil), ENV.fetch("TRAVIS_BRANCH", nil)]
         csv << row
       end
     end
+
+    RSpecRetryCsvReport.write(rows: retry_rows, suite_status: @suite_status, suite_runtime: suite_runtime)
   end
 end
 

--- a/spec/support/rspec_retry_csv_report.rb
+++ b/spec/support/rspec_retry_csv_report.rb
@@ -1,0 +1,26 @@
+require "csv"
+require "fileutils"
+require "time"
+
+class RSpecRetryCsvReport
+  HEADERS = ["Description", "File", "Status", "Start Date", "Start Time", "Run Time", "Exception",
+             "Backtrace", "Retry #", "Suite Status", "Suite Run Time", "Travis URL", "Travis Branch"].freeze
+
+  def self.write(rows:, suite_status:, suite_runtime:,
+                 directory: File.join(Dir.pwd, "tmp", "rspec-retries"),
+                 timestamp: Time.current.utc, process_id: Process.pid)
+    return if rows.empty?
+
+    FileUtils.mkdir_p(directory)
+    filename = File.join(directory, "#{timestamp.iso8601(6).tr(':', '-')}-#{process_id}.csv")
+
+    CSV.open(filename, "w", write_headers: true, headers: HEADERS) do |csv|
+      rows.each do |row|
+        csv << (row + [suite_status, suite_runtime, ENV.fetch("TRAVIS_BUILD_WEB_URL", nil),
+                       ENV.fetch("TRAVIS_BRANCH", nil)])
+      end
+    end
+
+    filename
+  end
+end


### PR DESCRIPTION
## Summary

- Write a compact CSV containing only failed attempts that were retried.
- Include the final suite status and runtime in that report.
- Upload the report when an RSpec shard succeeds after retrying an example.
- Keep the existing failure-only RSpec artifacts unchanged.

## Why

The existing failure artifacts make failed shards diagnosable, but they cannot show examples whose retries rescued an otherwise successful shard. That leaves the most useful measure of remaining flakiness invisible.

The retry callback already records each failed attempt. This change writes those rows to a separate report and uploads it only when:

1. the RSpec step ultimately succeeds, and
2. at least one retry report exists.

Ordinary successful shards do not create or upload an artifact.

## Impact

Test outcomes and retry policy are unchanged. Successful shards that recover from a retry gain one small, shard-specific diagnostic artifact.

## Public-data provenance

This follows from the public GitHub Actions diagnostics retained by #23643 and the retry behavior corrected by #23655. No maintainer-only CI data or private telemetry was used.

## Validation

- Focused retry report and retry policy specs: 5 examples, 0 failures
- End-to-end temporary `:flaky` example: failed once, passed on its second attempt, and produced a retry CSV with `Suite Status` set to `passed`
- Focused RuboCop checks: no offenses
- Workflow YAML parse
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787855733&installation_model_id=424141&pr_number=23685&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23685&signature=17be2a46e5c1889abd091b66dd7d09f59c936723e1b41f11f5045b88dd411ff3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->