### PR TITLE
Reduce home page edge cache duration to 60s and stale-while-revalidate to 60s

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -189,8 +189,8 @@ class StoriesController < ApplicationController
     get_latest_campaign_articles if Campaign.current.show_in_sidebar?
 
     set_surrogate_key_header "main_app_home_page"
-    set_cache_control_headers(600,
-                              stale_while_revalidate: 30,
+    set_cache_control_headers(60,
+                              stale_while_revalidate: 60,
                               stale_if_error: 86_400)
 
     render template: "articles/index"

--- a/config/fastly/snippets/stale_while_revalidate_controls.vcl
+++ b/config/fastly/snippets/stale_while_revalidate_controls.vcl
@@ -1,6 +1,6 @@
 sub vcl_fetch {
   if (req.url == "/" || req.url == "/?i=i") {
-    set beresp.stale_while_revalidate = 15s;
+    set beresp.stale_while_revalidate = 60s;
   }
 
   if (beresp.status >= 400) {

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -295,10 +295,11 @@ RSpec.describe "StoriesIndex" do
     def sets_fastly_headers
       expected_surrogate_key_headers = %w[main_app_home_page]
       expect(response.headers["Surrogate-Key"].split(", ")).to match_array(expected_surrogate_key_headers)
+      expect(response.headers["Surrogate-Control"]).to eq("max-age=60, stale-while-revalidate=60, stale-if-error=86400")
     end
 
     def sets_nginx_headers
-      expect(response.headers["X-Accel-Expires"]).to eq("600")
+      expect(response.headers["X-Accel-Expires"]).to eq("60")
     end
 
     it "shows default meta keywords if set" do


### PR DESCRIPTION
## Summary
Reduces the home page (`StoriesController#handle_base_index`) edge cache duration (`max-age`) from 600 seconds (10 minutes) to 60 seconds (1 minute), and sets `stale-while-revalidate` to 60 seconds across controller headers and Fastly VCL.

## Changes Made
- Updated `StoriesController#handle_base_index` cache control headers duration to 60 seconds (`max-age=60`) and `stale_while_revalidate` to 60 seconds.
- Updated Fastly VCL snippet `stale_while_revalidate_controls.vcl` for home page URL to `60s`.
- Updated request specs in `spec/requests/stories_index_spec.rb` to assert `X-Accel-Expires: 60` and `Surrogate-Control: max-age=60, stale-while-revalidate=60, stale-if-error=86400`.

## Verification
- Ran `bundle exec rspec spec/requests/stories_index_spec.rb`: 63 examples, 0 failures.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787856115&installation_model_id=424141&pr_number=23686&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23686&signature=af4a097a08384a5b7068d8fcca28f1da749a8fa7f79bf0f13a43370618d90fd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->