### PR TITLE
Use concurrent index creation with SET statement_timeout = 0 on articles and comments

### DIFF
--- a/db/migrate/20260728100100_add_index_to_articles_favorited_by_user_id.rb
+++ b/db/migrate/20260728100100_add_index_to_articles_favorited_by_user_id.rb
@@ -1,14 +1,18 @@
 class AddIndexToArticlesFavoritedByUserId < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
   def up
     safety_assured do
-      remove_index :articles, name: "index_articles_on_favorited_by_user_id", if_exists: true
-      add_index :articles, :favorited_by_user_id, if_not_exists: true
+      execute "SET statement_timeout = 0;"
+      remove_index :articles, name: "index_articles_on_favorited_by_user_id", if_exists: true, algorithm: :concurrently
+      add_index :articles, :favorited_by_user_id, algorithm: :concurrently
     end
   end
 
   def down
     safety_assured do
-      remove_index :articles, name: "index_articles_on_favorited_by_user_id", if_exists: true
+      execute "SET statement_timeout = 0;"
+      remove_index :articles, name: "index_articles_on_favorited_by_user_id", if_exists: true, algorithm: :concurrently
     end
   end
 end

--- a/db/migrate/20260728100400_add_index_to_comments_favorited_by_user_id.rb
+++ b/db/migrate/20260728100400_add_index_to_comments_favorited_by_user_id.rb
@@ -1,14 +1,18 @@
 class AddIndexToCommentsFavoritedByUserId < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
   def up
     safety_assured do
-      remove_index :comments, name: "index_comments_on_favorited_by_user_id", if_exists: true
-      add_index :comments, :favorited_by_user_id, if_not_exists: true
+      execute "SET statement_timeout = 0;"
+      remove_index :comments, name: "index_comments_on_favorited_by_user_id", if_exists: true, algorithm: :concurrently
+      add_index :comments, :favorited_by_user_id, algorithm: :concurrently
     end
   end
 
   def down
     safety_assured do
-      remove_index :comments, name: "index_comments_on_favorited_by_user_id", if_exists: true
+      execute "SET statement_timeout = 0;"
+      remove_index :comments, name: "index_comments_on_favorited_by_user_id", if_exists: true, algorithm: :concurrently
     end
   end
 end


### PR DESCRIPTION
## Summary
Fixes the release failure by using `algorithm: :concurrently` with `disable_ddl_transaction!` and `execute "SET statement_timeout = 0;"`.

## Why This Iteration Fixes The Issue
1. **Non-blocking (`algorithm: :concurrently` + `disable_ddl_transaction!`)**: Acquires `SHARE UPDATE EXCLUSIVE` lock in PostgreSQL, ensuring `SELECT`, `INSERT`, `UPDATE`, and `DELETE` web requests on `articles` and `comments` run completely uninhibited without any table lock risks.
2. **Session Statement Timeout Override (`execute "SET statement_timeout = 0;"`)**: Disables the 20-second session statement timeout for this migration connection, allowing `CREATE INDEX CONCURRENTLY` to wait for active transactions without being aborted by PostgreSQL.
3. **Clean Session Execution**: Avoids `ALTER ROLE` mutations or `ensure` resets that interfered with connection poolers in earlier attempts.
4. **Invalid Index Cleanup**: Cleans up pre-existing invalid indexes with `remove_index ..., if_exists: true, algorithm: :concurrently`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789144216&installation_model_id=424141&pr_number=23715&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23715&signature=d881f8d8b96f74cc4fad30b0a38808ff3a5c3495261abf7cf0914a89a9e0ec00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->