### PR TITLE
Mod center overhaul phase 2

### DIFF
--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -109,6 +109,14 @@ body.subforem-moderator-status-true .subforem-moderator-visible-block {
   display: block !important;
 }
 
+.community-leader-visible-block {
+  display: none !important;
+}
+
+body.community-leader-status-true .community-leader-visible-block {
+  display: block !important;
+}
+
 // The .admin-help-button class is included in this file since it
 // is referenced in both the admin and application layout.
 

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -92,6 +92,15 @@ module Admin
       end
     end
 
+    def unfavorite
+      article = Article.find(params[:id])
+
+      Favorites::Remove.call(favoritable: article, admin: current_user)
+
+      flash[:success] = I18n.t("admin.articles_controller.favorite_removed")
+      redirect_to admin_article_path(article.id)
+    end
+
     private
 
     def articles_top(months_ago)

--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -29,6 +29,15 @@ module Admin
       @countable_vomits[@comment.id] = calculate_flags_for_single_comment(@comment)
     end
 
+    def unfavorite
+      comment = Comment.find(params[:id])
+
+      Favorites::Remove.call(favoritable: comment, admin: current_user)
+
+      flash[:success] = I18n.t("admin.comments_controller.favorite_removed")
+      redirect_to admin_comment_path(comment.id)
+    end
+
     private
 
     def authorize_admin

--- a/app/controllers/admin/favorites_controller.rb
+++ b/app/controllers/admin/favorites_controller.rb
@@ -1,0 +1,15 @@
+module Admin
+  class FavoritesController < Admin::ApplicationController
+    layout "admin"
+
+    def index
+      @leaderboard = Favorites::ImpactData.call
+    end
+
+    protected
+
+    def authorization_resource
+      User
+    end
+  end
+end

--- a/app/controllers/leadership_dashboards_controller.rb
+++ b/app/controllers/leadership_dashboards_controller.rb
@@ -1,0 +1,32 @@
+class LeadershipDashboardsController < ApplicationController
+  before_action :set_no_cache_header
+  before_action :authenticate_user!
+
+  SECTIONS = %w[curation discussion].freeze
+
+  def show
+    # Not discoverable by non-leaders
+    return head :not_found unless current_user.community_leader?
+
+    @section = SECTIONS.include?(params[:section]) ? params[:section] : "curation"
+
+    if @section == "discussion"
+      setup_discussion
+    else
+      setup_curation
+    end
+  end
+
+  private
+
+  def setup_curation
+    @favorite_allowance = current_user.favorite_allowance
+    @favorited = Favorites::Fetch.call(user: current_user, page: params[:page])
+  end
+
+  def setup_discussion
+    @discussion_feed = Articles::Feeds::EngagementCandidates.call(
+      exclude_author: current_user, page: params[:page],
+    )
+  end
+end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -109,6 +109,7 @@ class UserDecorator < ApplicationDecorator
       "#{setting.resolved_font_name.tr('_', '-')}-article-body",
       "mod-status-#{any_admin? || !moderator_for_tags.empty?}",
       "trusted-status-#{trusted?}",
+      "community-leader-status-#{community_leader?}",
       "#{setting.config_navbar.tr('_', '-')}-header",
     ]
 

--- a/app/models/admin_menu.rb
+++ b/app/models/admin_menu.rb
@@ -9,6 +9,7 @@ class AdminMenu
       item(name: "invited members", controller: "invitations"),
       item(name: "gdpr actions", controller: "gdpr_delete_requests"),
       item(name: "bulk assign role", controller: "bulk_assign_role"),
+      item(name: "impact leaderboard", controller: "favorites"),
     ]
 
     scope :content_manager, "dashboard-line", [

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -524,7 +524,8 @@ class Article < ApplicationRecord
            :video, :user_id, :organization_id, :video_source_url, :video_code,
            :video_thumbnail_url, :video_closed_caption_track_url, :social_image,
            :published_from_feed, :crossposted_at, :published_at, :created_at, :edited_at,
-           :body_markdown, :email_digest_eligible, :processed_html, :co_author_ids, :score, :type_of)
+           :body_markdown, :email_digest_eligible, :processed_html, :co_author_ids, :score, :type_of,
+           :favorited_by_user_id)
   }
 
   scope :sorting, lambda { |value|

--- a/app/services/articles/feeds/engagement_candidates.rb
+++ b/app/services/articles/feeds/engagement_candidates.rb
@@ -1,0 +1,23 @@
+module Articles
+  module Feeds
+    # Surfaces posts that are candidates for an engagement boost, i.e.
+    # high-quality posts with fewer than the comment threshold. Pass a user as
+    # `exclude_author:` to leave that user's own posts out of the feed.
+    module EngagementCandidates
+      def self.call(exclude_author: nil, page: 1,
+                    number_of_articles: Article::DEFAULT_FEED_PAGINATION_WINDOW_SIZE)
+        minimum_score = Settings::UserExperience.home_feed_minimum_score
+
+        scope = Article
+          .published
+          .where(comments_count: ..5, score: minimum_score..)
+        scope = scope.where.not(user_id: exclude_author.id) if exclude_author
+
+        scope
+          .order(score: :desc, published_at: :desc)
+          .page(page)
+          .per(number_of_articles)
+      end
+    end
+  end
+end

--- a/app/services/favorites/fetch.rb
+++ b/app/services/favorites/fetch.rb
@@ -1,0 +1,66 @@
+module Favorites
+  # Returns a page of interleaved favorited articles and comments ordered by
+  # favorited_at. An optional user may be passed to limit results to that user's
+  # favorites.
+  class Fetch
+    DEFAULT_PER_PAGE = 20
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(user: nil, page: 1, per_page: DEFAULT_PER_PAGE)
+      @user = user
+      @page = page
+      @per_page = per_page
+    end
+
+    def call
+      refs = favorited_refs
+
+      Kaminari.paginate_array(
+        hydrate(refs),
+        total_count: refs.total_count,
+        limit: refs.limit_value,
+        offset: refs.offset_value,
+      )
+    end
+
+    private
+
+    attr_reader :user, :page, :per_page
+
+    def favorited_refs
+      favorited(Article).union_all(favorited(Comment))
+        .order(favorited_at: :desc)
+        .page(page)
+        .per(per_page)
+    end
+
+    def favorited(model)
+      scope = if user
+                model.where(favorited_by_user_id: user.id)
+              else
+                model.where.not(favorited_by_user_id: nil)
+              end
+
+      scope.select(
+        ActiveRecord::Base.sanitize_sql_array(["? AS favoritable_type", model.name]),
+        "id AS favoritable_id",
+        "favorited_at",
+      )
+    end
+
+    def hydrate(refs)
+      grouped = refs.group_by(&:favoritable_type)
+      articles = Article.where(id: Array(grouped["Article"]).map(&:favoritable_id))
+        .includes(:user).index_by(&:id)
+      comments = Comment.where(id: Array(grouped["Comment"]).map(&:favoritable_id))
+        .includes(:user, :commentable).index_by(&:id)
+
+      refs.filter_map do |ref|
+        (ref.favoritable_type == "Article" ? articles : comments)[ref.favoritable_id]
+      end
+    end
+  end
+end

--- a/app/services/favorites/impact_data.rb
+++ b/app/services/favorites/impact_data.rb
@@ -1,0 +1,88 @@
+module Favorites
+  # Ranks users by the downstream engagement of their favorite content. Results
+  # are cached internally.
+  #
+  # Impact is the engagement accrued on favorited content:
+  #   - articles: comments_count + public_reactions_count + page_views_count
+  #   - comments: public_reactions_count
+  #
+  # Impact calculation and caching are provisional and should be tuned to fit.
+  class ImpactData
+    CACHE_KEY = "favorites_impact_data".freeze
+
+    ARTICLE_IMPACT_SQL = "COALESCE(SUM(comments_count + public_reactions_count + page_views_count), 0)".freeze
+    COMMENT_IMPACT_SQL = "COALESCE(SUM(public_reactions_count), 0)".freeze
+
+    LIMIT = 25
+    PERIOD = 3.months
+
+    Row = Struct.new(
+      :user, :article_favorites_count, :comment_favorites_count,
+      :favorites_count, :impact_score,
+      keyword_init: true
+    )
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(limit: LIMIT)
+      @limit = limit
+    end
+
+    def call
+      aggregates = Rails.cache.fetch(CACHE_KEY, expires_in: 1.hour) do
+        ranked_aggregates
+      end
+
+      hydrate(aggregates.first(limit))
+    end
+
+    private
+
+    attr_reader :limit
+
+    # Cache-safe aggregated per-user data ranked by impact. Returns an array of
+    # { user_id:, articles:, comments:, impact: }.
+    def ranked_aggregates
+      totals = Hash.new { |hash, key| hash[key] = { articles: 0, comments: 0, impact: 0 } }
+      range = (PERIOD.ago..)
+
+      Article.favorited.where(published_at: range).group(:favorited_by_user_id)
+        .pluck(:favorited_by_user_id, Arel.sql("COUNT(*)"), Arel.sql(ARTICLE_IMPACT_SQL))
+        .each do |user_id, count, impact|
+          totals[user_id][:articles] = count
+          totals[user_id][:impact] += impact.to_i
+        end
+
+      Comment.favorited.where(created_at: range).group(:favorited_by_user_id)
+        .pluck(:favorited_by_user_id, Arel.sql("COUNT(*)"), Arel.sql(COMMENT_IMPACT_SQL))
+        .each do |user_id, count, impact|
+          totals[user_id][:comments] = count
+          totals[user_id][:impact] += impact.to_i
+        end
+
+      totals
+        .map { |user_id, row| row.merge(user_id: user_id) }
+        .sort_by { |row| -row[:impact] }
+    end
+
+    # Turns aggregate data into Rows with live Users, preserving ranked order.
+    def hydrate(aggregates)
+      users = User.where(id: aggregates.pluck(:user_id)).index_by(&:id)
+
+      aggregates.filter_map do |row|
+        user = users[row[:user_id]]
+        next unless user
+
+        Row.new(
+          user: user,
+          article_favorites_count: row[:articles],
+          comment_favorites_count: row[:comments],
+          favorites_count: row[:articles] + row[:comments],
+          impact_score: row[:impact],
+        )
+      end
+    end
+  end
+end

--- a/app/services/favorites/remove.rb
+++ b/app/services/favorites/remove.rb
@@ -1,0 +1,35 @@
+module Favorites
+  # Unmark an Article or Comment as favorite. This can only be done by admins.
+  class Remove
+    Result = Struct.new(:success?, :favoritable, keyword_init: true)
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(favoritable:, admin:)
+      @favoritable = favoritable
+      @admin = admin
+    end
+
+    def call
+      previous_favoriter_id = favoritable.favorited_by_user_id
+      favoritable.update!(favorited_by_user_id: nil, favorited_at: nil)
+      log_audit(previous_favoriter_id)
+      Result.new(success?: true, favoritable: favoritable)
+    end
+
+    private
+
+    attr_reader :favoritable, :admin
+
+    def log_audit(previous_favoriter_id)
+      Audit::Logger.log(:moderator, admin,
+                        "action" => "unfavorite",
+                        "favoritable_type" => favoritable.class.name,
+                        "favoritable_id" => favoritable.id,
+                        "previous_favoriter_id" => previous_favoriter_id,
+                        "target_user_id" => favoritable.user_id)
+    end
+  end
+end

--- a/app/views/admin/articles/_article_item.html.erb
+++ b/app/views/admin/articles/_article_item.html.erb
@@ -9,7 +9,7 @@
 
   <article class="js-individual-article crayons-card p-6 flex flex-col gap-4">
     <header>
-      <% if decorated_article.pinned? || article.featured || article.approved || (!article.published? && article.published_from_feed?) || article.video || article.user&.warned? %>
+      <% if decorated_article.pinned? || article.featured || article.approved || article.favorited_by_user_id? || (!article.published? && article.published_from_feed?) || article.video || article.user&.warned? %>
         <div class="flex gap-1 mb-1">
           <% if !article.published? && article.published_from_feed? %>
             <span class="c-indicator c-indicator--danger"><%= t("views.moderations.article.unplublished") %></span>
@@ -22,6 +22,12 @@
           <% end %>
           <% if article.approved %>
             <span class="c-indicator c-indicator--info"><%= t("views.moderations.article.approved") %></span>
+          <% end %>
+          <% if article.favorited_by_user_id? %>
+            <span class="c-indicator c-indicator--warning">
+              <%= t("views.moderations.article.favorited_by") %>
+              <a href="<%= article.favorited_by_user&.path %>" target="_blank" rel="noopener" class="shrink-0 c-link c-link--branded fw-bold"><%= article.favorited_by_user&.username %></a>
+            </span>
           <% end %>
           <% if article.video %>
             <span class="c-indicator"><%= t("views.moderations.article.contains_video") %></span>
@@ -122,6 +128,13 @@
               <button type="submit" class="c-btn">
                 <%= t("views.moderations.article.pin_post") %>
               </button>
+            </form>
+          <% end %>
+          <% if article.favorited_by_user_id? %>
+            <form method="post" action="<%= unfavorite_admin_article_path(article.id) %>" class="inline">
+              <input type="hidden" name="_method" value="delete" />
+              <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>" />
+              <button type="submit" class="c-btn"><%= t("views.moderations.article.unfavorite") %></button>
             </form>
           <% end %>
           <a class="c-link c-link--block" href="<%= admin_user_path(article.user_id) %>" target="_blank" rel="noopener"><%= t("views.moderations.article.user") %></a>

--- a/app/views/admin/comments/_comment.html.erb
+++ b/app/views/admin/comments/_comment.html.erb
@@ -1,39 +1,50 @@
 <div>
   <article class="crayons-card p-4 pt-3 pb-2 flex flex-col gap-3">
     <% if comment.commentable %>
-      <header class="flex justify-between gap-4 items-center border-b-1 border-base-10 border-solid border-0 pb-3 -mx-2 px-2">
-        <div class="flex gap-2 items-center">
-          <% if comment.user %>
-            <a href="<%= comment.user.path %>" target="_blank" rel="noopener" class="shrink-0 c-link">
-              <img width="32" height="32" class="radius-full block" src="<%= comment.user.profile_image_url_for(length: 64) %>" alt="<%= comment.user.username %> profile" loading="lazy" />
-            </a>
-          <% end %>
-          <p>
-            <a href="<%= comment.user.path %>" target="_blank" rel="noopener" class="c-link c-link--branded fw-bold"><%= comment.user.username %></a>
-            on:
-            <a href="<%= comment.commentable.path %>" class="c-link c-link--branded"><%= comment.commentable.title %></a>
-          </p>
-        </div>
-        <div class="flex items-center gap-1">
-          <span class="crayons-card crayons-card--secondary px-3 py-1 flex gap-2 items-center" title="<%= t("views.moderations.actions.thumb_up") %>">
-            <%= crayons_icon_tag("twemoji/thumb-up", native: true, width: 16, height: 16) %>
-            <span class="fs-s fw-medium lh-base"><%= comment.privileged_reaction_counts["thumbsup"] || "0" %></span>
-          </span>
+      <header>
+        <% if comment.favorited_by_user_id? %>
+          <div class="flex gap-1 mb-1">
+            <span class="c-indicator c-indicator--warning">
+              <%= t("views.moderations.article.favorited_by") %>
+              <a href="<%= comment.favorited_by_user&.path %>" target="_blank" rel="noopener" class="shrink-0 c-link c-link--branded fw-bold"><%= comment.favorited_by_user&.username %></a>
+            </span>
+          </div>
+        <% end %>
 
-          <span class="crayons-card crayons-card--secondary px-3 py-1 flex gap-2 items-center" title="<%= t("views.moderations.actions.thumb_down") %>">
-            <%= crayons_icon_tag("twemoji/thumb-down", native: true, width: 16, height: 16) %>
-            <span class="fs-s fw-medium lh-base"><%= comment.privileged_reaction_counts["thumbsdown"] || "0" %></span>
-          </span>
+        <div class="flex justify-between gap-4 items-center border-b-1 border-base-10 border-solid border-0 pb-3 -mx-2 px-2">
+          <div class="flex gap-2 items-center">
+            <% if comment.user %>
+              <a href="<%= comment.user.path %>" target="_blank" rel="noopener" class="shrink-0 c-link">
+                <img width="32" height="32" class="radius-full block" src="<%= comment.user.profile_image_url_for(length: 64) %>" alt="<%= comment.user.username %> profile" loading="lazy" />
+              </a>
+            <% end %>
+            <p>
+              <a href="<%= comment.user.path %>" target="_blank" rel="noopener" class="c-link c-link--branded fw-bold"><%= comment.user.username %></a>
+              on:
+              <a href="<%= comment.commentable.path %>" class="c-link c-link--branded"><%= comment.commentable.title %></a>
+            </p>
+          </div>
+          <div class="flex items-center gap-1">
+            <span class="crayons-card crayons-card--secondary px-3 py-1 flex gap-2 items-center" title="<%= t("views.moderations.actions.thumb_up") %>">
+              <%= crayons_icon_tag("twemoji/thumb-up", native: true, width: 16, height: 16) %>
+              <span class="fs-s fw-medium lh-base"><%= comment.privileged_reaction_counts["thumbsup"] || "0" %></span>
+            </span>
 
-          <span class="crayons-card crayons-card--secondary px-3 py-1 flex gap-2 items-center" title="<%= t("views.moderations.actions.vomit") %>">
-            <%= crayons_icon_tag("twemoji/flag", native: true, width: 16, height: 16) %>
-            <span class="fs-s fw-medium lh-base"><%= @countable_vomits&.dig(comment.id) || 0 %></span>
-          </span>
+            <span class="crayons-card crayons-card--secondary px-3 py-1 flex gap-2 items-center" title="<%= t("views.moderations.actions.thumb_down") %>">
+              <%= crayons_icon_tag("twemoji/thumb-down", native: true, width: 16, height: 16) %>
+              <span class="fs-s fw-medium lh-base"><%= comment.privileged_reaction_counts["thumbsdown"] || "0" %></span>
+            </span>
 
-          <span class="crayons-card crayons-card--secondary px-3 py-1 ml-3 flex gap-2 items-center" title="<%= t("views.moderations.actions.score") %>">
-            <%= crayons_icon_tag("analytics", native: true, width: 16, height: 16) %>
-            <span class="fs-s fw-medium lh-base"><%= comment.score %></span>
-          </span>
+            <span class="crayons-card crayons-card--secondary px-3 py-1 flex gap-2 items-center" title="<%= t("views.moderations.actions.vomit") %>">
+              <%= crayons_icon_tag("twemoji/flag", native: true, width: 16, height: 16) %>
+              <span class="fs-s fw-medium lh-base"><%= @countable_vomits&.dig(comment.id) || 0 %></span>
+            </span>
+
+            <span class="crayons-card crayons-card--secondary px-3 py-1 ml-3 flex gap-2 items-center" title="<%= t("views.moderations.actions.score") %>">
+              <%= crayons_icon_tag("analytics", native: true, width: 16, height: 16) %>
+              <span class="fs-s fw-medium lh-base"><%= comment.score %></span>
+            </span>
+          </div>
         </div>
       </header>
     <% end %>
@@ -53,6 +64,14 @@
         <a href="/admin/content_manager/comments/<%= comment.id %>" class="c-link c-link--block">
           <%= t("views.moderations.comments.view_details") %>
         </a>
+      <% end %>
+
+      <% if comment.favorited_by_user_id? %>
+        <form method="post" action="<%= unfavorite_admin_comment_path(comment.id) %>" class="inline">
+          <input type="hidden" name="_method" value="delete" />
+          <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>" />
+          <button type="submit" class="c-btn"><%= t("views.moderations.article.unfavorite") %></button>
+        </form>
       <% end %>
     </footer>
   </article>

--- a/app/views/admin/favorites/index.html.erb
+++ b/app/views/admin/favorites/index.html.erb
@@ -1,0 +1,35 @@
+<header class="crayons-card p-6 mb-6">
+  <h1 class="crayons-title"><%= t("views.admin.favorites.leaderboard.heading") %></h1>
+  <p class="color-base-60 mt-1"><%= t("views.admin.favorites.leaderboard.description") %></p>
+</header>
+
+<% if @leaderboard.empty? %>
+  <div class="crayons-notice">
+    <%= t("views.admin.favorites.leaderboard.empty") %>
+  </div>
+<% else %>
+  <table class="crayons-table" width="100%">
+    <thead>
+      <tr>
+        <th scope="col"><%= t("views.admin.favorites.leaderboard.rank") %></th>
+        <th scope="col"><%= t("views.admin.favorites.leaderboard.leader") %></th>
+        <th scope="col"><%= t("views.admin.favorites.leaderboard.favorites") %></th>
+        <th scope="col"><%= t("views.admin.favorites.leaderboard.articles") %></th>
+        <th scope="col"><%= t("views.admin.favorites.leaderboard.comments") %></th>
+        <th scope="col"><%= t("views.admin.favorites.leaderboard.impact") %></th>
+      </tr>
+    </thead>
+    <tbody class="crayons-card">
+      <% @leaderboard.each_with_index do |row, index| %>
+        <tr data-row-id="<%= row.user.id %>">
+          <td class="whitespace-nowrap"><%= index + 1 %></td>
+          <td><%= link_to row.user.username, admin_user_path(row.user), class: "c-link c-link--branded fw-bold" %></td>
+          <td><%= row.favorites_count %></td>
+          <td><%= row.article_favorites_count %></td>
+          <td><%= row.comment_favorites_count %></td>
+          <td class="fw-bold"><%= row.impact_score %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/layouts/_nav_menu.html.erb
+++ b/app/views/layouts/_nav_menu.html.erb
@@ -24,9 +24,6 @@
     <li>
       <a href="<%= header_link(mod_path) %>" class="c-link c-link--block trusted-visible-block"><%= t("views.main.nav.moderator_center") %></a>
     </li>
-    <li>
-      <a href="<%= header_link(leadership_path) %>" class="c-link c-link--block community-leader-visible-block"><%= t("views.main.nav.leadership") %></a>
-    </li>
     <% if ArticlePolicy.is_root_subforem? %>
       <li>
         <button 

--- a/app/views/layouts/_nav_menu.html.erb
+++ b/app/views/layouts/_nav_menu.html.erb
@@ -24,6 +24,9 @@
     <li>
       <a href="<%= header_link(mod_path) %>" class="c-link c-link--block trusted-visible-block"><%= t("views.main.nav.moderator_center") %></a>
     </li>
+    <li>
+      <a href="<%= header_link(leadership_path) %>" class="c-link c-link--block community-leader-visible-block"><%= t("views.main.nav.leadership") %></a>
+    </li>
     <% if ArticlePolicy.is_root_subforem? %>
       <li>
         <button 

--- a/app/views/leadership_dashboards/_curation.html.erb
+++ b/app/views/leadership_dashboards/_curation.html.erb
@@ -1,0 +1,17 @@
+<section class="crayons-card pb-4">
+  <div class="p-4 m:p-6 pb-0 m:pb-2">
+    <p>
+      <%= t("views.leadership.curation.allowance", remaining: @favorite_allowance) %>
+    </p>
+  </div>
+
+  <% if @favorited.any? %>
+    <%= render partial: "favorited_row", collection: @favorited, as: :favoritable %>
+
+    <div class="p-4 m:p-6 pt-2 m:pt-2 pb-0 m:pb-0">
+      <%= paginate @favorited %>
+    </div>
+  <% else %>
+    <p class="color-base-60 p-4 m:p-6 pt-2 m:pt-2 m-0"><%= t("views.leadership.curation.empty") %></p>
+  <% end %>
+</section>

--- a/app/views/leadership_dashboards/_discussion.html.erb
+++ b/app/views/leadership_dashboards/_discussion.html.erb
@@ -1,0 +1,17 @@
+<section class="crayons-card pb-4">
+  <div class="p-4 m:p-6 pb-0 m:pb-2">
+    <p>
+      <%= t("views.leadership.discussion.subtitle") %>
+    </p>
+  </div>
+
+  <% if @discussion_feed.any? %>
+    <%= render partial: "discussion_row", collection: @discussion_feed, as: :article %>
+
+    <div class="p-4 m:p-6 pt-2 m:pt-2 pb-0 m:pb-0">
+      <%= paginate @discussion_feed %>
+    </div>
+  <% else %>
+    <p class="color-base-60 p-4 m:p-6 pt-2 m:pt-2 m-0"><%= t("views.leadership.discussion.empty") %></p>
+  <% end %>
+</section>

--- a/app/views/leadership_dashboards/_discussion_row.html.erb
+++ b/app/views/leadership_dashboards/_discussion_row.html.erb
@@ -1,0 +1,22 @@
+<article class="flex p-4 m:p-6 pb-0 m:pb-2 pr-2 m:pr-6">
+  <a href="/<%= article.cached_user.username %>" class="crayons-avatar crayons-avatar--l shrink-0">
+    <img src="<%= article.cached_user.profile_image_90 %>" alt="<%= article.cached_user.name %> profile" class="crayons-avatar__image" loading="lazy" />
+  </a>
+
+  <div class="flex-1 pl-2 m:pl-4">
+    <a href="<%= article.path %>" class="flex crayons-link">
+      <h2 class="fs-base lh-tight m:fs-l fw-bold break-word"><%= article.title %></h2>
+    </a>
+    <p class="fs-s">
+      <a href="/<%= article.cached_user.username %>" class="crayons-link fw-medium"><%= article.cached_user.name %></a>
+      <span class="color-base-30"> • </span>
+      <span class="color-base-60"><%= article.readable_publish_date %></span>
+    </p>
+  </div>
+
+  <div class="m:self-center">
+    <a href="<%= article.path %>#comments" class="crayons-btn crayons-btn--ghost crayons-btn--s whitespace-nowrap">
+      <%= t("views.leadership.discussion.cta") %>
+    </a>
+  </div>
+</article>

--- a/app/views/leadership_dashboards/_favorited_row.html.erb
+++ b/app/views/leadership_dashboards/_favorited_row.html.erb
@@ -1,0 +1,28 @@
+<article class="flex p-4 m:p-6 pb-0 m:pb-2 pr-2 m:pr-6">
+  <a href="/<%= favoritable.user.username %>" class="crayons-avatar crayons-avatar--l shrink-0">
+    <img src="<%= favoritable.user.profile_image_90 %>" alt="<%= favoritable.user.name %> profile" class="crayons-avatar__image" loading="lazy" />
+  </a>
+
+  <div class="flex-1 pl-2 m:pl-4">
+    <a href="<%= favoritable.path %>" class="flex crayons-link">
+      <h2 class="fs-base lh-tight m:fs-l fw-bold break-word">
+        <% if favoritable.is_a?(Comment) %>
+          <%= t("views.leadership.curation.comment_on", title: favoritable.commentable&.title) %>
+        <% else %>
+          <%= favoritable.title %>
+        <% end %>
+      </h2>
+    </a>
+    <p class="fs-s">
+      <a href="/<%= favoritable.user.username %>" class="crayons-link fw-medium"><%= favoritable.user.name %></a>
+      <span class="color-base-30"> • </span>
+      <span class="color-base-60"><%= favoritable.readable_publish_date %></span>
+    </p>
+  </div>
+
+  <%# The icon keeps its own colours (native), and its gem is drawn in
+      currentColor, so the favorite colour is set here. %>
+  <div class="m:self-center" style="color: var(--reaction-favorite-color);">
+    <%= crayons_icon_tag("favorite-checked", native: true, title: t("favorites.favorited_by_you")) %>
+  </div>
+</article>

--- a/app/views/leadership_dashboards/_nav_menu.html.erb
+++ b/app/views/leadership_dashboards/_nav_menu.html.erb
@@ -1,0 +1,33 @@
+<% sections = [
+     ["curation", leadership_path],
+     ["discussion", leadership_section_path(:discussion)],
+   ] %>
+
+<nav class="hidden m:block" aria-label="<%= t("views.leadership.nav.aria_label") %>">
+  <% sections.each do |section, path| %>
+    <a
+      class="crayons-link crayons-link--block <%= "crayons-link--current" if @section == section %>"
+      href="<%= path %>"
+      aria-current="<%= "page" if @section == section %>">
+      <%= t("views.leadership.#{section}.heading") %>
+    </a>
+  <% end %>
+</nav>
+
+<nav class="block m:hidden px-3" aria-label="<%= t("views.leadership.nav.aria_label") %>">
+  <div class="crayons-tabs">
+    <ul class="crayons-tabs__list">
+      <% sections.each do |section, path| %>
+        <li>
+          <a
+            data-text="<%= t("views.leadership.#{section}.heading") %>"
+            class="crayons-tabs__item <%= "crayons-tabs__item--current" if @section == section %>"
+            href="<%= path %>"
+            aria-current="<%= "page" if @section == section %>">
+            <%= t("views.leadership.#{section}.heading") %>
+          </a>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</nav>

--- a/app/views/leadership_dashboards/show.html.erb
+++ b/app/views/leadership_dashboards/show.html.erb
@@ -1,0 +1,16 @@
+<% title t("views.leadership.heading") %>
+<main id="main-content">
+  <div class="crayons-layout crayons-layout--header-inside crayons-layout--limited-l crayons-layout--2-cols">
+    <header class="crayons-page-header">
+      <h1 class="crayons-title"><%= t("views.leadership.heading") %></h1>
+    </header>
+
+    <div class="crayons-layout__sidebar-left">
+      <%= render "nav_menu" %>
+    </div>
+
+    <div class="crayons-layout__content">
+      <%= render partial: @section %>
+    </div>
+  </div>
+</main>

--- a/config/locales/controllers/admin/en.yml
+++ b/config/locales/controllers/admin/en.yml
@@ -40,6 +40,9 @@ en:
       saved: Article saved!
       pinned: Article Pinned!
       unpinned: Article Unpinned!
+      favorite_removed: Favorite removed.
+    comments_controller:
+      favorite_removed: Favorite removed.
     badge_achievements_controller:
       deleted: Badge achievement has been deleted!
       rewarded: Badges are being rewarded. The task will finish shortly.

--- a/config/locales/controllers/admin/fr.yml
+++ b/config/locales/controllers/admin/fr.yml
@@ -40,6 +40,9 @@ fr:
       saved: Article sauvegardé !
       pinned: Article épinglé !
       unpinned: Article désépinglé !
+      favorite_removed: Favori supprimé.
+    comments_controller:
+      favorite_removed: Favori supprimé.
     badge_achievements_controller:
       deleted: La réalisation du badge a été supprimée !
       rewarded: Les badges sont en train d'être récompensés. La tâche sera bientôt terminée.

--- a/config/locales/controllers/admin/pt.yml
+++ b/config/locales/controllers/admin/pt.yml
@@ -5,6 +5,9 @@ pt:
       saved: Artigo salvo!
       pinned: Artigo Fixado!
       unpinned: Artigo Desfixado!
+      favorite_removed: Favorito removido.
+    comments_controller:
+      favorite_removed: Favorito removido.
     badge_achievements_controller:
       deleted: Conquista de badge foi excluída!
       rewarded: Badges estão sendo recompensados. A tarefa terminará em breve.

--- a/config/locales/views/admin/en.yml
+++ b/config/locales/views/admin/en.yml
@@ -562,6 +562,17 @@ en:
             enable: Enable Dofollow
             disable: Disable Dofollow
             enabled_notice: Dofollow links are enabled for this organization's readme page.
+      favorites:
+        leaderboard:
+          heading: Impact Leaderboard
+          description: User ranking by downstream engagement of their favorite content.
+          empty: No favorite content yet.
+          rank: Rank
+          leader: Leader
+          favorites: Favorites
+          articles: Articles
+          comments: Comments
+          impact: Impact
       org_features:
         heading: Org Features
         description: Manage organization feature flags globally or per-organization.

--- a/config/locales/views/admin/fr.yml
+++ b/config/locales/views/admin/fr.yml
@@ -551,6 +551,17 @@ fr:
             enable: Activer Dofollow
             disable: Désactiver Dofollow
             enabled_notice: Les liens dofollow sont activés pour la page readme de cette organisation.
+      favorites:
+        leaderboard:
+          heading: Classement d'impact
+          description: Classement des utilisateurs selon l'engagement généré par leurs contenus mis en favori.
+          empty: Aucun contenu en favori pour le moment.
+          rank: Rang
+          leader: Leader
+          favorites: Favoris
+          articles: Articles
+          comments: Commentaires
+          impact: Impact
       org_features:
         heading: Fonctionnalités Org
         description: Gérer les fonctionnalités des organisations globalement ou par organisation.

--- a/config/locales/views/admin/pt.yml
+++ b/config/locales/views/admin/pt.yml
@@ -448,6 +448,17 @@ pt:
             enable: Habilitar Dofollow
             disable: Desabilitar Dofollow
             enabled_notice: Links dofollow estão habilitados para a página readme desta organização.
+      favorites:
+        leaderboard:
+          heading: Ranking de impacto
+          description: Classificação de usuários pelo engajamento gerado por seus conteúdos favoritados.
+          empty: Nenhum conteúdo favoritado ainda.
+          rank: Posição
+          leader: Líder
+          favorites: Favoritos
+          articles: Artigos
+          comments: Comentários
+          impact: Impacto
       org_features:
         heading: Funcionalidades Org
         description: Gerencie as funcionalidades das organizações globalmente ou por organização.

--- a/config/locales/views/leadership/en.yml
+++ b/config/locales/views/leadership/en.yml
@@ -1,0 +1,17 @@
+---
+en:
+  views:
+    leadership:
+      heading: Community Leadership
+      nav:
+        aria_label: Sections
+      curation:
+        heading: Curation
+        allowance: "You have %{remaining} favorites remaining."
+        comment_on: Comment on “%{title}”
+        empty: You haven't favorited any content yet.
+      discussion:
+        heading: Further the Discussion
+        subtitle: Spark engagement by joining the discussion.
+        cta: Comment
+        empty: No posts to recommend.

--- a/config/locales/views/leadership/fr.yml
+++ b/config/locales/views/leadership/fr.yml
@@ -1,0 +1,17 @@
+---
+fr:
+  views:
+    leadership:
+      heading: Leadership communautaire
+      nav:
+        aria_label: Sections
+      curation:
+        heading: Curation
+        allowance: "Il vous reste %{remaining} favoris."
+        comment_on: Commentaire sur « %{title} »
+        empty: Vous n'avez encore mis aucun contenu en favori.
+      discussion:
+        heading: Approfondir la discussion
+        subtitle: Suscitez l'engagement en participant à la discussion.
+        cta: Commenter
+        empty: Aucun article à recommander.

--- a/config/locales/views/leadership/pt.yml
+++ b/config/locales/views/leadership/pt.yml
@@ -1,0 +1,17 @@
+---
+pt:
+  views:
+    leadership:
+      heading: Liderança Comunitária
+      nav:
+        aria_label: Seções
+      curation:
+        heading: Curadoria
+        allowance: "Você tem %{remaining} favoritos restantes."
+        comment_on: Comentário em “%{title}”
+        empty: Você ainda não favoritou nenhum conteúdo.
+      discussion:
+        heading: Aprofundar a Discussão
+        subtitle: Estimule o engajamento participando da discussão.
+        cta: Comentar
+        empty: Nenhum post para recomendar.

--- a/config/locales/views/main/en.yml
+++ b/config/locales/views/main/en.yml
@@ -33,6 +33,7 @@ en:
         placeholder: "..."
         list: Reading list
         moderator_center: Moderator Center
+        leadership: Community Leadership
         other: Other
         settings: Settings
         account: Account

--- a/config/locales/views/main/fr.yml
+++ b/config/locales/views/main/fr.yml
@@ -32,6 +32,7 @@ fr:
         placeholder: "..."
         list: Liste de lecture
         moderator_center: Centre de modération
+        leadership: Leadership communautaire
         other: Other
         settings: Paramètres
         account: Compte

--- a/config/locales/views/main/pt.yml
+++ b/config/locales/views/main/pt.yml
@@ -32,6 +32,7 @@ pt:
         placeholder: "..."
         list: Lista de leitura
         moderator_center: Centro de Moderação
+        leadership: Liderança Comunitária
         other: Outros
         settings: Configurações
         account: Conta

--- a/config/locales/views/moderations/en.yml
+++ b/config/locales/views/moderations/en.yml
@@ -160,6 +160,8 @@ en:
         set_to_min_indexing: Set to min indexing
         edit: Edit
         featured: Featured
+        favorited_by: Favorited by
+        unfavorite: Unfavorite
         likes: likes
         notes:
           user_notes: user notes

--- a/config/locales/views/moderations/fr.yml
+++ b/config/locales/views/moderations/fr.yml
@@ -159,6 +159,8 @@ fr:
         set_to_min_indexing: Définir sur l'indexation minimale
         edit: Modifier
         featured: Mis en exergue
+        favorited_by: Mis en favori par
+        unfavorite: Retirer des favoris
         likes: aime
         notes:
           user_notes: notes d'utilisateur

--- a/config/locales/views/moderations/pt.yml
+++ b/config/locales/views/moderations/pt.yml
@@ -160,6 +160,8 @@ pt:
         set_to_min_indexing: Definir para a indexação mínima
         edit: Edit
         featured: Featured
+        favorited_by: Favoritado por
+        unfavorite: Desfavoritar
         likes: likes
         notes:
           user_notes: user notes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -519,6 +519,9 @@ Rails.application.routes.draw do
                                      }
     get "/dashboard/:username", to: "dashboards#show", as: :dashboard_show_user
 
+    get "/leadership", to: "leadership_dashboards#show", as: :leadership
+    get "/leadership/:section", to: "leadership_dashboards#show", as: :leadership_section
+
     unless Rails.env.production?
       get "/rails/mailers", to: "rails/mailers#index"
       get "/rails/mailers/*path", to: "rails/mailers#preview"

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -84,6 +84,8 @@ namespace :admin do
 
     resources :bulk_assign_role, only: %i[index]
     post "/bulk_assign_role", to: "bulk_assign_role#assign_role"
+
+    resources :favorites, only: %i[index]
   end
 
   scope :content_manager do

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -92,6 +92,7 @@ namespace :admin do
       member do
         delete :unpin
         post :pin
+        delete :unfavorite
       end
     end
 
@@ -105,7 +106,11 @@ namespace :admin do
     resources :badge_achievements, only: %i[index destroy]
     get "/badge_achievements/award_badges", to: "badge_achievements#award"
     post "/badge_achievements/award_badges", to: "badge_achievements#award_badges"
-    resources :comments, only: %i[index show]
+    resources :comments, only: %i[index show] do
+      member do
+        delete :unfavorite
+      end
+    end
     resources :organizations, only: %i[index show destroy] do
       member do
         patch "update_org_credits"

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -77,7 +77,8 @@ RSpec.describe UserDecorator, type: :decorator do
       expected_result = %W[
         light-theme sans-serif-article-body
         mod-status-#{user.admin? || !user.moderator_for_tags.empty?}
-        trusted-status-#{user.trusted?} #{user.setting.config_navbar}-header
+        trusted-status-#{user.trusted?} community-leader-status-#{user.community_leader?}
+        #{user.setting.config_navbar}-header
       ].join(" ")
       expect(user.decorate.config_body_class).to eq(expected_result)
     end
@@ -87,7 +88,8 @@ RSpec.describe UserDecorator, type: :decorator do
       expected_result = %W[
         light-theme sans-serif-article-body
         mod-status-#{user.admin? || !user.moderator_for_tags.empty?}
-        trusted-status-#{user.trusted?} #{user.setting.config_navbar}-header
+        trusted-status-#{user.trusted?} community-leader-status-#{user.community_leader?}
+        #{user.setting.config_navbar}-header
         user-role--tag_moderator
       ].join(" ")
       expect(user.decorate.config_body_class).to eq(expected_result)
@@ -98,7 +100,8 @@ RSpec.describe UserDecorator, type: :decorator do
       expected_result = %W[
         light-theme sans-serif-article-body
         mod-status-#{user.admin? || !user.moderator_for_tags.empty?}
-        trusted-status-#{user.trusted?} #{user.setting.config_navbar}-header
+        trusted-status-#{user.trusted?} community-leader-status-#{user.community_leader?}
+        #{user.setting.config_navbar}-header
       ].join(" ")
       expect(user.decorate.config_body_class).to eq(expected_result)
     end
@@ -108,7 +111,8 @@ RSpec.describe UserDecorator, type: :decorator do
       expected_result = %W[
         dark-theme sans-serif-article-body
         mod-status-#{user.admin? || !user.moderator_for_tags.empty?}
-        trusted-status-#{user.trusted?} #{user.setting.config_navbar}-header
+        trusted-status-#{user.trusted?} community-leader-status-#{user.community_leader?}
+        #{user.setting.config_navbar}-header
         ten-x-hacker-theme
       ].join(" ")
       expect(user.decorate.config_body_class).to eq(expected_result)
@@ -119,7 +123,8 @@ RSpec.describe UserDecorator, type: :decorator do
       expected_result = %W[
         light-theme sans-serif-article-body
         mod-status-#{user.admin? || !user.moderator_for_tags.empty?}
-        trusted-status-#{user.trusted?} static-header
+        trusted-status-#{user.trusted?} community-leader-status-#{user.community_leader?}
+        static-header
       ].join(" ")
       expect(user.decorate.config_body_class).to eq(expected_result)
     end
@@ -132,7 +137,7 @@ RSpec.describe UserDecorator, type: :decorator do
 
         expected_result = %w[
           light-theme sans-serif-article-body mod-status-false
-          trusted-status-true default-header user-role--trusted
+          trusted-status-true community-leader-status-false default-header user-role--trusted
         ].join(" ")
         expect(user.decorate.config_body_class).to eq(expected_result)
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1006,36 +1006,48 @@ RSpec.describe User do
     end
 
     it "creates proper body class with defaults" do
-      # rubocop:disable Layout/LineLength
-      classes = "light-theme sans-serif-article-body mod-status-#{user.admin? || !user.moderator_for_tags.empty?} trusted-status-#{user.trusted?} #{user.setting.config_navbar}-header"
-      # rubocop:enable Layout/LineLength
+      classes = %W[
+        light-theme sans-serif-article-body
+        mod-status-#{user.admin? || !user.moderator_for_tags.empty?}
+        trusted-status-#{user.trusted?} community-leader-status-#{user.community_leader?}
+        #{user.setting.config_navbar}-header
+      ].join(" ")
       expect(user.decorate.config_body_class).to eq(classes)
     end
 
     it "creates proper body class with sans serif config" do
       user.setting.config_font = "sans_serif"
 
-      # rubocop:disable Layout/LineLength
-      classes = "light-theme sans-serif-article-body mod-status-#{user.admin? || !user.moderator_for_tags.empty?} trusted-status-#{user.trusted?} #{user.setting.config_navbar}-header"
-      # rubocop:enable Layout/LineLength
+      classes = %W[
+        light-theme sans-serif-article-body
+        mod-status-#{user.admin? || !user.moderator_for_tags.empty?}
+        trusted-status-#{user.trusted?} community-leader-status-#{user.community_leader?}
+        #{user.setting.config_navbar}-header
+      ].join(" ")
       expect(user.decorate.config_body_class).to eq(classes)
     end
 
     it "creates proper body class with open dyslexic config" do
       user.setting.config_font = "open_dyslexic"
 
-      # rubocop:disable Layout/LineLength
-      classes = "light-theme open-dyslexic-article-body mod-status-#{user.admin? || !user.moderator_for_tags.empty?} trusted-status-#{user.trusted?} #{user.setting.config_navbar}-header"
-      # rubocop:enable Layout/LineLength
+      classes = %W[
+        light-theme open-dyslexic-article-body
+        mod-status-#{user.admin? || !user.moderator_for_tags.empty?}
+        trusted-status-#{user.trusted?} community-leader-status-#{user.community_leader?}
+        #{user.setting.config_navbar}-header
+      ].join(" ")
       expect(user.decorate.config_body_class).to eq(classes)
     end
 
     it "creates proper body class with dark theme" do
       user.setting.config_theme = "dark_theme"
 
-      # rubocop:disable Layout/LineLength
-      classes = "dark-theme sans-serif-article-body mod-status-#{user.admin? || !user.moderator_for_tags.empty?} trusted-status-#{user.trusted?} #{user.setting.config_navbar}-header ten-x-hacker-theme"
-      # rubocop:enable Layout/LineLength
+      classes = %W[
+        dark-theme sans-serif-article-body
+        mod-status-#{user.admin? || !user.moderator_for_tags.empty?}
+        trusted-status-#{user.trusted?} community-leader-status-#{user.community_leader?}
+        #{user.setting.config_navbar}-header ten-x-hacker-theme
+      ].join(" ")
       expect(user.decorate.config_body_class).to eq(classes)
     end
   end

--- a/spec/requests/admin/favorites_spec.rb
+++ b/spec/requests/admin/favorites_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+require "requests/shared_examples/internal_policy_dependant_request"
+
+RSpec.describe "/admin/favorites" do
+  # The page is user/role data, so it authorizes against User.
+  it_behaves_like "an InternalPolicy dependant request", User do
+    let(:request) { get admin_favorites_path }
+  end
+
+  describe "GET /admin/favorites" do
+    let(:admin) { create(:user, :super_admin) }
+    let(:leader) { create(:user) }
+
+    before do
+      Rails.cache.clear
+      sign_in admin
+    end
+
+    it "renders the impact leaderboard for a leader with favorited content" do
+      article = create(:article)
+      article.update_columns(favorited_by_user_id: leader.id, favorited_at: Time.current, page_views_count: 7)
+
+      get admin_favorites_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(leader.username)
+    end
+
+    it "renders the empty state when nothing has been favorited" do
+      get admin_favorites_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(I18n.t("views.admin.favorites.leaderboard.empty"))
+    end
+  end
+end

--- a/spec/requests/admin/favorites_unfavorite_spec.rb
+++ b/spec/requests/admin/favorites_unfavorite_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "Admin un-favorite" do
+  let(:admin) { create(:user, :admin) }
+  let(:leader) { create(:user, :community_leader_level_1) }
+
+  before { sign_in admin }
+
+  describe "DELETE /admin/content_manager/articles/:id/unfavorite" do
+    it "clears the favorite and redirects" do
+      article = create(:article, favorited_by_user: leader, favorited_at: Time.current)
+
+      delete unfavorite_admin_article_path(article.id)
+
+      expect(response).to redirect_to(admin_article_path(article.id))
+      expect(article.reload.favorited_by_user_id).to be_nil
+    end
+  end
+
+  describe "DELETE /admin/content_manager/comments/:id/unfavorite" do
+    it "clears the favorite and redirects" do
+      comment = create(:comment, favorited_by_user: leader, favorited_at: Time.current)
+
+      delete unfavorite_admin_comment_path(comment.id)
+
+      expect(response).to redirect_to(admin_comment_path(comment.id))
+      expect(comment.reload.favorited_by_user_id).to be_nil
+    end
+  end
+
+  context "when the requester is not an admin" do
+    it "is not authorized" do
+      sign_in create(:user)
+      article = create(:article, favorited_by_user: leader, favorited_at: Time.current)
+
+      expect { delete unfavorite_admin_article_path(article.id) }.to raise_error(Pundit::NotAuthorizedError)
+      expect(article.reload.favorited_by_user_id).to eq(leader.id)
+    end
+  end
+end

--- a/spec/requests/leadership_dashboards_spec.rb
+++ b/spec/requests/leadership_dashboards_spec.rb
@@ -1,0 +1,102 @@
+require "rails_helper"
+
+RSpec.describe "Leadership dashboard" do
+  let(:leader) { create(:user, :community_leader_level_1) }
+
+  describe "GET /leadership" do
+    context "when signed in as a community leader" do
+      before { sign_in leader }
+
+      it "defaults to the curation section and shows both section links" do
+        get leadership_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(I18n.t("views.leadership.curation.heading"))
+        expect(response.body).to include(I18n.t("views.leadership.discussion.heading"))
+      end
+
+      it "renders the section nav for both viewports and marks the current section" do
+        get leadership_section_path("discussion")
+
+        page = Capybara.string(response.body)
+
+        # Stacked links on wide viewports, tabs on narrow ones.
+        expect(page).to have_css("nav.m\\:block a.crayons-link--block", count: 2)
+        expect(page).to have_css("nav.m\\:hidden a.crayons-tabs__item", count: 2)
+
+        current = page.all("[aria-current='page']").map { |link| link.text.strip }.uniq
+        expect(current).to eq([I18n.t("views.leadership.discussion.heading")])
+      end
+
+      it "shows the leader's favorited content in the curation section" do
+        favorited = create(:article)
+        favorited.update_columns(favorited_by_user_id: leader.id, favorited_at: Time.current)
+
+        get leadership_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(favorited.title)
+        expect(response.body).to include(CGI.escapeHTML(favorited.user.name))
+      end
+
+      it "shows favorited comments alongside favorited posts" do
+        commented_on = create(:article)
+        comment = create(:comment, commentable: commented_on)
+        comment.update_columns(favorited_by_user_id: leader.id, favorited_at: Time.current)
+
+        get leadership_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(CGI.escapeHTML(comment.user.name))
+      end
+
+      it "renders the suggested discussion feed" do
+        surfaced = create(:article, user: create(:user))
+        surfaced.update_columns(score: 100, comments_count: 0)
+
+        get leadership_section_path("discussion")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(surfaced.title)
+        expect(response.body).to include(CGI.escapeHTML(surfaced.cached_user.name))
+        expect(response.body).to include(I18n.t("views.leadership.discussion.cta"))
+      end
+
+      it "excludes the leader's own posts from the discussion feed" do
+        own = create(:article, user: leader)
+        own.update_columns(score: 100, comments_count: 0)
+
+        get leadership_section_path("discussion")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include(own.title)
+      end
+
+      it "accepts pagination params on each section" do
+        get leadership_path(page: 2)
+        expect(response).to have_http_status(:ok)
+
+        get leadership_section_path("discussion", page: 2)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when signed in as a non-leader" do
+      it "returns 404" do
+        sign_in create(:user)
+
+        get leadership_path
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when signed out" do
+      it "does not render the dashboard" do
+        get leadership_path
+
+        expect(response).not_to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/services/articles/feeds/engagement_candidates_spec.rb
+++ b/spec/services/articles/feeds/engagement_candidates_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe Articles::Feeds::EngagementCandidates, type: :service do
+  subject(:feed) { described_class.call(exclude_author: user) }
+
+  let(:user) { create(:user) }
+  let(:minimum_score) { Settings::UserExperience.home_feed_minimum_score }
+
+  it "includes high-quality, under-discussed published posts" do
+    article = create(:article, published: true, score: minimum_score + 10)
+
+    expect(feed).to include(article)
+  end
+
+  it "excludes posts below the minimum score" do
+    low = create(:article, published: true, score: minimum_score - 1)
+
+    expect(feed).not_to include(low)
+  end
+
+  it "excludes posts with more than 5 comments" do
+    busy = create(:article, published: true, score: minimum_score + 10)
+    busy.update_column(:comments_count, 6)
+
+    expect(feed).not_to include(busy)
+  end
+
+  it "excludes unpublished posts" do
+    draft = create(:article, published: false, score: minimum_score + 10)
+
+    expect(feed).not_to include(draft)
+  end
+
+  it "excludes the posts of the user given as exclude_author" do
+    own = create(:article, user: user, published: true, score: minimum_score + 10)
+
+    expect(feed).not_to include(own)
+  end
+
+  it "orders by score, highest first" do
+    lower = create(:article, published: true, score: minimum_score + 1)
+    higher = create(:article, published: true, score: minimum_score + 100)
+
+    expect(feed.to_a.index(higher)).to be < feed.to_a.index(lower)
+  end
+end

--- a/spec/services/favorites/fetch_spec.rb
+++ b/spec/services/favorites/fetch_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe Favorites::Fetch, type: :service do
+  let(:leader) { create(:user) }
+  let(:other_leader) { create(:user) }
+
+  def favorite(favoritable, user, favorited_at)
+    favoritable.update_columns(favorited_by_user_id: user.id, favorited_at: favorited_at)
+    favoritable
+  end
+
+  context "when scoped to a user" do
+    it "returns that user's favorited articles and comments" do
+      article = favorite(create(:article), leader, 1.hour.ago)
+      comment = favorite(create(:comment, commentable: create(:article)), leader, 2.hours.ago)
+
+      expect(described_class.call(user: leader)).to eq([article, comment])
+    end
+
+    it "excludes favorites claimed by other users" do
+      favorite(create(:article), other_leader, 1.hour.ago)
+
+      expect(described_class.call(user: leader)).to be_empty
+    end
+
+    it "excludes unfavorited content" do
+      create(:article)
+      create(:comment, commentable: create(:article))
+
+      expect(described_class.call(user: leader)).to be_empty
+    end
+
+    it "orders by favorited_at, newest first" do
+      older = favorite(create(:article), leader, 3.days.ago)
+      newer = favorite(create(:article), leader, 1.day.ago)
+
+      expect(described_class.call(user: leader)).to eq([newer, older])
+    end
+  end
+
+  context "without a user" do
+    it "returns favorites claimed by any user" do
+      article = favorite(create(:article), leader, 1.hour.ago)
+      comment = favorite(create(:comment, commentable: create(:article)), other_leader, 2.hours.ago)
+
+      expect(described_class.call).to eq([article, comment])
+    end
+
+    it "excludes unfavorited content" do
+      create(:article)
+      create(:comment, commentable: create(:article))
+
+      expect(described_class.call).to be_empty
+    end
+  end
+
+  describe "pagination" do
+    it "returns only the requested page" do
+      newer = favorite(create(:article), leader, 1.day.ago)
+      older = favorite(create(:article), leader, 2.days.ago)
+
+      expect(described_class.call(user: leader, page: 1, per_page: 1)).to eq([newer])
+      expect(described_class.call(user: leader, page: 2, per_page: 1)).to eq([older])
+    end
+
+    it "reports the total count across both types" do
+      favorite(create(:article), leader, 1.day.ago)
+      favorite(create(:comment, commentable: create(:article)), leader, 2.days.ago)
+
+      result = described_class.call(user: leader, page: 1, per_page: 1)
+
+      expect(result.total_count).to eq(2)
+      expect(result.total_pages).to eq(2)
+      expect(result.current_page).to eq(1)
+    end
+
+    it "treats a nil page as the first page" do
+      article = favorite(create(:article), leader, 1.day.ago)
+
+      expect(described_class.call(user: leader, page: nil)).to eq([article])
+    end
+  end
+end

--- a/spec/services/favorites/impact_data_spec.rb
+++ b/spec/services/favorites/impact_data_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe Favorites::ImpactData, type: :service do
+  let(:user_a) { create(:user) }
+  let(:user_b) { create(:user) }
+
+  def favorite_article(user, comments_count: 0, public_reactions_count: 0, page_views_count: 0)
+    create(:article).tap do |article|
+      article.update_columns(
+        favorited_by_user_id: user.id, favorited_at: Time.current,
+        comments_count: comments_count, public_reactions_count: public_reactions_count,
+        page_views_count: page_views_count
+      )
+    end
+  end
+
+  def favorite_comment(user, public_reactions_count: 0)
+    create(:comment).tap do |comment|
+      comment.update_columns(
+        favorited_by_user_id: user.id, favorited_at: Time.current,
+        public_reactions_count: public_reactions_count
+      )
+    end
+  end
+
+  it "returns an empty ranking when nothing is favorited" do
+    expect(described_class.call).to eq([])
+  end
+
+  it "scores article impact as comments + reactions + views" do
+    favorite_article(user_a, comments_count: 3, public_reactions_count: 5, page_views_count: 10)
+
+    row = described_class.call.first
+
+    expect(row.user).to eq(user_a)
+    expect(row.impact_score).to eq(18)
+    expect(row.article_favorites_count).to eq(1)
+    expect(row.comment_favorites_count).to eq(0)
+    expect(row.favorites_count).to eq(1)
+  end
+
+  it "scores comment impact from reactions only" do
+    favorite_comment(user_a, public_reactions_count: 4)
+
+    row = described_class.call.first
+
+    expect(row.impact_score).to eq(4)
+    expect(row.comment_favorites_count).to eq(1)
+  end
+
+  it "combines a user's article and comment favorites" do
+    favorite_article(user_a, comments_count: 1, public_reactions_count: 1, page_views_count: 1)
+    favorite_comment(user_a, public_reactions_count: 2)
+
+    row = described_class.call.first
+
+    expect(row.impact_score).to eq(5)
+    expect(row.favorites_count).to eq(2)
+    expect(row.article_favorites_count).to eq(1)
+    expect(row.comment_favorites_count).to eq(1)
+  end
+
+  it "ranks users by descending impact" do
+    favorite_article(user_a, page_views_count: 100)
+    favorite_article(user_b, page_views_count: 5)
+
+    expect(described_class.call.map(&:user)).to eq([user_a, user_b])
+  end
+
+  it "honors the limit" do
+    favorite_article(user_a, page_views_count: 20)
+    favorite_article(user_b, page_views_count: 10)
+
+    expect(described_class.call(limit: 1).map(&:user)).to eq([user_a])
+  end
+end

--- a/spec/services/favorites/remove_spec.rb
+++ b/spec/services/favorites/remove_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe Favorites::Remove, type: :service do
+  let(:admin) { create(:user, :admin) }
+  let(:leader) { create(:user, :community_leader_level_1) }
+
+  it "clears the favorite from an article" do
+    article = create(:article, favorited_by_user: leader, favorited_at: Time.current)
+
+    result = described_class.call(favoritable: article, admin: admin)
+
+    expect(result.success?).to be true
+    expect(article.reload.favorited_by_user_id).to be_nil
+    expect(article.favorited_at).to be_nil
+  end
+
+  it "clears the favorite from a comment" do
+    comment = create(:comment, favorited_by_user: leader, favorited_at: Time.current)
+
+    described_class.call(favoritable: comment, admin: admin)
+
+    expect(comment.reload.favorited_by_user_id).to be_nil
+  end
+
+  it "audit-logs the removal" do
+    article = create(:article, favorited_by_user: leader, favorited_at: Time.current)
+    allow(Audit::Logger).to receive(:log).and_call_original
+
+    described_class.call(favoritable: article, admin: admin)
+
+    expect(Audit::Logger).to have_received(:log).with(
+      :moderator, admin, hash_including("action" => "unfavorite", "previous_favoriter_id" => leader.id)
+    )
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

### Phase 2 scope: Admin review and leadership dashboard for community leaders

* Admin review
  * Impact leaderboard showing downstream engagement on each leader's favorited content over
  * Allow admins to unfavorite content

* Leadership dashboard
  * Curation section showing favorite allowance and history
  * Further the Discussion section suggesting high-quality articles for engagement

Implementation notes
* Phase 2 changes are visible to community leaders and admins
* Content Manager Posts and Comments sections have been updated to indicate when content is favorited and let admins unfavorite
* Admins can also review favorite actions the audit log for a user
* Added nav link to Leadership dashboard, visible to community leaders only
* The Leadership dashboard 404s for non-community leaders for now
* The Curation section has a unified view of historical favorited posts and comments ordered by `favorited_at desc`
* Both the Curation and Discussion section are paged

## Related Tickets & Documents

https://mlhacks.atlassian.net/browse/DEV-4052

## QA Instructions, Screenshots, Recordings

Admin Content Manager indicates favorites and shows unfavorite button
<img width="1386" height="650" alt="Screenshot 2026-08-07 at 8 24 10 PM" src="https://github.com/user-attachments/assets/16b0a6b1-955c-4495-b759-a873139f7b27" />
<img width="1393" height="505" alt="Screenshot 2026-08-07 at 8 26 35 PM" src="https://github.com/user-attachments/assets/ed1c9505-0386-42db-ba6e-33e0c0c78c3f" />

Admin favorite impact leaderboard
<img width="1403" height="495" alt="Screenshot 2026-08-07 at 8 29 28 PM" src="https://github.com/user-attachments/assets/830b0020-fa97-441f-bec7-458d22e0cb1c" />

Audit log shows favorite actions
<img width="1108" height="829" alt="Screenshot 2026-08-07 at 8 39 19 PM" src="https://github.com/user-attachments/assets/5b9f8668-68e4-4c2d-8921-53636f4809aa" />

Community Leadership (`/leaderboard`)
<img width="1091" height="588" alt="Screenshot 2026-08-07 at 9 07 36 PM" src="https://github.com/user-attachments/assets/1e3d77ba-022f-4c12-ae49-b0f31889bf25" />
<img width="1091" height="588" alt="Screenshot 2026-08-07 at 9 07 45 PM" src="https://github.com/user-attachments/assets/edab9f15-ce87-4fca-803e-ea586978b309" />

Nav link
<img width="330" height="495" alt="Screenshot 2026-08-07 at 9 08 29 PM" src="https://github.com/user-attachments/assets/8bdd08bc-5176-4801-8ec4-7e8cbe551ee0" />


### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [x] Semantic HTML implemented?
- [x] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788707541&installation_model_id=424141&pr_number=23704&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23704&signature=eeacc8e487a9d3247a2940d4b337cad1ebdf5a60e43c983e05fd93d850376a0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->