### PR TITLE
Verify MLH OAuth state and bound identity error metrics

### DIFF
--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -162,7 +162,10 @@ module Authentication
     rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
       # A concurrent request can claim the same provider + uid first. Leave the
       # existing link as it was rather than failing the whole callback.
-      ForemStatsClient.increment("identity.errors", tags: ["error:#{e.class}", "message:#{e.message}"])
+      ForemStatsClient.increment(
+        "identity.errors",
+        tags: ["error:#{e.class}", "provider:#{linked_identity.provider}"],
+      )
       nil
     end
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -79,7 +79,6 @@ MLH_OMNIAUTH_SETUP = lambda do |env|
   env["omniauth.strategy"].options[:scope] = "user:read:email user:read:phone user:read:profile user:read:demographics user:read:education user:read:employment user:read:address public offline_access mlh:read:user"
   env["omniauth.strategy"].options[:client_id] = Settings::Authentication.mlh_key
   env["omniauth.strategy"].options[:client_secret] = Settings::Authentication.mlh_secret
-  env["omniauth.strategy"].options[:provider_ignores_state] = true
   # Note: redirect_uri is handled by the prepended MlhCallbackUrlOverride module
   # which overrides both callback_url and authorize_params to ensure no query parameters
 end

--- a/spec/initializers/mlh_omniauth_setup_spec.rb
+++ b/spec/initializers/mlh_omniauth_setup_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe "MLH OmniAuth setup" do # rubocop:disable RSpec/DescribeClass
+  let(:app) { ->(_env) { [200, {}, ["OK"]] } }
+  let(:strategy) { OmniAuth::Strategies::MLH.new(app, "client-id", "client-secret") }
+
+  before do
+    MLH_OMNIAUTH_SETUP.call("omniauth.strategy" => strategy)
+  end
+
+  it "keeps OAuth state verification enabled" do
+    expect(strategy.options.provider_ignores_state).to be(false)
+  end
+
+  it "sends the state it records in the initiating session" do
+    session = {}
+    allow(strategy).to receive(:session).and_return(session)
+
+    params = strategy.authorize_params
+
+    expect(params[:state]).to be_present
+    expect(session["omniauth.state"]).to eq(params[:state])
+  end
+
+  it "rejects a callback whose state does not match the initiating session" do
+    request = instance_double(
+      Rack::Request,
+      params: { "code" => "authorization-code", "state" => "returned-state" },
+    )
+    allow(strategy).to receive_messages(
+      request: request,
+      session: { "omniauth.state" => "session-state" },
+      fail!: nil,
+      build_access_token: nil,
+    )
+
+    strategy.callback_phase
+
+    expect(strategy).not_to have_received(:build_access_token)
+    expect(strategy).to have_received(:fail!).with(
+      :csrf_detected,
+      instance_of(OmniAuth::Strategies::OAuth2::CallbackError),
+    )
+  end
+end

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -1069,10 +1069,10 @@ RSpec.describe Authentication::Authenticator, type: :service do
 
         identity.reload
         expect(identity.uid).to eq("a-placeholder-id")
-        expect(ForemStatsClient).to have_received(:increment).with(
-          "identity.errors",
-          tags: ["error:ActiveRecord::RecordNotUnique", "provider:mlh"],
-        )
+expect(ForemStatsClient).to have_received(:increment).with(
+  "identity.errors",
+  tags: match_array(["error:ActiveRecord::RecordNotUnique", "provider:mlh"]),
+)
       end
 
       it "does not repoint a link the user established themselves" do

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -1069,8 +1069,10 @@ RSpec.describe Authentication::Authenticator, type: :service do
 
         identity.reload
         expect(identity.uid).to eq("a-placeholder-id")
-        tags = hash_including(tags: array_including("error:ActiveRecord::RecordNotUnique"))
-        expect(ForemStatsClient).to have_received(:increment).with("identity.errors", tags)
+        expect(ForemStatsClient).to have_received(:increment).with(
+          "identity.errors",
+          tags: ["error:ActiveRecord::RecordNotUnique", "provider:mlh"],
+        )
       end
 
       it "does not repoint a link the user established themselves" do


### PR DESCRIPTION
## What changed

- Restore OAuth `state` generation and verification for the MLH OmniAuth strategy.
- Add regression coverage proving Forem sends and stores the same state value and rejects mismatched callback state before token exchange.
- Replace the repoint-conflict metric's raw exception-message tag with a bounded provider tag.

## Why

The MLH strategy explicitly set `provider_ignores_state`, disabling the OAuth request/callback binding that protects login and account-linking flows from CSRF. Core already preserves the standard OAuth `state` parameter, so this is a Forem-only correction.

The repoint-conflict metric also tagged raw exception messages. Those messages can contain identifiers and create unbounded Datadog cardinality; exception class plus provider provides stable operational dimensions without including message contents.

## Impact

MLH authorization callbacks must carry the same state Forem placed in the initiating session. Missing or mismatched state fails as `csrf_detected` before the authorization code is exchanged. Valid OAuth flows remain unchanged.

## Verification

- `bundle exec rspec spec/initializers/mlh_omniauth_setup_spec.rb spec/initializers/omniauth_oauth2_monkey_patch_spec.rb spec/requests/omniauth_callbacks_failure_spec.rb spec/services/authentication/authenticator_spec.rb spec/services/authentication/providers/mlh_spec.rb spec/requests/user/user_settings_spec.rb` — 210 examples, 0 failures
- RuboCop on the changed service/spec files — no offenses
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788706169&installation_model_id=424141&pr_number=23703&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23703&signature=f697758416f58e56b009a7708c61cc7a8d97ef0e0267a4d7e7fdd81c087708b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->