### PR TITLE
Fix release failure during concurrent index creation on articles and comments

### DIFF
--- a/db/migrate/20260728100100_add_index_to_articles_favorited_by_user_id.rb
+++ b/db/migrate/20260728100100_add_index_to_articles_favorited_by_user_id.rb
@@ -2,14 +2,25 @@ class AddIndexToArticlesFavoritedByUserId < ActiveRecord::Migration[8.0]
   disable_ddl_transaction!
 
   def up
-    return if index_exists?(:articles, :favorited_by_user_id)
+    safety_assured do
+      db_user = connection.query_value("SELECT current_user")
+      begin
+        execute "ALTER ROLE \"#{db_user}\" SET statement_timeout = 0;"
+        execute "SET statement_timeout = 0;"
 
-    add_index :articles, :favorited_by_user_id, algorithm: :concurrently
+        remove_index :articles, name: "index_articles_on_favorited_by_user_id", if_exists: true,
+                                algorithm: :concurrently
+
+        add_index :articles, :favorited_by_user_id, algorithm: :concurrently
+      ensure
+        execute "ALTER ROLE \"#{db_user}\" RESET statement_timeout;"
+      end
+    end
   end
 
   def down
-    return unless index_exists?(:articles, :favorited_by_user_id)
-
-    remove_index :articles, :favorited_by_user_id, algorithm: :concurrently
+    safety_assured do
+      remove_index :articles, name: "index_articles_on_favorited_by_user_id", if_exists: true, algorithm: :concurrently
+    end
   end
 end

--- a/db/migrate/20260728100400_add_index_to_comments_favorited_by_user_id.rb
+++ b/db/migrate/20260728100400_add_index_to_comments_favorited_by_user_id.rb
@@ -2,14 +2,25 @@ class AddIndexToCommentsFavoritedByUserId < ActiveRecord::Migration[8.0]
   disable_ddl_transaction!
 
   def up
-    return if index_exists?(:comments, :favorited_by_user_id)
+    safety_assured do
+      db_user = connection.query_value("SELECT current_user")
+      begin
+        execute "ALTER ROLE \"#{db_user}\" SET statement_timeout = 0;"
+        execute "SET statement_timeout = 0;"
 
-    add_index :comments, :favorited_by_user_id, algorithm: :concurrently
+        remove_index :comments, name: "index_comments_on_favorited_by_user_id", if_exists: true,
+                                algorithm: :concurrently
+
+        add_index :comments, :favorited_by_user_id, algorithm: :concurrently
+      ensure
+        execute "ALTER ROLE \"#{db_user}\" RESET statement_timeout;"
+      end
+    end
   end
 
   def down
-    return unless index_exists?(:comments, :favorited_by_user_id)
-
-    remove_index :comments, :favorited_by_user_id, algorithm: :concurrently
+    safety_assured do
+      remove_index :comments, name: "index_comments_on_favorited_by_user_id", if_exists: true, algorithm: :concurrently
+    end
   end
 end


### PR DESCRIPTION
## Summary
Fixes a release failure during deploy (`./release-tasks.sh`) caused by `20260728100100_add_index_to_articles_favorited_by_user_id.rb` timing out during concurrent index creation.

## Cause & Solution
1. **Role Statement Timeout**: `CREATE INDEX CONCURRENTLY` on large production tables (`articles` and `comments`) exceeded the PostgreSQL role statement timeout threshold (~20s).
2. **Invalid Index Cleanup**: Timed out concurrent index builds leave behind an `INVALID` index in PostgreSQL, which breaks subsequent migration attempts.
3. **Fix**:
   - Temporarily disable statement timeouts at the role & session level during execution (`ALTER ROLE "#{db_user}" SET statement_timeout = 0;`).
   - Run `remove_index ..., if_exists: true, algorithm: :concurrently` prior to `add_index` to clean up any pre-existing invalid index left behind by a failed deploy.
   - Restores role statement timeout in an `ensure` block.
   - Wrapped in `safety_assured` block for `strong_migrations` compliance.

## Verification
- Verified `bundle exec rubocop` passes with 0 offenses.
- Tested `db:migrate:down` and `db:migrate:up` for both migration versions (`20260728100100` and `20260728100400`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789137263&installation_model_id=424141&pr_number=23712&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23712&signature=79be11822d7830b6cad654c3d62613b39311491b1c6bc283742d10ec8ab5a421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->