### PR TITLE
Add RFC 8058 one-click unsubscribe (List-Unsubscribe headers)

### DIFF
--- a/app/controllers/email_subscriptions_controller.rb
+++ b/app/controllers/email_subscriptions_controller.rb
@@ -1,4 +1,9 @@
 class EmailSubscriptionsController < ApplicationController
+  # RFC 8058 one-click unsubscribe requests are POSTed by the mailbox provider
+  # (Gmail, Yahoo, ...) and cannot carry a CSRF token. The signed `ut` token is
+  # what authenticates the request.
+  skip_before_action :verify_authenticity_token, only: %i[unsubscribe]
+
   def unsubscribe
     verified_params = Rails.application.message_verifier(:unsubscribe).verify(params[:ut]).with_indifferent_access
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -34,6 +34,16 @@ class ApplicationMailer < ActionMailer::Base
                                                               })
   end
 
+  # RFC 8058 one-click unsubscribe. Gmail and Yahoo require bulk senders to
+  # expose these two headers so the mailbox provider can render its own
+  # unsubscribe control, which POSTs to the URL without a confirmation step.
+  # Only bulk/marketing style mail should call this -- transactional mail
+  # (password resets, verification, etc.) must stay subscribed.
+  def add_unsubscribe_headers(token)
+    headers["List-Unsubscribe"] = "<#{email_subscriptions_unsubscribe_url(ut: token)}>"
+    headers["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
+  end
+
   def setup_subforem_context
     # Determine subforem from user's onboarding_subforem_id or fall back to default
     user = find_user_for_email

--- a/app/mailers/custom_mailer.rb
+++ b/app/mailers/custom_mailer.rb
@@ -1,4 +1,6 @@
 class CustomMailer < ApplicationMailer
+  include Rails.application.routes.url_helpers
+
   default from: -> { email_from(I18n.t("mailers.custom_mailer.from")) }
 
   has_history extra: lambda {
@@ -13,6 +15,7 @@ class CustomMailer < ApplicationMailer
     @content = Email.replace_merge_tags(params[:content], @user)
     @subject = Email.replace_merge_tags(params[:subject], @user)
     @unsubscribe = generate_unsubscribe_token(@user.id, :email_newsletter)
+    add_unsubscribe_headers(@unsubscribe)
     @from_topic = params[:from_name] || Email.find_by(id: params[:email_id])&.default_from_name_based_on_type
 
     # set sendgrid category in the header using smtp api

--- a/app/mailers/digest_mailer.rb
+++ b/app/mailers/digest_mailer.rb
@@ -11,6 +11,7 @@ class DigestMailer < ApplicationMailer
     @smart_summary_html = ContentRenderer.new(@smart_summary).process.processed_html if @smart_summary.present?
     @feed_config_id = params[:feed_config_id]
     @unsubscribe = generate_unsubscribe_token(@user.id, :email_digest_periodic)
+    add_unsubscribe_headers(@unsubscribe)
     @user_follows_any_subforems = user_follows_any_subforems?
 
     subject = generate_title

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -20,6 +20,7 @@ class NotifyMailer < ApplicationMailer
     return if RateLimitChecker.new.limit_by_email_recipient_address(@user.email)
 
     @unsubscribe = generate_unsubscribe_token(@user.id, :email_comment_notifications)
+    add_unsubscribe_headers(@unsubscribe)
 
     # Don't send the email if there's no visible contents
     # Placed here to allow the preview to continue to work
@@ -51,6 +52,7 @@ class NotifyMailer < ApplicationMailer
 
     @follower = follow.follower
     @unsubscribe = generate_unsubscribe_token(@user.id, :email_follower_notifications)
+    add_unsubscribe_headers(@unsubscribe)
 
     customerio_delivery_options(
       transactional_message_id: "dev_new_follower_email",
@@ -74,6 +76,7 @@ class NotifyMailer < ApplicationMailer
     @mentionable_type = @mention.decorate.formatted_mentionable_type
 
     @unsubscribe = generate_unsubscribe_token(@user.id, :email_mention_notifications)
+    add_unsubscribe_headers(@unsubscribe)
 
     customerio_delivery_options(
       transactional_message_id: "dev_new_mention_email",
@@ -95,6 +98,7 @@ class NotifyMailer < ApplicationMailer
 
     @unread_notifications_count = @user.notifications.unread.count
     @unsubscribe = generate_unsubscribe_token(@user.id, :email_unread_notifications)
+    add_unsubscribe_headers(@unsubscribe)
     community_name = Settings::Community.community_name(subforem_id: @subforem_id)
     subject = I18n.t("mailers.notify_mailer.unread_notifications", count: @unread_notifications_count,
                                                                    community: community_name)
@@ -132,6 +136,7 @@ class NotifyMailer < ApplicationMailer
     @user = @badge_achievement.user
     @badge = @badge_achievement.badge
     @unsubscribe = generate_unsubscribe_token(@user.id, :email_badge_notifications)
+    add_unsubscribe_headers(@unsubscribe)
     badge_description = @badge.description if @badge_achievement.include_default_description
 
     customerio_delivery_options(

--- a/app/services/delivery_methods/customer_io.rb
+++ b/app/services/delivery_methods/customer_io.rb
@@ -10,6 +10,11 @@ module DeliveryMethods
       tracked: true
     }.freeze
 
+    # Customer.io renders the message itself, so headers set on the Mail object
+    # are not carried over unless we forward them explicitly. RFC 8058
+    # one-click unsubscribe only works if these reach the recipient.
+    FORWARDED_HEADERS = %w[List-Unsubscribe List-Unsubscribe-Post].freeze
+
     def initialize(delivery_method_options = {})
       self.settings = DEFAULTS.merge(delivery_method_options)
     end
@@ -35,7 +40,16 @@ module DeliveryMethods
         message[:identifiers] = { email: mail.to.first } if mail.to
         message[:reply_to] = mail.reply_to.first if mail.reply_to
         message[:to] = mail.to.join(",") if mail.to
+        forwarded = forwarded_headers(mail)
+        message[:headers] = forwarded if forwarded.any?
       end.merge(settings)
+    end
+
+    def forwarded_headers(mail)
+      FORWARDED_HEADERS.each_with_object({}) do |name, headers|
+        value = mail[name]&.value
+        headers[name] = value if value.present?
+      end
     end
 
     # Customer.io's body field is HTML. Prefer the html_part (Mail searches

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -364,6 +364,8 @@ Rails.application.routes.draw do
     get "/notification_subscriptions/:notifiable_type/:notifiable_id", to: "notification_subscriptions#show"
     post "/notification_subscriptions/:notifiable_type/:notifiable_id", to: "notification_subscriptions#upsert"
     get "email_subscriptions/unsubscribe"
+    # RFC 8058 one-click unsubscribe: mailbox providers POST to the same URL.
+    post "email_subscriptions/unsubscribe", to: "email_subscriptions#unsubscribe"
 
     get "/internal", to: redirect("/admin")
     get "/internal/:path", to: redirect("/admin/%{path}")

--- a/spec/mailers/custom_mailer_spec.rb
+++ b/spec/mailers/custom_mailer_spec.rb
@@ -133,6 +133,12 @@ RSpec.describe CustomMailer, type: :mailer do
       end
     end
 
+    context "with one-click unsubscribe" do
+      let(:email) { mail }
+
+      include_examples "#renders_one_click_unsubscribe_headers"
+    end
+
     context "when SendGrid is disabled" do
       before do
         allow(ForemInstance).to receive(:sendgrid_enabled?).and_return(false)

--- a/spec/mailers/digest_mailer_spec.rb
+++ b/spec/mailers/digest_mailer_spec.rb
@@ -98,6 +98,12 @@ RSpec.describe DigestMailer do
       }.not_to raise_error
     end
 
+    context "with one-click unsubscribe" do
+      let(:email) { described_class.with(user: user, articles: [article]).digest_email }
+
+      include_examples "#renders_one_click_unsubscribe_headers"
+    end
+
     it "does not use Customer.io delivery when Customer.io is not configured" do
       email = described_class.with(user: user, articles: [article]).digest_email
 

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe NotifyMailer do
     let(:email) { described_class.with(comment: comment).new_reply_email }
 
     include_examples "#renders_proper_email_headers"
+    include_examples "#renders_one_click_unsubscribe_headers"
 
     it "renders proper subject" do
       expected_subject = "#{comment.user.name} replied to your #{comment.parent_type}"
@@ -60,6 +61,7 @@ RSpec.describe NotifyMailer do
     before { user2.follow(user) }
 
     include_examples "#renders_proper_email_headers"
+    include_examples "#renders_one_click_unsubscribe_headers"
 
     it "renders proper subject" do
       expect(email.subject).to eq("#{user2.name} just followed you on #{Settings::Community.community_name}")
@@ -97,6 +99,7 @@ RSpec.describe NotifyMailer do
       let(:email) { described_class.with(mention: comment_mention).new_mention_email }
 
       include_examples "#renders_proper_email_headers"
+      include_examples "#renders_one_click_unsubscribe_headers"
 
       it "renders proper subject and receiver", :aggregate_failures do
         expect(email.subject).to eq("#{comment.user.name} just mentioned you in their comment")
@@ -111,6 +114,7 @@ RSpec.describe NotifyMailer do
       let(:email) { described_class.with(mention: article_mention).new_mention_email }
 
       include_examples "#renders_proper_email_headers"
+      include_examples "#renders_one_click_unsubscribe_headers"
 
       it "renders proper subject and receiver", :aggregate_failures do
         expect(email.subject).to eq("#{article.user.name} just mentioned you in their post")
@@ -147,6 +151,7 @@ RSpec.describe NotifyMailer do
     let(:email) { described_class.with(user: user).unread_notifications_email }
 
     include_examples "#renders_proper_email_headers"
+    include_examples "#renders_one_click_unsubscribe_headers"
 
     it "renders proper subject" do
       expect(email.subject).to eq("🔥 You have 0 unread notifications on #{Settings::Community.community_name}")
@@ -255,6 +260,7 @@ RSpec.describe NotifyMailer do
     end
 
     include_examples "#renders_proper_email_headers"
+    include_examples "#renders_one_click_unsubscribe_headers"
 
     it "renders proper subject" do
       expect(email.subject).to eq("You just got a badge")
@@ -665,6 +671,11 @@ RSpec.describe NotifyMailer do
     let(:email) { described_class.with(email: user.email, attachment: "attachment").export_email }
 
     include_examples "#renders_proper_email_headers"
+
+    it "does not render one-click unsubscribe headers on transactional mail", :aggregate_failures do
+      expect(email["List-Unsubscribe"]).to be_nil
+      expect(email["List-Unsubscribe-Post"]).to be_nil
+    end
 
     it "renders proper subject" do
       expect(email.subject).to include("export of your content is ready")

--- a/spec/mailers/shared_examples/renders_one_click_unsubscribe_headers.rb
+++ b/spec/mailers/shared_examples/renders_one_click_unsubscribe_headers.rb
@@ -1,0 +1,13 @@
+# RFC 8058: bulk mail must expose a List-Unsubscribe URL plus the
+# List-Unsubscribe-Post opt-in so Gmail/Yahoo can render a native
+# one-click unsubscribe control.
+RSpec.shared_examples "#renders_one_click_unsubscribe_headers" do
+  it "renders the one-click unsubscribe headers", :aggregate_failures do
+    list_unsubscribe = email["List-Unsubscribe"].value
+
+    expect(list_unsubscribe).to start_with("<")
+    expect(list_unsubscribe).to end_with(">")
+    expect(list_unsubscribe).to include("/email_subscriptions/unsubscribe?ut=")
+    expect(email["List-Unsubscribe-Post"].value).to eq("List-Unsubscribe=One-Click")
+  end
+end

--- a/spec/requests/email_subscriptions_spec.rb
+++ b/spec/requests/email_subscriptions_spec.rb
@@ -56,4 +56,34 @@ RSpec.describe "EmailSubscriptions" do
       end
     end
   end
+
+  # RFC 8058: Gmail/Yahoo POST to the List-Unsubscribe URL with a
+  # "List-Unsubscribe=One-Click" body and no CSRF token.
+  describe "POST /email_subscriptions/unsubscribe" do
+    around do |example|
+      original = ActionController::Base.allow_forgery_protection
+      ActionController::Base.allow_forgery_protection = true
+      example.run
+    ensure
+      ActionController::Base.allow_forgery_protection = original
+    end
+
+    it "unsubscribes the user and returns 200 without a CSRF token", :aggregate_failures do
+      post email_subscriptions_unsubscribe_path(ut: generate_token(user.id)),
+           params: { "List-Unsubscribe" => "One-Click" }
+
+      expect(response).to have_http_status(:ok)
+      user.reload
+      expect(user.notification_setting.email_mention_notifications).to be(false)
+    end
+
+    it "renders the expired notice for a stale token" do
+      token = generate_token(user.id)
+      Timecop.freeze(32.days.from_now) do
+        post email_subscriptions_unsubscribe_path(ut: token),
+             params: { "List-Unsubscribe" => "One-Click" }
+        expect(response.body).to include("Token expired or invalid")
+      end
+    end
+  end
 end

--- a/spec/services/delivery_methods/customer_io_spec.rb
+++ b/spec/services/delivery_methods/customer_io_spec.rb
@@ -39,6 +39,22 @@ RSpec.describe DeliveryMethods::CustomerIo do
     expect(message[:message_data]).to eq("name" => "Sloan")
   end
 
+  it "forwards the one-click unsubscribe headers so RFC 8058 survives the Customer.io render" do
+    mail["List-Unsubscribe"] = "<https://dev.to/email_subscriptions/unsubscribe?ut=token>"
+    mail["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
+
+    message = delivered_message(transactional_message_id: "dev_test_template")
+
+    expect(message[:headers]).to eq(
+      "List-Unsubscribe" => "<https://dev.to/email_subscriptions/unsubscribe?ut=token>",
+      "List-Unsubscribe-Post" => "List-Unsubscribe=One-Click",
+    )
+  end
+
+  it "sends no custom headers when the mail carries no unsubscribe headers" do
+    expect(delivered_message[:headers]).to eq({})
+  end
+
   it "prefers identifiers passed in options over the recipient email" do
     message = delivered_message(identifiers: { id: "42" })
     expect(message[:identifiers]).to eq(id: "42")


### PR DESCRIPTION
## Why

Google Postmaster Tools flags dev.to as **missing one-click unsubscribe**. Gmail's and Yahoo's bulk-sender rules require senders of >5k messages/day to support RFC 8058 one-click unsubscribe, and Gmail has been *rejecting* non-compliant bulk mail (not just spam-foldering it) since November 2025. Non-compliance is a deliverability risk for every digest, newsletter, and notification email we send.

## What was missing

Forem already had everything except the headers:

- `ApplicationMailer#generate_unsubscribe_token` mints a signed, expiring token.
- Every bulk mailer already embeds `email_subscriptions_unsubscribe_url(ut: token)` — but **only in the email body**.
- `EmailSubscriptionsController#unsubscribe` already performs an immediate, no-confirmation unsubscribe from that token — which is exactly the RFC 8058 semantic.

There was no `List-Unsubscribe` / `List-Unsubscribe-Post` header anywhere in the repo, and the route was `GET`-only.

## The fix

**1. Headers.** New `ApplicationMailer#add_unsubscribe_headers(token)` sets:

```
List-Unsubscribe: <https://dev.to/email_subscriptions/unsubscribe?ut=…>
List-Unsubscribe-Post: List-Unsubscribe=One-Click
```

It's called from every mailer action that already generates an unsubscribe token:

| Mailer | Action |
| --- | --- |
| `DigestMailer` | `digest_email` |
| `CustomMailer` | `custom_email` (newsletter / drip / one-off) |
| `NotifyMailer` | `new_reply_email`, `new_follower_email`, `new_mention_email`, `unread_notifications_email`, `new_badge_email` |

`CustomMailer` needed `include Rails.application.routes.url_helpers` to resolve the URL in the mailer body, matching what `DigestMailer` and `NotifyMailer` already do.

**Transactional mail is deliberately excluded** — Devise, `VerificationMailer`, account deletion/export, moderator confirmations, feedback responses, etc. Those aren't bulk mail, there is no subscription to leave, and offering a one-click unsubscribe on a password reset would be wrong (there's also no notification setting to flip). A spec on `export_email` pins this so the headers don't leak onto transactional mail by accident.

**2. POST route.** Mailbox providers POST to the `List-Unsubscribe` URL with body `List-Unsubscribe=One-Click`. `config/routes.rb` now maps `POST /email_subscriptions/unsubscribe` to the same action alongside the existing `GET` (the GET keeps the named route/helper, so nothing else changes).

**3. CSRF.** That POST originates at Gmail/Yahoo and carries no CSRF token, and `ApplicationController` uses `protect_from_forgery with: :exception, prepend: true` — so it would 422. Added a narrowly scoped `skip_before_action :verify_authenticity_token, only: %i[unsubscribe]` on `EmailSubscriptionsController` only. The signed `ut` token is what authenticates the request; forgery protection is untouched everywhere else. The existing render path returns 200, which satisfies the 2xx requirement.

**4. Customer.io passthrough.** `DeliveryMethods::CustomerIo` builds its payload from scratch and never forwarded custom headers, so the two new headers would have been silently dropped on every message routed through Customer.io — which on dev.to is the digest and notification path. It now forwards `List-Unsubscribe` / `List-Unsubscribe-Post` via the Customer.io Send Email API's `headers` field. Without this, the fix would have been a no-op for the highest-volume mail we send.

## Token expiry

`generate_unsubscribe_token` sets `expires_at: 31.days.from_now`, and the controller rejects expired tokens. That's above the ~30 days mailbox providers expect a `List-Unsubscribe` URL to stay live, so **no change was made**. Worth noting for the future: the window is measured from *send* time, so a recipient who unsubscribes from a >31-day-old message in their archive will get the "Token expired or invalid" page rather than being unsubscribed. If Postmaster reports unsubscribe failures after this ships, lengthening that constant is the first thing to look at.

## Tests

New coverage:

- `spec/mailers/shared_examples/renders_one_click_unsubscribe_headers.rb` — new shared example asserting both headers, applied to the digest, newsletter, and all five notification mailer specs.
- `spec/mailers/notify_mailer_spec.rb` — negative case on `export_email` asserting transactional mail has **no** unsubscribe headers.
- `spec/requests/email_subscriptions_spec.rb` — `POST /email_subscriptions/unsubscribe` unsubscribes the user and returns 200 **with `allow_forgery_protection` turned on for the example**, so the test actually exercises the CSRF skip (the test env disables forgery protection globally). Plus an expired-token case on the POST path.
- `spec/services/delivery_methods/customer_io_spec.rb` — headers are forwarded to the Customer.io payload, and no `headers` are sent when the mail carries none.

Ran locally against Ruby 3.3.0 / Postgres:

```
bundle exec rspec spec/mailers spec/views/email_subscriptions \
  spec/requests/email_subscriptions_spec.rb spec/services/delivery_methods
=> 289 examples, 1 failure
```

The single failure is **pre-existing on `main`** and unrelated — `ApplicationMailer#setup_subforem_context when user has onboarding_subforem_id uses the subforem's community name in the from address` fails identically with these changes stashed (`ForemInstance.from_email_address` returns `nil` in that example). Everything else is green.

`bundle exec rubocop` is clean on every changed line.

## Caveats

- The `List-Unsubscribe` URL scheme comes from `config.action_mailer.default_url_options`, which in production is `APP_PROTOCOL + APP_DOMAIN`. RFC 8058 requires an **https** URL, so `APP_PROTOCOL` must be `https://` in any environment that sends bulk mail (it is on dev.to; the default in `config/environments/production.rb` is `http://`).
- Some ESPs inject their own `List-Unsubscribe`. Ours is set on the message, so it takes precedence on the SMTP path; on the Customer.io path we now pass it explicitly. Worth spot-checking a delivered digest's raw headers after deploy, then re-checking Postmaster Tools.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788646625&installation_model_id=424141&pr_number=23700&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23700&signature=024355813343b8cae5d04353fbad09edc79ef29bcd79eb4764d31a1cc9daea70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->