### PR TITLE
Send community_name and profile URLs in Customer.io message_data

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -34,6 +34,7 @@ class NotifyMailer < ApplicationMailer
         "comment_html" => @truncated_comment,
         "comment_url" => URL.comment(@comment),
         "article_or_parent_title" => @comment.commentable&.title || "Content No Longer Available",
+        "community_name" => Settings::Community.community_name(subforem_id: @subforem_id),
         "unsubscribe_url" => email_subscriptions_unsubscribe_url(ut: @unsubscribe)
       },
     )
@@ -64,6 +65,7 @@ class NotifyMailer < ApplicationMailer
           URL.local_image(@follower.profile_image), width: 150
         ),
         "followers_count" => @user.good_standing_followers_count,
+        "community_name" => Settings::Community.community_name(subforem_id: @subforem_id),
         "unsubscribe_url" => email_subscriptions_unsubscribe_url(ut: @unsubscribe)
       },
     )
@@ -87,12 +89,15 @@ class NotifyMailer < ApplicationMailer
       transactional_message_id: "dev_new_mention_email",
       message_data: {
         "mentioner_name" => @mentioner.name,
+        # new_mention_email.html.erb links the mentioner's name to their profile.
+        "mentioner_profile_url" => URL.user(@mentioner),
         "mentionable_type" => @mentionable_type,
         "mention_url" => URL.url(@mention.mentionable.path, RequestStore.store[:subforem_domain]),
         # new_mention_email.html.erb quotes the comment itself for comment
         # mentions and links straight out for anything else; nil here is what
         # tells the Customer.io template which of the two it is looking at.
         "comment_html" => (@mentionable.processed_html if @mentionable.is_a?(Comment)),
+        "community_name" => Settings::Community.community_name(subforem_id: @subforem_id),
         "unsubscribe_url" => email_subscriptions_unsubscribe_url(ut: @unsubscribe)
       },
     )
@@ -157,6 +162,8 @@ class NotifyMailer < ApplicationMailer
         # Already-rendered HTML (BadgeAchievement#render_rewarding_context_message_html),
         # italicised by new_badge_email.html.erb when a rewarder left a note.
         "rewarding_context_message_html" => @badge_achievement.rewarding_context_message.presence,
+        # Target of the "Check out your profile" CTA, the email's only call to action.
+        "profile_url" => URL.user(@user),
         "unsubscribe_url" => email_subscriptions_unsubscribe_url(ut: @unsubscribe)
       },
     )

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe NotifyMailer do
         expect(settings[:message_data]["comment_html"]).to be_present
         expect(settings[:message_data]["comment_url"]).to eq(URL.comment(comment))
         expect(settings[:message_data]["article_or_parent_title"]).to eq(article.title)
+        expect(settings[:message_data]["community_name"]).to eq(Settings::Community.community_name)
         expect(settings[:message_data]["unsubscribe_url"]).to include("ut=")
       end
     end
@@ -90,6 +91,7 @@ RSpec.describe NotifyMailer do
         expect(settings[:message_data]["follower_profile_url"]).to eq(URL.user(user2))
         expect(settings[:message_data]["follower_profile_image_url"]).to be_present
         expect(settings[:message_data]["followers_count"]).to eq(user.good_standing_followers_count)
+        expect(settings[:message_data]["community_name"]).to eq(Settings::Community.community_name)
         expect(settings[:message_data]["unsubscribe_url"]).to include("ut=")
       end
     end
@@ -141,10 +143,12 @@ RSpec.describe NotifyMailer do
 
         expect(settings[:transactional_message_id]).to eq("dev_new_mention_email")
         expect(settings[:message_data]["mentioner_name"]).to eq(comment.user.name)
+        expect(settings[:message_data]["mentioner_profile_url"]).to eq(URL.user(comment.user))
         expect(settings[:message_data]["mentionable_type"]).to eq(comment_mention.decorate.formatted_mentionable_type)
         expected_mention_url = URL.url(comment_mention.mentionable.path, RequestStore.store[:subforem_domain])
         expect(settings[:message_data]["mention_url"]).to eq(expected_mention_url)
         expect(settings[:message_data]["comment_html"]).to eq(comment.processed_html)
+        expect(settings[:message_data]["community_name"]).to eq(Settings::Community.community_name)
         expect(settings[:message_data]["unsubscribe_url"]).to include("ut=")
       end
     end
@@ -293,6 +297,7 @@ RSpec.describe NotifyMailer do
         expect(settings[:message_data]["badge_image_url"]).to eq(badge.badge_image_url)
         expect(settings[:message_data]["rewarding_context_message_html"])
           .to eq(badge_achievement.rewarding_context_message.presence)
+        expect(settings[:message_data]["profile_url"]).to eq(URL.user(user))
         expect(settings[:message_data]["unsubscribe_url"]).to include("ut=")
       end
     end

--- a/spec/mailers/survey_mailer_spec.rb
+++ b/spec/mailers/survey_mailer_spec.rb
@@ -72,8 +72,18 @@ RSpec.describe SurveyMailer, type: :mailer do
         expect(settings[:message_data]["survey_url"]).to end_with("/survey/#{survey.slug}")
         expect(settings[:message_data]["community_name"]).to eq(community_name)
         expect(settings[:message_data]["extra_email_context_paragraph"])
-          .to eq(survey.extra_email_context_paragraph)
+          .to eq("This is a super important survey.")
         expect(settings[:message_data]["subject"]).to eq(expected_subject)
+      end
+
+      # The mailer sends the paragraph through .presence, so the template can
+      # gate on it with a plain {% if %} rather than testing for whitespace.
+      it "sends nil rather than a blank string when the survey has no extra paragraph" do
+        survey.update!(extra_email_context_paragraph: "")
+
+        settings = mail.message.delivery_method.settings
+
+        expect(settings[:message_data]["extra_email_context_paragraph"]).to be_nil
       end
     end
 


### PR DESCRIPTION
Building the Customer.io templates for tier 3 and tier 4 surfaced values the Rails views render but `message_data` never carried, so the templates had to hardcode or drop them. This adds the missing keys.

## Changes

**`community_name`** — added to `new_reply_email`, `new_follower_email`, `new_mention_email`.

All three render the community name in their views, but none passed it. The Customer.io templates were hardcoding `"DEV Community"`, which is wrong for the ~20 non-default subforems in production (`Forem`, `CodeNewbie Community`, `Music Forem`, …).

Uses `Settings::Community.community_name(subforem_id: @subforem_id)`, matching the ten other places in this file. Worth noting: `ApplicationHelper#community_name`, which the ERB views call, is **not** subforem-aware — it calls `Settings::Community.community_name` with no argument. So for subforem recipients the Customer.io copy is now *more* correct than the ERB copy.

**`profile_url`** — added to `new_badge_email`.

This is the target of the "Check out your profile" button, the email's only call to action. The view builds it from `user_url(@user)`; nothing in the payload could reconstruct it. Without this key the Customer.io template ships with no CTA.

**`mentioner_profile_url`** — added to `new_mention_email`.

`new_mention_email.html.erb` links the mentioner's name to their profile; the payload had only their name.

`new_badge_email` deliberately does **not** get `community_name` — unlike the other two, its view never renders it, so the key would be dead weight.

## Follow-up from #23726 review

Copilot flagged on #23726 that `spec/mailers/survey_mailer_spec.rb` asserted `extra_email_context_paragraph` against the raw attribute while the mailer sends it through `.presence`, so a survey saved with `""` would compare `nil` to `""`. Fixed here.

Rather than mirror `.presence` in the expectation — which restates the implementation instead of testing it — the existing assertion now pins the literal string, and a new example covers the blank case. That case is the whole reason `.presence` is there: the Customer.io template gates on the key with a plain `{% if %}` and needs `nil`, not `""`.

The other Copilot comment, on `digest_mailer.rb:33`, is a false positive. It claims `experience_level_set` "can become nil due to the safe-navigation operator", but `&.` guards only the immediate call: `@user.setting&.experience_level` yields `nil`, and `.present?` is then invoked on `nil` through a regular dot, returning `false`. Verified all three paths — missing setting, nil level, set level — return strict booleans. `digest_mailer_spec.rb` already pins this with `be(false)` / `be(true)` identity matchers. No change made.

## Templates

The Customer.io side is already built and active for all of these. The two that consume `community_name` today use `{{trigger.community_name | default: "DEV Community"}}`, so they render correctly both before and after this deploys. The badge CTA is wrapped in `{% if trigger.profile_url %}` and lights up as soon as this ships — no template change needed.

## Testing

Extended the existing `when routed through Customer.io` assertions for all four affected mailers. `bundle exec rspec spec/mailers/notify_mailer_spec.rb spec/mailers/survey_mailer_spec.rb spec/mailers/digest_mailer_spec.rb` — 176 examples, 0 failures. RuboCop clean on `notify_mailer.rb`; the five offenses in `survey_mailer_spec.rb` are pre-existing (lines 3–44) and untouched.

https://claude.ai/code/session_01Agp1w4i5CoQzZQLms2kvXA