### PR TITLE
Remove email from Person JSON-LD schema to prevent structured PII indexing (#23696)

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -515,7 +515,6 @@ class StoriesController < ApplicationController
       sameAs: user_same_as,
       image: @user.profile_image_url_for(length: 320),
       name: @user.name,
-      email: decorated_user.profile_email,
       description: decorated_user.profile_summary
     }.compact_blank
   end

--- a/spec/requests/user/user_show_spec.rb
+++ b/spec/requests/user/user_show_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "UserShow" do
       )
     end
 
-    it "does not include email in JSON-LD structured data regardless of display_email_on_profile" do
+    it "does not include email in JSON-LD structured data even when display_email_on_profile is enabled" do
       user.setting.update(display_email_on_profile: true)
       get user.path
       text = Nokogiri::HTML(response.body).at('script[type="application/ld+json"]').text

--- a/spec/requests/user/user_show_spec.rb
+++ b/spec/requests/user/user_show_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe "UserShow" do
     end
 
     it "renders the proper JSON-LD for a user" do
-      user.setting.update(display_email_on_profile: true)
       get user.path
       text = Nokogiri::HTML(response.body).at('script[type="application/ld+json"]').text
       response_json = JSON.parse(text)
@@ -41,9 +40,16 @@ RSpec.describe "UserShow" do
         ],
         "image" => user.profile_image_url_for(length: 320),
         "name" => user.name,
-        "email" => user.email,
         "description" => user.tag_line,
       )
+    end
+
+    it "does not include email in JSON-LD structured data regardless of display_email_on_profile" do
+      user.setting.update(display_email_on_profile: true)
+      get user.path
+      text = Nokogiri::HTML(response.body).at('script[type="application/ld+json"]').text
+      response_json = JSON.parse(text)
+      expect(response_json.key?("email")).to be(false)
     end
 
     it "includes a subscription icon if user is subscribed" do


### PR DESCRIPTION


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Profile pages embed a `<script type="application/ld+json">` block in the HTML `<head>` using the Schema.org `Person` type. When a user has `display_email_on_profile` set to `true`, this block currently includes:

```json
{
  "@type": "Person",
  "email": "user@example.com",
  ...
}
```

Googlebot parses this block and stores the `email` value in Google's search index, associated with the profile URL. This is the direct cause of the experience reported in #23696: Google's **"Results About You"** privacy monitoring service scans Google's index for registered personal identifiers and alerts users when it finds their email address in indexed structured data.

The `email` property in Schema.org's `Person` type provides no SEO benefit — it does not improve profile page ranking or discoverability. Profile indexing is driven by `name`, `description`, `url`, `sameAs`, and `image`. Removing `email` from the JSON-LD output has no effect on how profiles appear in or rank in search results.

This PR removes the `email` field from the `Person` JSON-LD schema in `set_user_json_ld`. The email address set via `display_email_on_profile` remains visible in the profile page HTML for human visitors.

**Changes:**
- Removed `email: decorated_user.profile_email` from the `@user_json_ld` hash in `app/controllers/stories_controller.rb`.
- Updated `spec/requests/user/user_show_spec.rb` to remove the previous assertion that `email` was present in JSON-LD output, and added an explicit regression test asserting `email` is absent from the structured data block regardless of `display_email_on_profile` setting.

**Out of scope / follow-up:**
- The email address in the profile page HTML (`mailto:` link) is still publicly visible to all visitors and web crawlers reading HTML body content. Gating this behind authentication or applying HTML obfuscation is a separate decision pending discussion.

## Related Tickets & Documents

- Related Issue #23696
- Closes #23696

## Added/updated tests?

- [x] Yes

## [optional] Are there any post deployment tasks we need to perform?

Previously indexed email values from Google's search index, Google would need to re-crawl profile pages after this deploys — this happens automatically over time through Googlebot's regular crawl schedule and any Fastly cache purges triggered by profile updates.