### PR TITLE
Fix layout breakdown in admin content manager articles view

### DIFF
--- a/app/views/admin/articles/_article_item.html.erb
+++ b/app/views/admin/articles/_article_item.html.erb
@@ -188,7 +188,6 @@
             </button>
           </div>
         </div>
-        </div>
       </div>
       <% if article.context_notes.any? %>
         <div class="flex">
@@ -251,9 +250,9 @@
 
       <nav class="mt-4 pt-1 pb-2 px-3 member-data-heading" aria-label="Member details">
         <ul class="crayons-navigation crayons-navigation--horizontal">
-          <li><%= link_to "Flags", admin_article_path(tab: :flags), class: "crayons-navigation__item #{'crayons-navigation__item crayons-navigation__item--current' if params[:tab] == 'flags' || params[:tab].blank?}", aria: @current_tab == "flags" ? { current: "" } : {} %></li></li>
+          <li><%= link_to "Flags", admin_article_path(tab: :flags), class: "crayons-navigation__item #{'crayons-navigation__item crayons-navigation__item--current' if params[:tab] == 'flags' || params[:tab].blank?}", aria: @current_tab == "flags" ? { current: "" } : {} %></li>
           <li><%= link_to "Quality reactions", admin_article_path(tab: :quality_reactions), class: "crayons-navigation__item #{'crayons-navigation__item crayons-navigation__item--current' if params[:tab] == 'quality_reactions'}",
-                                                                                            aria: @current_tab == "quality_reactions" ? { current: "" } : {} %></li></li>
+                                                                                            aria: @current_tab == "quality_reactions" ? { current: "" } : {} %></li>
         </ul>
       </nav>
 
@@ -280,7 +279,7 @@
             </div>
           <% end %>
         <% end %>
-      <div>
+      </div>
     </article>
   <% end %>
 </div>


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes a layout breakdown on `/admin/content_manager/articles` caused by HTML tag mismatches in `app/views/admin/articles/_article_item.html.erb`. Specifically, an extra closing `</div>` tag prematurely closed the container element during collection rendering, causing subsequent cards to break out of the page layout wrapper.

## Related Tickets & Documents

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

### UI accessibility checklist
- [x] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: View layout fix covered by existing `spec/requests/admin/articles_spec.rb` specs.
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)