### PR TITLE
Exclude API routes from Fastly edge error caching

### DIFF
--- a/config/fastly/snippets/stale_while_revalidate_controls.vcl
+++ b/config/fastly/snippets/stale_while_revalidate_controls.vcl
@@ -3,7 +3,12 @@ sub vcl_fetch {
     set beresp.stale_while_revalidate = 60s;
   }
 
-  if (beresp.status >= 400) {
+  # Cache error responses briefly to protect origin from repeated error traffic,
+  # but NEVER cache errors for API routes. API error responses (401, 429, etc.)
+  # are per-request and per-user (keyed by the api-key header which is not part
+  # of the Fastly cache key). Caching them causes valid authenticated requests
+  # to receive stale error responses from other users or rate-limit windows.
+  if (beresp.status >= 400 && !(req.url ~ "^/api")) {
     set beresp.ttl = 30s;
     set beresp.cacheable = true;
   }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Commit `27db76580` (#23616) enabled Fastly edge caching (`beresp.cacheable = true`) for all HTTP status codes $\ge 400$. 

Because Fastly does not vary cached error responses on the `api-key` header, error responses (such as `401 Unauthorized` and `429 Too Many Requests`) returned for `/api/*` endpoints were cached at the edge for 30s. Subsequent authenticated requests to API routes were served stale edge-cached error responses without reaching origin.

This PR adds a `!(req.url ~ "^/api")` guard in `stale_while_revalidate_controls.vcl` to ensure error responses on API routes are never cached at the Fastly edge.

## Related Tickets & Documents

- Related Issue #23675

## QA Instructions, Screenshots, Recordings

Verify in `config/fastly/snippets/stale_while_revalidate_controls.vcl` that HTTP status $\ge 400$ caching explicitly excludes `/api` routes (`!(req.url ~ "^/api")`).

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Edge VCL configuration snippet change.

## [optional] Are there any post deployment tasks we need to perform?

None.

## [optional] What gif best describes this PR or how it makes you feel?

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788111386&installation_model_id=424141&pr_number=23695&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23695&signature=b4c20974744d26891390df9f2748fc2037d92eabfb44e909c67e9cb7d9eb8833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->