### PR TITLE
Prevent FOUC during dynamic stylesheet alignment on internal navigation

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -174,8 +174,30 @@
               var link = document.getElementById(id);
               if (link) {
                 var currentHref = link.getAttribute('href');
-                if (currentHref && currentHref !== expectedHref) {
-                  link.setAttribute('href', expectedHref);
+                if (currentHref && currentHref !== expectedHref && link.dataset.pendingHref !== expectedHref) {
+                  link.dataset.pendingHref = expectedHref;
+                  var newLink = document.createElement('link');
+                  newLink.rel = 'stylesheet';
+                  newLink.media = link.media || 'all';
+                  newLink.href = expectedHref;
+                  newLink.onload = (function(targetLink, replacementLink, targetId) {
+                    return function() {
+                      replacementLink.id = targetId;
+                      delete targetLink.dataset.pendingHref;
+                      if (targetLink.parentNode) {
+                        targetLink.parentNode.replaceChild(replacementLink, targetLink);
+                      }
+                    };
+                  })(link, newLink, id);
+                  newLink.onerror = (function(targetLink, replacementLink) {
+                    return function() {
+                      delete targetLink.dataset.pendingHref;
+                      if (replacementLink.parentNode) {
+                        replacementLink.parentNode.removeChild(replacementLink);
+                      }
+                    };
+                  })(link, newLink);
+                  document.head.appendChild(newLink);
                 }
               }
             }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -180,23 +180,33 @@
                   newLink.rel = 'stylesheet';
                   newLink.media = link.media || 'all';
                   newLink.href = expectedHref;
-                  newLink.onload = (function(targetLink, replacementLink, targetId) {
+                  newLink.onload = (function(targetId, expectedUrl, replacementLink) {
                     return function() {
-                      replacementLink.id = targetId;
-                      delete targetLink.dataset.pendingHref;
-                      if (targetLink.parentNode) {
-                        targetLink.parentNode.replaceChild(replacementLink, targetLink);
+                      var currentTarget = document.getElementById(targetId);
+                      if (currentTarget && currentTarget.dataset.pendingHref === expectedUrl) {
+                        replacementLink.id = targetId;
+                        delete currentTarget.dataset.pendingHref;
+                        if (currentTarget.parentNode) {
+                          currentTarget.parentNode.replaceChild(replacementLink, currentTarget);
+                          return;
+                        }
                       }
-                    };
-                  })(link, newLink, id);
-                  newLink.onerror = (function(targetLink, replacementLink) {
-                    return function() {
-                      delete targetLink.dataset.pendingHref;
                       if (replacementLink.parentNode) {
                         replacementLink.parentNode.removeChild(replacementLink);
                       }
                     };
-                  })(link, newLink);
+                  })(id, expectedHref, newLink);
+                  newLink.onerror = (function(targetId, expectedUrl, replacementLink) {
+                    return function() {
+                      var currentTarget = document.getElementById(targetId);
+                      if (currentTarget && currentTarget.dataset.pendingHref === expectedUrl) {
+                        delete currentTarget.dataset.pendingHref;
+                      }
+                      if (replacementLink.parentNode) {
+                        replacementLink.parentNode.removeChild(replacementLink);
+                      }
+                    };
+                  })(id, expectedHref, newLink);
                   document.head.appendChild(newLink);
                 }
               }

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -628,6 +628,8 @@ RSpec.describe "StoriesIndex" do
       expect(response.body).to include(%("minimal": "#{expected_minimal}"))
       expect(response.body).to include(%("views": "#{expected_views}"))
       expect(response.body).to include(%("crayons": "#{expected_crayons}"))
+      expect(response.body).to include("pendingHref")
+      expect(response.body).to include("replaceChild")
       # Internal navigation excludes the outer layout, so the outer shell links should not be rendered
       expect(response.body).not_to include('id="main-minimal-stylesheet"')
     end


### PR DESCRIPTION
## What does this PR do?
When navigating internally via InstantClick (such as moving from the home feed to an article show page), an inline alignment script ensures the active stylesheets in the page shell (`main-*-stylesheet` in `<head>` and `secondary-*-stylesheet` in `<body>`) match the expected digest for the target page.

Previously, this was done by calling `link.setAttribute('href', expectedHref)` directly on active `<link rel="stylesheet">` nodes. In browsers, changing `href` on an active stylesheet element immediately drops the parsed CSS rules from the CSSOM while the new asset is fetched over the network, causing a noticeable flash of unstyled content (FOUC) or layout shift.

This change:
1. Creates a new `<link rel="stylesheet">` node for the expected asset and appends it to `document.head` to initiate background downloading and parsing.
2. Keeps the active stylesheet node completely untouched in the DOM during the fetch, preventing any unstyled gaps.
3. Swaps the old link node with the new link node via `replaceChild` only once the new stylesheet's `onload` event fires.
4. Adds duplicate-request guards (`dataset.pendingHref`) and `onerror` error handling.

## Testing
- Updated and ran request specs in `spec/requests/stories_index_spec.rb`.
- All 63 examples passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789249455&installation_model_id=424141&pr_number=23722&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23722&signature=128320ee57bb7cc27ebaa9ea41ffefb6eb4d7a144bb73fd73bb925b82290aaf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->