### PR TITLE
Limit cached_reading_list_article_ids to 1000 items

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -494,11 +494,12 @@ class User < ApplicationRecord
 
   def cached_reading_list_article_ids
     Rails.cache.fetch("reading_list_ids_of_articles_#{id}_#{public_reactions_count}_#{last_reacted_at}_#{RequestStore.store[:subforem_id]}") do
-      user_activity&.alltime_reading_list_articles.presence || begin
-        readinglist = Reaction.readinglist_for_user(self).order("created_at DESC")
+      ids = user_activity&.alltime_reading_list_articles.presence || begin
+        readinglist = Reaction.readinglist_for_user(self).order("created_at DESC").limit(1000)
         published = Article.published.from_subforem.where(id: readinglist.pluck(:reactable_id)).ids
         readinglist.filter_map { |r| r.reactable_id if published.include? r.reactable_id }
       end
+      ids.first(1000)
     end
   end
 

--- a/spec/models/user_activity_spec.rb
+++ b/spec/models/user_activity_spec.rb
@@ -246,6 +246,26 @@ RSpec.describe UserActivity, type: :model do
 
       expect(user_activity.reload.alltime_reading_list_articles).to contain_exactly(article1.id)
     end
+
+    it "stores all reading list article IDs without limit" do
+      user_activity = create(:user_activity, user: user, alltime_reading_list_articles: [])
+      reactions_data = (1..1005).map do |n|
+        {
+          user_id: user.id,
+          category: "readinglist",
+          reactable_type: "Article",
+          reactable_id: n,
+          status: "valid",
+          created_at: Time.current,
+          updated_at: Time.current
+        }
+      end
+      Reaction.insert_all(reactions_data)
+
+      described_class.update_reading_list_articles_for(user.id)
+
+      expect(user_activity.reload.alltime_reading_list_articles.length).to eq(1005)
+    end
   end
 
   describe "associations" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1219,6 +1219,14 @@ RSpec.describe User do
       expect(user.cached_reading_list_article_ids).to contain_exactly(article1.id, article2.id)
     end
 
+    it "limits cached_reading_list_article_ids to at most 1000 items" do
+      large_id_list = (1..1005).to_a
+      create(:user_activity, user: user, alltime_reading_list_articles: large_id_list)
+
+      expect(user.cached_reading_list_article_ids.length).to eq(1000)
+      expect(user.cached_reading_list_article_ids).to eq((1..1000).to_a)
+    end
+
     it "has an accurate agent_sessions_count using counter cache" do
       expect(user.agent_sessions_count).to eq(0)
       create(:agent_session, user: user)


### PR DESCRIPTION
## Summary
Limits `User#cached_reading_list_article_ids` to at most 1,000 article IDs when building the payload for `AsyncInfoController#base_data` (`userData().reading_list_ids`).

- `UserActivity.alltime_reading_list_articles` continues storing the complete history of saved article IDs in primary storage.
- Prevents oversized array payloads in `base_data` for power users while maintaining correct UI behavior (sidebar count badge continues displaying `999+`).

## Testing
- Added RSpec unit tests in `spec/models/user_spec.rb` and `spec/models/user_activity_spec.rb` verifying the 1,000 item limit on `cached_reading_list_article_ids` and unlimited primary storage in `UserActivity`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789159099&installation_model_id=424141&pr_number=23718&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23718&signature=9880811bd91f821c4ea3cd2ca8a0b00e3ab31bbc4dabd21edbd06a9dd1af68fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->