### PR TITLE
Prevent Fastly edge cache poisoning from auth state desync

### DIFF
--- a/app/controllers/concerns/caching_headers.rb
+++ b/app/controllers/concerns/caching_headers.rb
@@ -26,6 +26,11 @@ module CachingHeaders
     # Only public forems should be edge-cached based on current functionality.
     return unless Settings::UserExperience.public
 
+    if auth_state_desynced_with_fastly?
+      unset_cache_control_headers
+      return
+    end
+
     request.session_options[:skip] = true # no cookies
 
     RequestStore.store[:edge_caching_in_place] = true # To be observed downstream.
@@ -57,6 +62,10 @@ module CachingHeaders
   end
 
   private
+
+  def auth_state_desynced_with_fastly?
+    request.cookies.key?("remember_user_token") != user_signed_in?
+  end
 
   def build_surrogate_control(max_age, stale_while_revalidate: nil, stale_if_error: 26_400)
     surrogate_control = "max-age=#{max_age}"

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -292,6 +292,30 @@ RSpec.describe "StoriesIndex" do
       sets_nginx_headers
     end
 
+    context "when auth state is desynced with remember_user_token cookie" do
+      it "unsets surrogate control headers when remember_user_token is present but user is signed out" do
+        cookies["remember_user_token"] = "invalid_or_expired_token"
+        get "/"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.headers["Surrogate-Control"]).to be_nil
+        expect(response.headers["Cache-Control"]).not_to eq("public, no-cache")
+      end
+
+      it "unsets surrogate control headers when remember_user_token is absent but user is signed in" do
+        user = create(:user)
+        sign_in user
+        # Explicitly remove remember_user_token cookie to simulate session-only auth
+        cookies.delete("remember_user_token")
+
+        get "/"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.headers["Surrogate-Control"]).to be_nil
+        expect(response.headers["Cache-Control"]).not_to eq("public, no-cache")
+      end
+    end
+
     def sets_fastly_headers
       expected_surrogate_key_headers = %w[main_app_home_page]
       expect(response.headers["Surrogate-Key"].split(", ")).to match_array(expected_surrogate_key_headers)


### PR DESCRIPTION
## Summary
Fixes an intermittent issue where users are served the wrong homepage variant (e.g., logged-in users seeing the logged-out homepage shell or vice-versa) due to Fastly edge cache poisoning.

### Root Cause
Fastly tags incoming requests as `X-Loggedin: logged-in` vs `logged-out` by checking `req.http.Cookie ~ "remember_user_token"`.
When a request has a `remember_user_token` cookie that is invalid or expired in the database, Devise authentication in Rails fails (`user_signed_in?` evaluates to `false`). Rails then renders the **logged-out homepage shell**. Because Fastly tagged the request as `logged-in`, Fastly caches the logged-out HTML under the `X-Loggedin: logged-in` cache slot—poisoning the edge cache globally for all signed-in users until purged or expired.

Likewise, if a request lacks `remember_user_token` but Rails authenticates via `_forem_session`, Rails renders the signed-in page and Fastly caches it under `X-Loggedin: logged-out`.

### Solution
In `CachingHeaders#set_cache_control_headers`, check if the incoming `remember_user_token` cookie presence matches `user_signed_in?`. If they are desynced (`request.cookies["remember_user_token"].present? != user_signed_in?`), immediately call `unset_cache_control_headers` so Rails omits `Surrogate-Control` and `Cache-Control: public, no-cache`, preventing Fastly from edge-caching the response.

### Specs Added
Added unit tests in `spec/requests/stories_index_spec.rb` ensuring surrogate cache headers are un-set when authentication state and `remember_user_token` cookie presence are desynced.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789236572&installation_model_id=424141&pr_number=23721&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23721&signature=ce759713e62e0d27db59154f2b34abfe4f8d77fbc76d5b47e157655db7fbdbe0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->