### PR TITLE
Carry the last per-mailer values into Customer.io message_data

### DIFF
--- a/app/mailers/digest_mailer.rb
+++ b/app/mailers/digest_mailer.rb
@@ -26,7 +26,10 @@ class DigestMailer < ApplicationMailer
         "billboards_html" => digest_billboards_html,
         "email_end_phrase" => email_end_phrase,
         "unsubscribe_url" => email_subscriptions_unsubscribe_url(ut: @unsubscribe),
-        "user_follows_any_subforems" => @user_follows_any_subforems
+        "user_follows_any_subforems" => @user_follows_any_subforems,
+        # digest_email.html.erb only offers the "update your experience level"
+        # tip to people who have not set one.
+        "experience_level_set" => @user.setting&.experience_level.present?
       },
     )
 

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -59,6 +59,11 @@ class NotifyMailer < ApplicationMailer
       message_data: {
         "follower_name" => @follower.name,
         "follower_profile_url" => URL.user(@follower),
+        # Mirrors the avatar and follower count new_follower_email.html.erb renders.
+        "follower_profile_image_url" => ApplicationController.helpers.optimized_image_url(
+          URL.local_image(@follower.profile_image), width: 150
+        ),
+        "followers_count" => @user.good_standing_followers_count,
         "unsubscribe_url" => email_subscriptions_unsubscribe_url(ut: @unsubscribe)
       },
     )
@@ -84,6 +89,10 @@ class NotifyMailer < ApplicationMailer
         "mentioner_name" => @mentioner.name,
         "mentionable_type" => @mentionable_type,
         "mention_url" => URL.url(@mention.mentionable.path, RequestStore.store[:subforem_domain]),
+        # new_mention_email.html.erb quotes the comment itself for comment
+        # mentions and links straight out for anything else; nil here is what
+        # tells the Customer.io template which of the two it is looking at.
+        "comment_html" => (@mentionable.processed_html if @mentionable.is_a?(Comment)),
         "unsubscribe_url" => email_subscriptions_unsubscribe_url(ut: @unsubscribe)
       },
     )
@@ -145,6 +154,9 @@ class NotifyMailer < ApplicationMailer
         "badge_name" => @badge.title,
         "badge_description" => badge_description,
         "badge_image_url" => @badge.badge_image_url,
+        # Already-rendered HTML (BadgeAchievement#render_rewarding_context_message_html),
+        # italicised by new_badge_email.html.erb when a rewarder left a note.
+        "rewarding_context_message_html" => @badge_achievement.rewarding_context_message.presence,
         "unsubscribe_url" => email_subscriptions_unsubscribe_url(ut: @unsubscribe)
       },
     )

--- a/app/mailers/survey_mailer.rb
+++ b/app/mailers/survey_mailer.rb
@@ -23,6 +23,8 @@ class SurveyMailer < ApplicationMailer
         "survey_type" => survey_type,
         "survey_url" => survey_url(@survey.slug),
         "community_name" => @community_name,
+        # Optional per-survey paragraph, rendered above the CTA when present.
+        "extra_email_context_paragraph" => @survey.extra_email_context_paragraph.presence,
         "subject" => subject
       },
     )

--- a/spec/mailers/digest_mailer_spec.rb
+++ b/spec/mailers/digest_mailer_spec.rb
@@ -157,6 +157,19 @@ RSpec.describe DigestMailer do
         expect(data["email_end_phrase"]).to be_present
       end
 
+      it "reports whether the recipient has set an experience level", :aggregate_failures do
+        payload = lambda {
+          email = described_class.with(user: user, articles: [article]).digest_email
+          email.message.delivery_method.settings[:message_data]
+        }
+
+        user.setting.update!(experience_level: nil)
+        expect(payload.call["experience_level_set"]).to be(false)
+
+        user.setting.update!(experience_level: 5)
+        expect(payload.call["experience_level_set"]).to be(true)
+      end
+
       it "falls back to the truncated description in the payload when ai_summary is blank" do
         article.update_columns(ai_summary: nil, description: "Fallback description text.")
 

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -88,6 +88,8 @@ RSpec.describe NotifyMailer do
         expect(settings[:transactional_message_id]).to eq("dev_new_follower_email")
         expect(settings[:message_data]["follower_name"]).to eq(user2.name)
         expect(settings[:message_data]["follower_profile_url"]).to eq(URL.user(user2))
+        expect(settings[:message_data]["follower_profile_image_url"]).to be_present
+        expect(settings[:message_data]["followers_count"]).to eq(user.good_standing_followers_count)
         expect(settings[:message_data]["unsubscribe_url"]).to include("ut=")
       end
     end
@@ -142,6 +144,7 @@ RSpec.describe NotifyMailer do
         expect(settings[:message_data]["mentionable_type"]).to eq(comment_mention.decorate.formatted_mentionable_type)
         expected_mention_url = URL.url(comment_mention.mentionable.path, RequestStore.store[:subforem_domain])
         expect(settings[:message_data]["mention_url"]).to eq(expected_mention_url)
+        expect(settings[:message_data]["comment_html"]).to eq(comment.processed_html)
         expect(settings[:message_data]["unsubscribe_url"]).to include("ut=")
       end
     end
@@ -288,6 +291,8 @@ RSpec.describe NotifyMailer do
         expect(settings[:message_data]["badge_name"]).to eq(badge.title)
         expect(settings[:message_data]["badge_description"]).to eq(badge.description)
         expect(settings[:message_data]["badge_image_url"]).to eq(badge.badge_image_url)
+        expect(settings[:message_data]["rewarding_context_message_html"])
+          .to eq(badge_achievement.rewarding_context_message.presence)
         expect(settings[:message_data]["unsubscribe_url"]).to include("ut=")
       end
     end

--- a/spec/mailers/survey_mailer_spec.rb
+++ b/spec/mailers/survey_mailer_spec.rb
@@ -71,6 +71,8 @@ RSpec.describe SurveyMailer, type: :mailer do
         expect(settings[:message_data]["survey_type"]).to eq("pulse")
         expect(settings[:message_data]["survey_url"]).to end_with("/survey/#{survey.slug}")
         expect(settings[:message_data]["community_name"]).to eq(community_name)
+        expect(settings[:message_data]["extra_email_context_paragraph"])
+          .to eq(survey.extra_email_context_paragraph)
         expect(settings[:message_data]["subject"]).to eq(expected_subject)
       end
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Follow-up to #23725. Five mailers still render something from an Active Record object that never reaches `message_data`, so their Customer.io templates can't reproduce the email they replace. Each is a single value:

| Mailer | Key | What it is |
|---|---|---|
| `new_follower_email` | `follower_profile_image_url`, `followers_count` | the avatar and "you now have N total followers" — most of what this email *is* |
| `new_mention_email` | `comment_html` | the quoted comment, for comment mentions |
| `new_badge_email` | `rewarding_context_message_html` | the note a rewarder leaves on a manually granted badge |
| `digest_email` | `experience_level_set` | whether the footer offers the "set your experience level" tip |
| `pulse_survey` | `extra_email_context_paragraph` | optional per-survey paragraph above the CTA |

Each value is taken the same way the ERB takes it, so the payload matches what the view would have rendered — `optimized_image_url` at the same width for the avatar, already-rendered HTML for the badge note and the quoted comment.

`comment_html` is deliberately `nil` for non-Comment mentions: `new_mention_email.html.erb` quotes the comment for comment mentions and links straight out for anything else, and its absence is what tells the template which of those two branches it's in.

No greeting keys here — `name` is already supplied for every `ApplicationMailer` descendant by `Deliverable#layout_message_data` (#23725), which covers the seven templates that only needed that one.

## Related Tickets & Documents

Follows #23725. Part of the Customer.io email migration stack (#23617 → #23628).

## QA Instructions, Screenshots, Recordings

These keys only surface once the corresponding Customer.io templates are built — the payload is additive, so existing behaviour is unchanged either way. To inspect a payload without sending:

```ruby
user = User.find_by(email: "you@example.com")
FeatureFlag.enable(Deliverable::CUSTOMERIO_FLAG, FeatureFlag::Actor[user])

follow = Follow.where(followable: user).last
NotifyMailer.with(follow: follow).new_follower_email
            .message.delivery_method.settings[:message_data]
# => now includes "follower_profile_image_url" and "followers_count"

FeatureFlag.disable(Deliverable::CUSTOMERIO_FLAG, FeatureFlag::Actor[user])
```

Keep `Flipper.enabled?(Deliverable::CUSTOMERIO_FLAG)` false — the global gate also disables the drip and admin broadcasts.

The SMTP path is untouched: nothing here changes the ERB views, only what gets attached to the Customer.io delivery options.

No UI changes.

## Added/updated tests?

- [x] Yes

Extended the existing Customer.io routing specs in `notify_mailer_spec.rb`, `digest_mailer_spec.rb` and `survey_mailer_spec.rb` to assert each new key. The digest one is a standalone example rather than an added assertion, since a `experience_level_set == user.setting.experience_level.present?` check would just restate the implementation — it sets the level both ways and asserts `false` then `true`.

`spec/mailers/` is 279 examples / 1 failure — `application_mailer_spec.rb:8`, which fails on `main` unmodified and is unrelated.

RuboCop on the six touched files reports the same 34 pre-existing offenses before and after this change; it adds none.

## [optional] Are there any post deployment tasks we need to perform?

None. Additive payload keys; the templates that consume them are built separately in Customer.io.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789326291&installation_model_id=424141&pr_number=23726&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23726&signature=96a46f0c554a501ade14e8ebb4d70717feac3cb3c33cd617121dd33f9d8cd9e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->