### PR TITLE
Repoint a machine-created identity link on re-auth

### DIFF
--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -124,14 +124,46 @@ module Authentication
     #
     # `incoming_identity` is built by `Identity.build_from_omniauth`, so it is
     # only persisted when the payload's provider + uid already exist in the
-    # database. We refresh solely when that is the very same row the current
-    # user is linked through: a payload carrying a different uid must never
-    # silently repoint an existing identity.
+    # database. That gives three cases:
+    #
+    #   1. the payload is the row the user is already linked through: refresh
+    #      it in place.
+    #   2. the payload's uid is unclaimed and the linked row has no stored auth
+    #      payload: that link was machine-created, and completing OAuth as the
+    #      new uid proves the user owns it, so move the link onto it.
+    #   3. anything else: no-op. A uid held by some other identity is never
+    #      taken over, and a link the user established themselves is never
+    #      silently moved.
     def refresh_identity(incoming_identity, linked_identity)
-      return unless incoming_identity.persisted?
-      return unless incoming_identity.id == linked_identity.id
+      if incoming_identity.persisted?
+        return unless incoming_identity.id == linked_identity.id
 
-      incoming_identity.save!
+        incoming_identity.save!
+      elsif linked_identity.auth_data_dump.nil?
+        repoint_identity(incoming_identity, linked_identity)
+      end
+    end
+
+    # Moves a payload-less link onto the uid the user just authenticated as.
+    # Touching the user afterwards is what surfaces the new uid to the outbound
+    # sync, the same profile_updated_at signal a freshly linked identity sends.
+    def repoint_identity(incoming_identity, linked_identity)
+      ActiveRecord::Base.transaction do
+        linked_identity.update!(
+          uid: incoming_identity.uid,
+          token: incoming_identity.token,
+          secret: incoming_identity.secret,
+          auth_data_dump: incoming_identity.auth_data_dump,
+        )
+
+        current_user.profile_updated_at = Time.current
+        current_user.save!
+      end
+    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+      # A concurrent request can claim the same provider + uid first. Leave the
+      # existing link as it was rather than failing the whole callback.
+      ForemStatsClient.increment("identity.errors", tags: ["error:#{e.class}", "message:#{e.message}"])
+      nil
     end
 
     def proper_user(identity)

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -1011,8 +1011,12 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect(identity.token).to eq(auth_payload.credentials.token)
       end
 
-      it "leaves the identity untouched when the incoming uid differs" do
-        identity = Identity.create!(user: user, provider: "mlh", uid: "a-different-core-id")
+      # The seeded uid points at a placeholder account, so the person almost
+      # always authenticates as a different, real one. Completing OAuth proves
+      # they own the incoming uid, and the link being replaced was never
+      # established by a person, so the row moves onto the new uid.
+      it "repoints the link when the incoming uid is unclaimed" do
+        identity = Identity.create!(user: user, provider: "mlh", uid: "a-placeholder-id")
 
         result = nil
         expect do
@@ -1021,9 +1025,69 @@ RSpec.describe Authentication::Authenticator, type: :service do
 
         expect(result).to eq(user)
         identity.reload
-        expect(identity.uid).to eq("a-different-core-id")
-        expect(identity.auth_data_dump).to be_nil
-        expect(identity.token).to be_nil
+        expect(identity.uid).to eq(auth_payload.uid)
+        expect(identity.auth_data_dump.info.email).to eq(auth_payload.info.email)
+        expect(identity.token).to eq(auth_payload.credentials.token)
+      end
+
+      it "touches the user when the link is repointed so the sync sees the new uid" do
+        Identity.create!(user: user, provider: "mlh", uid: "a-placeholder-id")
+        user.update_column(:profile_updated_at, 2.years.ago)
+
+        expect do
+          described_class.call(auth_payload, current_user: user)
+        end.to change { user.reload.profile_updated_at }
+
+        expect(user.profile_updated_at).to be_within(5.seconds).of(Time.current)
+      end
+
+      it "emits user_updated carrying the new uid" do
+        Identity.create!(user: user, provider: "mlh", uid: "a-placeholder-id")
+        allow(Trackable::Registry).to receive(:active_names).and_return([:any])
+        allow(Trackable::DispatchWorker).to receive(:perform_async)
+        Settings::General.customerio_cdp_enabled = true
+        FeatureFlag.enable(:dev_core_user_sync, FeatureFlag::Actor[user])
+
+        with_trackable_events do
+          described_class.call(auth_payload, current_user: user)
+        end
+
+        expect(Trackable::DispatchWorker).to have_received(:perform_async)
+          .with(anything, "user_updated", [user.id], hash_including("mlh_user_id" => auth_payload.uid), anything)
+      ensure
+        FeatureFlag.remove(:dev_core_user_sync)
+      end
+
+      it "leaves the link alone when the uid is claimed concurrently" do
+        identity = Identity.create!(user: user, provider: "mlh", uid: "a-placeholder-id")
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Identity).to receive(:update!).and_raise(ActiveRecord::RecordNotUnique)
+        # rubocop:enable RSpec/AnyInstance
+        allow(ForemStatsClient).to receive(:increment)
+
+        expect(described_class.call(auth_payload, current_user: user)).to eq(user)
+
+        identity.reload
+        expect(identity.uid).to eq("a-placeholder-id")
+        tags = hash_including(tags: array_including("error:ActiveRecord::RecordNotUnique"))
+        expect(ForemStatsClient).to have_received(:increment).with("identity.errors", tags)
+      end
+
+      it "does not repoint a link the user established themselves" do
+        established_payload = auth_payload.dup
+        established_payload.uid = "an-established-id"
+        identity = Identity.create!(user: user, provider: "mlh", uid: "an-established-id",
+                                    auth_data_dump: established_payload)
+
+        result = nil
+        expect do
+          result = described_class.call(auth_payload, current_user: user)
+        end.not_to change(Identity, :count)
+
+        expect(result).to eq(user)
+        identity.reload
+        expect(identity.uid).to eq("an-established-id")
+        expect(identity.auth_data_dump.uid).to eq("an-established-id")
       end
 
       it "returns the current user when the identity is refreshed" do
@@ -1032,16 +1096,20 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect(described_class.call(auth_payload, current_user: user)).to eq(user)
       end
 
-      it "does not repoint an identity belonging to another user" do
+      it "leaves both rows alone when the incoming uid belongs to another user" do
         other_user = create(:user)
         other_identity = Identity.create!(user: other_user, provider: "mlh", uid: auth_payload.uid)
-        Identity.create!(user: user, provider: "mlh", uid: "yet-another-core-id")
+        identity = Identity.create!(user: user, provider: "mlh", uid: "yet-another-placeholder-id")
 
         described_class.call(auth_payload, current_user: user)
 
         other_identity.reload
         expect(other_identity.user_id).to eq(other_user.id)
         expect(other_identity.auth_data_dump).to be_nil
+
+        identity.reload
+        expect(identity.uid).to eq("yet-another-placeholder-id")
+        expect(identity.auth_data_dump).to be_nil
       end
 
       it "still links a brand new identity when the user has none" do


### PR DESCRIPTION
Follow-up to #23699, which added the "Reconnect" button and made a completed re-auth refresh the linked identity. Production repro shows that refresh almost never fires.

## The repro

Identities created through the admin API carry a uid the seeding system had on hand — a placeholder account, not the account the person actually signs in with. So the common path through `Authenticator#refresh_identity` is:

1. User has an mlh identity with `uid = <placeholder>`, `auth_data_dump = nil`.
2. They click **Reconnect MLH Account** and authenticate as their real MLH account, uid `<real>`.
3. `Identity.build_from_omniauth` finds no row for `["mlh", <real>]`, so the incoming identity is a new record.
4. The differing-uid guard fires and the method returns.

The result is a **silent no-op**: no identity write, no `profile_updated_at` touch, and therefore no `user_updated` event. Because the downstream merge keys off a changed `mlh_user_id` in DEV's `user_updated` payload, it never gets its signal, and the placeholder account is never merged away. Reconnect only worked for the small minority who happened to authenticate as the exact seeded uid — which is precisely the case that needed fixing least.

## The change

`Authentication::Authenticator#refresh_identity` now resolves three cases instead of two:

1. **Incoming payload is the row the user is already linked through** → refresh token/secret/payload in place. Unchanged.
2. **NEW — incoming uid is unclaimed AND the linked row has `auth_data_dump.nil?`** → repoint the row in place: copy uid, token, secret and payload onto the linked identity and save.
3. **Everything else** → no-op, unchanged.

### Why repointing is safe here

Two conditions have to hold together, and each one carries a piece of the argument:

- **`auth_data_dump.nil?`** means the link was machine-created. No person ever completed an OAuth round-trip to establish it, so there is no user intent being overwritten — only a seeded guess. A link a user built themselves has a payload and is never touched.
- **The incoming uid is unclaimed** — no identity row anywhere holds `["mlh", <incoming uid>]`. Nothing is being taken away from anyone.

And the user has just completed OAuth as the incoming uid, which is proof they own it. Replacing a guess with a proven fact, on a row nobody established, with a uid nobody else holds.

Cases that remain no-ops, deliberately:

- Incoming uid already belongs to **another identity** (whether the current user's or someone else's). Never taken over — that would be an account takeover primitive, and the collision needs a human.
- Linked identity **has a payload**. A user-established link is never silently moved, even to an unclaimed uid.

### Completing the chain

On the repoint path only, the user is touched (`profile_updated_at = Time.current` + `save!`) exactly as the new-identity path in `#call` already does. This matters mechanically: `profile_updated_at` is in `User::SYNC_TRIGGER_KEYS`, so `User#enqueue_trackable_event_updated` emits `user_updated`; `Trackable` dispatches from an `after_commit` callback, so `User#trackable_payload` — which resolves `mlh_user_id` with `identities.where(provider: "mlh").pick(:uid)` — runs after the repointed identity has committed and therefore carries the **new** uid. (That is why the touch uses `save!` and not `update_column`, which would skip the callback entirely.) With this, Reconnect → repoint → `user_updated` → downstream merge works end to end.

Race handling: the `["provider", "uid"]` unique index means a concurrent request can claim the same uid between the lookup and the write. The repoint runs in a transaction and rescues `RecordNotUnique` / `RecordInvalid`, reporting through the class's existing `ForemStatsClient.increment("identity.errors", ...)` pattern and leaving the link exactly as it was, rather than failing the whole callback with a 500.

No user-facing copy or UI changed, so there are no new i18n keys and nothing to eyeball manually. No API routes, controllers or params changed, so no RSWAG/OpenAPI regeneration is needed.

## Tests

`spec/services/authentication/authenticator_spec.rb`, extending the existing "relinking a uid-only identity" block:

- Unclaimed differing uid → the linked row's uid is updated **in place** (same identity id, `Identity.count` unchanged), payload and token stored.
- Same case → user's `profile_updated_at` changes.
- Same case → `Trackable::DispatchWorker` receives `user_updated` with `hash_including("mlh_user_id" => <new uid>)`, using the `with_trackable_events` + feature-flag pattern the admin user specs already use.
- Linked identity **with** an `auth_data_dump` + differing uid → untouched.
- Differing uid held by **another user's** identity → both rows untouched.
- Concurrent claim (`update!` raises `RecordNotUnique`) → link unchanged, `identity.errors` reported, call still returns the user.
- The matching-uid refresh and brand-new-link specs from #23699 are unchanged and still pass.

The rewritten spec replaces #23699's "leaves the identity untouched when the incoming uid differs", whose asserted behaviour is what this PR deliberately changes.

Run locally (Ruby 3.3.0, local Postgres + Redis):

```
bundle exec rspec spec/services/authentication/authenticator_spec.rb \
                  spec/requests/user/user_settings_spec.rb
# 189 examples, 0 failures

bundle exec rspec spec/requests/authenticator_api_link_round_trip_spec.rb \
                  spec/requests/omniauth_callbacks_failure_spec.rb \
                  spec/models/identity_spec.rb \
                  spec/models/concerns/trackable_spec.rb
# 47 examples, 0 failures

bundle exec rubocop app/services/authentication/authenticator.rb \
                    spec/services/authentication/authenticator_spec.rb
# 2 files inspected, no offenses detected
```

Both sync assertions were checked against a deliberately broken build (touch removed) and fail there, so they are not vacuous.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788703550&installation_model_id=424141&pr_number=23702&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23702&signature=30e244f79e80df525eae95377f107f43f71b12bf66bc5b0d0d30f0acc79261f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->