### PR TITLE
Fix organization page reorder cache bust

### DIFF
--- a/app/controllers/organization_pages_controller.rb
+++ b/app/controllers/organization_pages_controller.rb
@@ -75,7 +75,7 @@ class OrganizationPagesController < ApplicationController
 
   def reorder
     if reorder_page(params[:direction].to_s)
-      Pages::BustCacheWorker.perform_async(@page.slug)
+      Pages::BustCacheWorker.perform_async(@page.slug, @organization.id)
       flash[:settings_notice] = I18n.t("views.organization_settings.pages.reordered")
     end
 

--- a/spec/requests/organization_pages_spec.rb
+++ b/spec/requests/organization_pages_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe "Organization Pages Controller Backend Protection" do
     end
 
     it "moves a custom page up while keeping Showcase first" do
-      sidekiq_assert_enqueued_with(job: Pages::BustCacheWorker, args: [second_page.slug]) do
+      sidekiq_assert_enqueued_with(job: Pages::BustCacheWorker, args: [second_page.slug, organization.id]) do
         patch reorder_organization_page_path(organization.slug, second_page), params: { direction: "up" }
       end
 


### PR DESCRIPTION
## What changed

- Pass the organization ID to `Pages::BustCacheWorker` after an organization page reorder.
- Update the request spec to assert the organization-aware worker arguments.

## Why

Follow-up to #23682. Reordering persists positions with `update_columns`, so it intentionally bypasses the normal `Page` callbacks. The explicit cache-bust enqueue only passed the page slug, which prevented `EdgeCache::BustPage` from purging the organization's surrogate key and left the reordered navigation cached.

## Validation

- `bin/rspec spec/requests/organization_pages_spec.rb:156` — 1 example, 0 failures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788018561&installation_model_id=424141&pr_number=23692&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23692&signature=3d55b34882a69c4154106d95c7555018bed91cb6c135e5b1db382eeb6f5b9c56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->