### PR TITLE
Disable statement_timeout during index creation on articles and comments

### DIFF
--- a/db/migrate/20260728100100_add_index_to_articles_favorited_by_user_id.rb
+++ b/db/migrate/20260728100100_add_index_to_articles_favorited_by_user_id.rb
@@ -1,6 +1,7 @@
 class AddIndexToArticlesFavoritedByUserId < ActiveRecord::Migration[8.0]
   def up
     safety_assured do
+      execute "SET statement_timeout = 0;"
       remove_index :articles, name: "index_articles_on_favorited_by_user_id", if_exists: true
       add_index :articles, :favorited_by_user_id, if_not_exists: true
     end
@@ -8,6 +9,7 @@ class AddIndexToArticlesFavoritedByUserId < ActiveRecord::Migration[8.0]
 
   def down
     safety_assured do
+      execute "SET statement_timeout = 0;"
       remove_index :articles, name: "index_articles_on_favorited_by_user_id", if_exists: true
     end
   end

--- a/db/migrate/20260728100400_add_index_to_comments_favorited_by_user_id.rb
+++ b/db/migrate/20260728100400_add_index_to_comments_favorited_by_user_id.rb
@@ -1,6 +1,7 @@
 class AddIndexToCommentsFavoritedByUserId < ActiveRecord::Migration[8.0]
   def up
     safety_assured do
+      execute "SET statement_timeout = 0;"
       remove_index :comments, name: "index_comments_on_favorited_by_user_id", if_exists: true
       add_index :comments, :favorited_by_user_id, if_not_exists: true
     end
@@ -8,6 +9,7 @@ class AddIndexToCommentsFavoritedByUserId < ActiveRecord::Migration[8.0]
 
   def down
     safety_assured do
+      execute "SET statement_timeout = 0;"
       remove_index :comments, name: "index_comments_on_favorited_by_user_id", if_exists: true
     end
   end


### PR DESCRIPTION
## Cause & Solution
In production PostgreSQL, session-level database statement timeouts (20 seconds) canceled `add_index :articles, :favorited_by_user_id` while acquiring table locks or scanning the production `articles` table:
```
PG::QueryCanceled: ERROR: canceling statement due to statement timeout
```

This PR adds `execute "SET statement_timeout = 0;"` right inside the migration block (a standard Forem pattern used in existing index migrations like `20250821230000` and `20251119172153`) so PostgreSQL will not abort index creation during deploy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789143962&installation_model_id=424141&pr_number=23714&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23714&signature=171d0c7191eeb07f5568da91f839f24a4553e78ba1da88678b73ac8ee79dd5a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->