### PR TITLE
Replace broken MLH relink message with sign-in CTA

### DIFF
--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -117,9 +117,10 @@ module Authentication
       current_user&.identities&.find_by(provider: provider.name)
     end
 
-    # An identity created through the admin API rather than a completed OAuth
-    # flow has no token and no stored auth payload. A completed re-auth is the
-    # only chance we get to fill those in, so refresh the row in place.
+    # A completed re-auth always refreshes the linked row's token and stored
+    # auth payload with the just-received data. This matters most for an
+    # identity created through the admin API rather than a completed OAuth
+    # flow, which starts with no token and no payload at all.
     #
     # `incoming_identity` is built by `Identity.build_from_omniauth`, so it is
     # only persisted when the payload's provider + uid already exist in the

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -36,7 +36,11 @@ module Authentication
     def call
       identity = Identity.build_from_omniauth(provider)
       guard_against_spam_from!(identity: identity)
-      return current_user if current_user_identity_exists?
+
+      if (linked_identity = current_user_identity)
+        refresh_identity(identity, linked_identity)
+        return current_user
+      end
 
       # These variables need to be set outside of the scope of the
       # transaction in order to be used after the transaction is completed.
@@ -109,8 +113,24 @@ module Authentication
       provider_class.new(auth_payload)
     end
 
-    def current_user_identity_exists?
-      current_user&.identities&.exists?(provider: provider.name)
+    def current_user_identity
+      current_user&.identities&.find_by(provider: provider.name)
+    end
+
+    # An identity created through the admin API rather than a completed OAuth
+    # flow has no token and no stored auth payload. A completed re-auth is the
+    # only chance we get to fill those in, so refresh the row in place.
+    #
+    # `incoming_identity` is built by `Identity.build_from_omniauth`, so it is
+    # only persisted when the payload's provider + uid already exist in the
+    # database. We refresh solely when that is the very same row the current
+    # user is linked through: a payload carrying a different uid must never
+    # silently repoint an existing identity.
+    def refresh_identity(incoming_identity, linked_identity)
+      return unless incoming_identity.persisted?
+      return unless incoming_identity.id == linked_identity.id
+
+      incoming_identity.save!
     end
 
     def proper_user(identity)

--- a/app/services/authentication/providers/mlh.rb
+++ b/app/services/authentication/providers/mlh.rb
@@ -2,7 +2,9 @@ module Authentication
   module Providers
     # MyMLH authentication provider, uses omniauth-mlh as backend
     class Mlh < Provider
-      OFFICIAL_NAME = "MyMLH".freeze
+      # "MLH" rather than "MyMLH": this is the name we show people in settings
+      # copy, connect buttons and anywhere else `official_name` surfaces.
+      OFFICIAL_NAME = "MLH".freeze
       SETTINGS_URL = "https://my.mlh.io/oauth/applications".freeze
 
       def self.official_name

--- a/app/views/users/_account_providers_emails.html.erb
+++ b/app/views/users/_account_providers_emails.html.erb
@@ -12,13 +12,13 @@
       <li class="mb-2">
         <strong class="color-base-60"><%= t("views.settings.account.provider_email", provider: provider.official_name) %></strong>
         <%# An identity created through the admin API rather than a completed OAuth flow has no auth
-            payload, and therefore no email. For MLH, signing in at my.mlh.io with this address is what
+            payload, and therefore no email. For MLH, signing in at my.mlh.com with this address is what
             connects the two accounts, so link there instead of showing the generic "relink" error. %>
         <% if identity.provider == "mlh" && identity_email.blank? %>
           <span class="pl-2">
             <%= t(
                   "views.settings.account.mlh_sign_in_html",
-                  link: link_to(t("views.settings.account.mlh_sign_in_link"), "https://my.mlh.io/", class: "c-link", target: "_blank", rel: "noopener noreferrer"),
+                  link: link_to(t("views.settings.account.mlh_sign_in_link"), "https://my.mlh.com/", class: "c-link", target: "_blank", rel: "noopener noreferrer"),
                 ) %>
           </span>
         <% else %>

--- a/app/views/users/_account_providers_emails.html.erb
+++ b/app/views/users/_account_providers_emails.html.erb
@@ -8,9 +8,22 @@
 
     <% @user.identities_enabled.each do |identity| %>
       <% provider = authentication_provider(identity.provider) %>
+      <% identity_email = identity.auth_data_dump&.info&.email %>
       <li class="mb-2">
         <strong class="color-base-60"><%= t("views.settings.account.provider_email", provider: provider.official_name) %></strong>
-        <span class="pl-2"><%= identity.email %></span>
+        <%# An identity created through the admin API rather than a completed OAuth flow has no auth
+            payload, and therefore no email. For MLH, signing in at my.mlh.io with this address is what
+            connects the two accounts, so link there instead of showing the generic "relink" error. %>
+        <% if identity.provider == "mlh" && identity_email.blank? %>
+          <span class="pl-2">
+            <%= t(
+                  "views.settings.account.mlh_sign_in_html",
+                  link: link_to(t("views.settings.account.mlh_sign_in_link"), "https://my.mlh.io/", class: "c-link", target: "_blank", rel: "noopener noreferrer"),
+                ) %>
+          </span>
+        <% else %>
+          <span class="pl-2"><%= identity.email %></span>
+        <% end %>
       </li>
     <% end %>
   </ul>

--- a/app/views/users/_additional_authentication.html.erb
+++ b/app/views/users/_additional_authentication.html.erb
@@ -6,11 +6,11 @@
     API rather than a completed OAuth flow has no auth payload, and therefore no
     email; a completed re-auth is what fills that in, so keep offering the button
     in that case, labelled as a reconnect. %>
-<% existing_identities = @user.identities_enabled.to_a
+<% identities_by_provider = @user.identities_enabled.index_by(&:provider)
    connectable_providers = authentication_enabled_providers.filter_map do |provider|
      next if provider.provider_name == :apple
 
-     identity = existing_identities.detect { |existing| existing.provider == provider.provider_name.to_s }
+     identity = identities_by_provider[provider.provider_name.to_s]
      next [provider, false] if identity.nil?
      next [provider, true] if identity.auth_data_dump&.info&.email.blank?
 

--- a/app/views/users/_additional_authentication.html.erb
+++ b/app/views/users/_additional_authentication.html.erb
@@ -1,16 +1,30 @@
-<% unless @user.authenticated_with_all_providers? %>
+<%# INFO: [@forem/oss] We only support creating new accounts and then signing in
+    with them using Apple Auth. Connecting existing Forem accounts to Apple Auth
+    isn't supported and is why we skip it here.
+
+    Each entry below is [provider, relink]. An identity created through the admin
+    API rather than a completed OAuth flow has no auth payload, and therefore no
+    email; a completed re-auth is what fills that in, so keep offering the button
+    in that case, labelled as a reconnect. %>
+<% existing_identities = @user.identities_enabled.to_a
+   connectable_providers = authentication_enabled_providers.filter_map do |provider|
+     next if provider.provider_name == :apple
+
+     identity = existing_identities.detect { |existing| existing.provider == provider.provider_name.to_s }
+     next [provider, false] if identity.nil?
+     next [provider, true] if identity.auth_data_dump&.info&.email.blank?
+
+     nil
+   end %>
+<% if connectable_providers.any? %>
   <div class="crayons-card crayons-card--content-rows block">
-    <% authentication_enabled_providers.each do |provider| %>
-      <!--
-        INFO: [@forem/oss] We only support creating new accounts and then
-        signing in with them) using Apple Auth. Connecting Forem existing
-        accounts to Apple Auth isn't supported and is why we skip it here.
-      -->
-      <% next if provider.provider_name == :apple %>
-      <% unless @user.authenticated_through?(provider.provider_name) %>
-        <%= form_with url: provider.sign_in_path(state: "profile", origin: URL.url("/settings")), class: "flex w-100", local: true do |f| %>
-          <%= f.button type: :submit, class: "crayons-btn crayons-btn--icon-left crayons-btn--brand-#{provider.provider_name} m-1 w-100" do %>
-            <%= crayons_icon_tag(provider.provider_name, title: provider.official_name) %>
+    <% connectable_providers.each do |provider, relink| %>
+      <%= form_with url: provider.sign_in_path(state: "profile", origin: URL.url("/settings")), class: "flex w-100", local: true do |f| %>
+        <%= f.button type: :submit, class: "crayons-btn crayons-btn--icon-left crayons-btn--brand-#{provider.provider_name} m-1 w-100" do %>
+          <%= crayons_icon_tag(provider.provider_name, title: provider.official_name) %>
+          <% if relink %>
+            <%= t("views.settings.account.reconnect", provider: provider.official_name) %>
+          <% else %>
             <%= t("views.settings.account.connect", provider: provider.official_name) %>
           <% end %>
         <% end %>

--- a/config/locales/misc/en.yml
+++ b/config/locales/misc/en.yml
@@ -19,7 +19,7 @@ en:
       forem: "You're on a roll! 🎉  Do you have a Forem account? Consider <a href='/settings'>connecting it</a>."
       github: "You're on a roll! 🎉  Do you have a GitHub account? Consider <a href='/settings'>connecting it</a> so you can pin any of your repos to your profile."
       google: "You're on a roll! 🎉  Do you have a Google account? Consider <a href='/settings'>connecting it</a>."
-      mlh: "You're on a roll! 🎉  Do you have a MyMLH account? Consider <a href='/settings'>connecting it</a>."
+      mlh: "You're on a roll! 🎉  Do you have an MLH account? Consider <a href='/settings'>connecting it</a>."
       twitter: "You're on a roll! 🎉 Do you have a Twitter account? Consider <a href='/settings'>connecting it</a> so we can @mention you if we share your post via our Twitter account <a href='https://twitter.com/thePracticalDev'>@thePracticalDev</a>."
   errors:
     authentication:

--- a/config/locales/misc/fr.yml
+++ b/config/locales/misc/fr.yml
@@ -19,7 +19,7 @@ fr:
       forem: "Vous êtes sur une lancée ! 🎉  Avez-vous un compte Forem ? Pensez à <a href='/settings'>le connecter</a>."
       github: "Vous êtes sur une lancée ! 🎉  Avez-vous un compte GitHub ? Pensez à <a href='/settings'>le connecter</a> afin que vous puissiez épingler n'importe lequel de vos dépôts à votre profil."
       google: "Vous êtes sur une lancée ! 🎉  Avez-vous un compte google ? Pensez à <a href='/settings'>le connecter</a>."
-      mlh: "Vous êtes sur une lancée ! 🎉  Avez-vous un compte MyMLH ? Pensez à <a href='/settings'>le connecter</a>."
+      mlh: "Vous êtes sur une lancée ! 🎉  Avez-vous un compte MLH ? Pensez à <a href='/settings'>le connecter</a>."
       twitter: "Vous êtes sur une lancée ! 🎉 Avez-vous un compte Twitter ? Pensez à <a href='/settings'>le connecter</a> pour que nous puissions vous @mentionner si nous partageons votre article via notre compte Twitter. <a href='https://twitter.com/thePracticalDev'>@thePracticalDev</a>."
   errors:
     authentication:

--- a/config/locales/misc/pt.yml
+++ b/config/locales/misc/pt.yml
@@ -19,7 +19,7 @@ pt:
       forem: "Você está no caminho certo! 🎉 Você tem uma conta Forem? Considere <a href='/settings'>conectá-la</a>."
       github: "Você está no caminho certo! 🎉 Você tem uma conta GitHub? Considere <a href='/settings'>conectá-la</a> para que você possa fixar qualquer um dos seus repositórios no seu perfil."
       google: "Você está no caminho certo! 🎉 Você tem uma conta Google? Considere <a href='/settings'>conectá-la</a>."
-      mlh: "Você está no caminho certo! 🎉  Você tem uma conta MyMLH? Considere <a href='/settings'>conectá-la</a>."
+      mlh: "Você está no caminho certo! 🎉  Você tem uma conta MLH? Considere <a href='/settings'>conectá-la</a>."
       twitter: "Você está no caminho certo! 🎉 Você tem uma conta Twitter? Considere <a href='/settings'>conectá-la</a> para que possamos @mencionar você se compartilharmos seu post via nossa conta Twitter <a href='https://twitter.com/thePracticalDev'>@thePracticalDev</a>."
   errors:
     authentication:

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -6,10 +6,13 @@ en:
         title: Settings
       account:
         connect: Connect %{provider} Account
+        reconnect: Reconnect %{provider} Account
         emails: Account emails
         primary: Primary email
         provider_email: "%{provider} email"
         provider_profile: "%{provider} profile settings"
+        mlh_sign_in_link: Sign in to MLH
+        mlh_sign_in_html: "%{link} with this email address to finish connecting your account."
         delete:
           heading: Delete account
           desc1: 'Deleting your account will:'

--- a/config/locales/views/settings/fr.yml
+++ b/config/locales/views/settings/fr.yml
@@ -6,10 +6,13 @@ fr:
         title: Settings
       account:
         connect: Connect %{provider} Account
+        reconnect: Reconnecter le compte %{provider}
         emails: Account emails
         primary: Primary email
         provider_email: "%{provider} email"
         provider_profile: "%{provider} profile settings"
+        mlh_sign_in_link: Connectez-vous à MLH
+        mlh_sign_in_html: "%{link} avec cette adresse e-mail pour terminer la connexion de votre compte."
         delete:
           heading: Delete account
           desc1: 'Deleting your account will:'

--- a/config/locales/views/settings/pt.yml
+++ b/config/locales/views/settings/pt.yml
@@ -5,6 +5,14 @@ pt:
       account:
         title: Configurações da Conta
         description: Gerencie suas configurações de conta
+        connect: Conectar conta %{provider}
+        reconnect: Reconectar conta %{provider}
+        emails: E-mails da conta
+        primary: E-mail principal
+        provider_email: "E-mail %{provider}"
+        provider_profile: "Configurações de perfil %{provider}"
+        mlh_sign_in_link: Entre no MLH
+        mlh_sign_in_html: "%{link} com este endereço de e-mail para concluir a conexão da sua conta."
         profile:
           title: Perfil
           name: Nome

--- a/spec/requests/user/user_settings_spec.rb
+++ b/spec/requests/user/user_settings_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe "UserSettings" do
         sign_in user
         get user_settings_path(tab: "account")
 
-        expect(response.body).to include("https://my.mlh.io/")
+        expect(response.body).to include("https://my.mlh.com/")
         expect(response.body).to include("Sign in to MLH")
         expect(response.body).not_to include("Please relink your")
       end

--- a/spec/requests/user/user_settings_spec.rb
+++ b/spec/requests/user/user_settings_spec.rb
@@ -206,6 +206,55 @@ RSpec.describe "UserSettings" do
         expect(response.body).to include("Connect GitHub Account")
         expect(response.body).not_to include("Connect Apple Account")
       end
+
+      # Identities created through the admin API carry nothing but a uid, so
+      # they have no auth payload to read an email from.
+      it "points a uid-only mlh identity at MLH instead of the dead-end relink error", :aggregate_failures do
+        allow(Authentication::Providers).to receive(:enabled).and_return(Authentication::Providers.available)
+        user = create(:user)
+        Identity.create!(user: user, provider: "mlh", uid: "core-user-id")
+
+        sign_in user
+        get user_settings_path(tab: "account")
+
+        expect(response.body).to include("https://my.mlh.io/")
+        expect(response.body).to include("Sign in to MLH")
+        expect(response.body).not_to include("Please relink your")
+      end
+
+      it "labels a uid-only mlh row MLH email rather than MyMLH email", :aggregate_failures do
+        allow(Authentication::Providers).to receive(:enabled).and_return(Authentication::Providers.available)
+        user = create(:user)
+        Identity.create!(user: user, provider: "mlh", uid: "core-user-id")
+
+        sign_in user
+        get user_settings_path(tab: "account")
+
+        expect(response.body).to include("MLH email")
+        expect(response.body).not_to include("MyMLH email")
+      end
+
+      it "offers the provider button so a uid-only mlh identity can be relinked" do
+        allow(Authentication::Providers).to receive(:enabled).and_return(Authentication::Providers.available)
+        user = create(:user)
+        Identity.create!(user: user, provider: "mlh", uid: "core-user-id")
+
+        sign_in user
+        get user_settings_path(tab: "account")
+
+        expect(response.body).to include("Reconnect MLH Account")
+      end
+
+      it "does not offer a relink for an mlh identity that has a payload", :aggregate_failures do
+        allow(Authentication::Providers).to receive(:enabled).and_return(Authentication::Providers.available)
+        user = create(:user, :with_identity, identities: [:mlh])
+
+        sign_in user
+        get user_settings_path(tab: "account")
+
+        expect(response.body).not_to include("Reconnect MLH Account")
+        expect(response.body).not_to include("Connect MLH Account")
+      end
     end
 
     describe "GitHub repositories" do

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -999,7 +999,7 @@ RSpec.describe Authentication::Authenticator, type: :service do
     describe "relinking a uid-only identity" do
       let(:user) { create(:user, email: auth_payload.info.email) }
 
-      it "refreshes the stored payload, token and secret" do
+      it "refreshes the stored payload and token" do
         identity = Identity.create!(user: user, provider: "mlh", uid: auth_payload.uid)
 
         expect do
@@ -1014,17 +1014,19 @@ RSpec.describe Authentication::Authenticator, type: :service do
       it "leaves the identity untouched when the incoming uid differs" do
         identity = Identity.create!(user: user, provider: "mlh", uid: "a-different-core-id")
 
+        result = nil
         expect do
-          described_class.call(auth_payload, current_user: user)
+          result = described_class.call(auth_payload, current_user: user)
         end.not_to change(Identity, :count)
 
+        expect(result).to eq(user)
         identity.reload
         expect(identity.uid).to eq("a-different-core-id")
         expect(identity.auth_data_dump).to be_nil
         expect(identity.token).to be_nil
       end
 
-      it "returns the current user in both cases" do
+      it "returns the current user when the identity is refreshed" do
         Identity.create!(user: user, provider: "mlh", uid: auth_payload.uid)
 
         expect(described_class.call(auth_payload, current_user: user)).to eq(user)

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -993,5 +993,64 @@ RSpec.describe Authentication::Authenticator, type: :service do
         described_class.call(auth_payload, current_user: user)
       end.not_to change(Users::PrefillMlhProfileWorker.jobs, :size)
     end
+
+    # Identities created through the admin API carry only a uid: no token, no
+    # payload. A completed re-auth is the only opportunity to backfill them.
+    describe "relinking a uid-only identity" do
+      let(:user) { create(:user, email: auth_payload.info.email) }
+
+      it "refreshes the stored payload, token and secret" do
+        identity = Identity.create!(user: user, provider: "mlh", uid: auth_payload.uid)
+
+        expect do
+          described_class.call(auth_payload, current_user: user)
+        end.not_to change(Identity, :count)
+
+        identity.reload
+        expect(identity.auth_data_dump.info.email).to eq(auth_payload.info.email)
+        expect(identity.token).to eq(auth_payload.credentials.token)
+      end
+
+      it "leaves the identity untouched when the incoming uid differs" do
+        identity = Identity.create!(user: user, provider: "mlh", uid: "a-different-core-id")
+
+        expect do
+          described_class.call(auth_payload, current_user: user)
+        end.not_to change(Identity, :count)
+
+        identity.reload
+        expect(identity.uid).to eq("a-different-core-id")
+        expect(identity.auth_data_dump).to be_nil
+        expect(identity.token).to be_nil
+      end
+
+      it "returns the current user in both cases" do
+        Identity.create!(user: user, provider: "mlh", uid: auth_payload.uid)
+
+        expect(described_class.call(auth_payload, current_user: user)).to eq(user)
+      end
+
+      it "does not repoint an identity belonging to another user" do
+        other_user = create(:user)
+        other_identity = Identity.create!(user: other_user, provider: "mlh", uid: auth_payload.uid)
+        Identity.create!(user: user, provider: "mlh", uid: "yet-another-core-id")
+
+        described_class.call(auth_payload, current_user: user)
+
+        other_identity.reload
+        expect(other_identity.user_id).to eq(other_user.id)
+        expect(other_identity.auth_data_dump).to be_nil
+      end
+
+      it "still links a brand new identity when the user has none" do
+        expect do
+          described_class.call(auth_payload, current_user: user)
+        end.to change(Identity, :count).by(1)
+
+        identity = user.identities.find_by(provider: "mlh")
+        expect(identity.uid).to eq(auth_payload.uid)
+        expect(identity.auth_data_dump.info.email).to eq(auth_payload.info.email)
+      end
+    end
   end
 end

--- a/spec/services/authentication/providers/mlh_spec.rb
+++ b/spec/services/authentication/providers/mlh_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe Authentication::Providers::Mlh, type: :service do
   let(:provider) { described_class.new(auth_payload) }
 
   describe ".official_name" do
-    it "returns MyMLH" do
-      expect(described_class.official_name).to eq("MyMLH")
+    it "returns MLH" do
+      expect(described_class.official_name).to eq("MLH")
     end
   end
 


### PR DESCRIPTION
## The problem

DEV accounts are linked to MLH through `Identity` rows with `provider: "mlh"` and `uid: <core user id>`. About 3.4M of those rows were created by calling DEV's admin API (`Api::Admin::UserIdentitiesController` → `Identity.create!(user:, provider:, uid:)`), with **no `auth_data_dump`**. Only ~700 mlh identities ever came from a real OAuth round-trip.

An identity's email only exists inside that stored payload, so `Identity#email` fell through to `models.identity.no_email_msg`:

> No email found. Please relink your mlh account to avoid errors.

`/settings/account` rendered that string verbatim, with the raw lowercase provider name interpolated, for essentially every linked DEV user.

Worse, the instruction was impossible to follow:

- `_additional_authentication.html.erb` hid the "Connect MyMLH Account" button as soon as *any* mlh identity existed.
- Even if you reached the OAuth flow another way, `Authentication::Authenticator#call` returned early via `current_user_identity_exists?` and wrote nothing, so `auth_data_dump` stayed empty.

Signing in at my.mlh.io with the same email as the DEV account is what actually connects the two accounts, so that — not "relink" — is the correct call to action.

## Changes

**1. Settings page CTA** (`app/views/users/_account_providers_emails.html.erb`)

For an mlh identity whose stored payload has no email, the row renders a link to `https://my.mlh.io/` reading "Sign in to MLH with this email address to finish connecting your account." instead of the dead-end error. The check is a plain inline `identity.auth_data_dump&.info&.email` read in the partial — `Identity` itself is untouched. Non-mlh providers, and mlh identities that do have an email, render exactly as before.

**2. Relink actually works now**

- `app/views/users/_additional_authentication.html.erb` — the provider button is also offered when an already-connected identity has no payload email, labelled "Reconnect %{provider} Account". The partial now builds the list of offerable providers up front (and renders the card only when that list is non-empty), which replaces the old `authenticated_with_all_providers?` / `authenticated_through?` gating that would otherwise suppress the relink button.
- `app/services/authentication/authenticator.rb` — when the logged-in user already has an identity for the incoming provider, we now refresh that row (`token`, `secret`, `auth_data_dump` from the incoming payload) instead of returning untouched. `Identity.build_from_omniauth` looks up by provider+uid, so the refresh only fires when the incoming payload matches the very same row the user is linked through — **a payload carrying a different uid leaves everything alone**, so uids are never silently repointed, including when the matching uid belongs to a different user. The spam guard and every other existing guard run unchanged, before this.

**3. `OFFICIAL_NAME` is now "MLH", not "MyMLH"** (`app/services/authentication/providers/mlh.rb`)

The existing `official_name` machinery already feeds the settings row label, the connect/reconnect button text and the welcome broadcast, so this one-line change fixes the display name everywhere at once. `SETTINGS_URL` and the OAuth wiring are untouched. Updated to match: `spec/services/authentication/providers/mlh_spec.rb`, and the mlh welcome-broadcast copy in `config/locales/misc/{en,fr,pt}.yml` ("Do you have a MyMLH account?" → "an MLH account").

**4. i18n** — new `reconnect`, `mlh_sign_in_link` and `mlh_sign_in_html` keys added to `en`, `fr` and `pt`. `pt.yml` was also missing `connect` / `emails` / `primary` / `provider_email` / `provider_profile`, which `en`/`fr` already had; those are added in the same pass.

**Not touched:** `app/models/identity.rb` and `app/views/admin/users/show/_profile.html.erb` are zero-diff, to keep fork drift out of core Forem files. The `no_email_msg` fallback with the raw `"mlh"` interpolation still exists in `Identity#email`, but it is no longer user-visible for mlh — the CTA replaces it on the settings page.

## UI changes for manual review

No screenshots — flagging these for a human to eyeball per `AGENTS.md`:

- **`/settings/account`, "Account emails" card.** For a uid-only mlh identity the row label changes from "MyMLH email" to "MLH email", and the value changes from the red-flag error sentence to a sentence whose leading words ("Sign in to MLH") are a `c-link` to `https://my.mlh.io/`, opening in a new tab. Worth checking the link wraps sensibly on narrow viewports.
- **`/settings/account`, provider buttons card.** Users with a uid-only mlh identity now see an MLH-branded button reading "Reconnect MLH Account" where they previously saw nothing. Users whose mlh identity has a real payload see no button, as before. The card renders only when at least one button is offered, so users with nothing to connect still see nothing.
- **Anywhere the MLH provider is named** — connect button, settings row label, welcome broadcast — now reads "MLH" instead of "MyMLH".

## Tests

Regression specs added:

- `spec/services/authentication/authenticator_spec.rb` — relinking a uid-only mlh identity backfills payload/token; an incoming uid that differs leaves the row untouched; an identity belonging to another user is never repointed; the current user is still returned; the brand-new-link flow is unchanged.
- `spec/requests/user/user_settings_spec.rb` — the settings page renders the my.mlh.io CTA and not "Please relink your"; labels the row "MLH email" not "MyMLH email"; offers "Reconnect MLH Account"; and offers no relink for an mlh identity that does have a payload.

Run locally (Ruby 3.3.0, local Postgres + Redis):

```
bundle exec rspec spec/services/authentication/authenticator_spec.rb \
                  spec/models/identity_spec.rb \
                  spec/requests/user/user_settings_spec.rb \
                  spec/requests/admin/users_spec.rb \
                  spec/services/authentication/providers/mlh_spec.rb \
                  spec/i18n_spec.rb
# 307 examples, 0 failures, 2 pending (both pre-existing xit in spec/i18n_spec.rb)

bundle exec rspec spec/requests/authenticator_api_link_round_trip_spec.rb \
                  spec/requests/omniauth_callbacks_failure_spec.rb \
                  spec/requests/api/v1/admin \
                  spec/services/broadcasts
# 162 examples, 0 failures
```

`bundle exec rubocop` and `bundle exec erblint` are clean on every changed file (the two remaining rubocop offences in `user_settings_spec.rb` are on pre-existing lines this PR does not touch).

No API routes, controllers or params changed, so no RSWAG/OpenAPI regeneration is needed.
