### PR TITLE
Curate and document icons for the feature Liquid tag

### DIFF
--- a/app/liquid_tags/feature_tag.rb
+++ b/app/liquid_tags/feature_tag.rb
@@ -3,13 +3,50 @@ class FeatureTag < Liquid::Block
   include LiquidTagHelpers
 
   PARTIAL = "liquids/feature".freeze
+  ICON_NAME_REGEXP = /\A[a-z0-9-]+\z/
+
+  ICONS = %w[
+    analytics
+    badge
+    book
+    boost
+    calendar
+    checkmark
+    code
+    cog
+    comment
+    connect
+    discover
+    email
+    fire
+    heart
+    image
+    lightbulb
+    lightning
+    location
+    lock
+    organization
+    pencil
+    people
+    raised-hands
+    search
+    sparkle-heart
+    team
+    verified
+    video-camera
+    wallet
+  ].freeze
+
+  # "rocket" was documented in the editor help but never shipped an asset
+  LEGACY_ICON_ALIASES = { "rocket" => "lightning" }.freeze
 
   def initialize(tag_name, markup, parse_context)
     super
     options = parse_options(markup.strip)
-    @icon = options["icon"]
     @title = options["title"]
     raise StandardError, I18n.t("liquid_tags.feature_tag.missing_title") unless @title
+
+    @icon = validate_icon(options["icon"])
   end
 
   def render(context)
@@ -22,6 +59,20 @@ class FeatureTag < Liquid::Block
         title: @title,
         content: parsed_content,
       },
+    )
+  end
+
+  private
+
+  def validate_icon(icon)
+    return icon if icon.blank? || !icon.match?(ICON_NAME_REGEXP)
+    return LEGACY_ICON_ALIASES[icon] if LEGACY_ICON_ALIASES.key?(icon)
+    return icon if ICONS.include?(icon)
+
+    raise StandardError, I18n.t(
+      "liquid_tags.feature_tag.invalid_icon",
+      icon: icon,
+      valid_icons: ICONS.join(", "),
     )
   end
 end

--- a/app/views/liquids/_feature.html.erb
+++ b/app/views/liquids/_feature.html.erb
@@ -1,7 +1,7 @@
 <div class="ltag-feature">
   <% if icon.present? %>
     <div class="ltag-feature__icon">
-      <% if icon.match?(/\A[a-z0-9-]+\z/) %>
+      <% if FeatureTag::ICONS.include?(icon) %>
         <% begin %>
           <%= crayons_icon_tag(icon, width: 32, height: 32) %>
         <% rescue StandardError %>

--- a/app/views/pages/_editor_liquid_help.en.html.erb
+++ b/app/views/pages/_editor_liquid_help.en.html.erb
@@ -95,9 +95,12 @@
     <h4>Features</h4>
     <p>Display a grid of feature cards:</p>
     <pre>{% features %}
-  {% feature title="Fast" icon="rocket" %}Optimized for speed.{% endfeature %}
-  {% feature title="Secure" %}Built with security in mind.{% endfeature %}
+  {% feature title="Fast" icon="lightning" %}Optimized for speed.{% endfeature %}
+  {% feature title="Secure" icon="🔒" %}Built with security in mind.{% endfeature %}
+  {% feature title="Simple" %}No icon needed.{% endfeature %}
 {% endfeatures %}</pre>
+    <p class="fs-s"><code>title</code> is required. <code>icon</code> is optional and accepts either an emoji or one of the supported icon names below.</p>
+    <p class="fs-s">Supported icons: <%= safe_join(FeatureTag::ICONS.map { |icon_name| content_tag(:code, icon_name) }, ", ") %>.</p>
 
     <h4>Quote</h4>
     <p>Display a testimonial or quote:</p>

--- a/config/locales/liquid_tags/en.yml
+++ b/config/locales/liquid_tags/en.yml
@@ -167,6 +167,7 @@ en:
       no_args: "The features tag does not accept any arguments"
     feature_tag:
       missing_title: "Feature tag requires a title option"
+      invalid_icon: "Invalid icon '%{icon}' for feature tag. Use an emoji or one of: %{valid_icons}"
     offer_tag:
       default_button: "Learn More"
     quote_tag:

--- a/config/locales/liquid_tags/fr.yml
+++ b/config/locales/liquid_tags/fr.yml
@@ -167,6 +167,7 @@ fr:
       no_args: "La balise features n'accepte aucun argument"
     feature_tag:
       missing_title: "La balise feature nécessite une option title"
+      invalid_icon: "Icône '%{icon}' non valide pour la balise feature. Utilisez un emoji ou l'une des icônes suivantes : %{valid_icons}"
     offer_tag:
       default_button: "En savoir plus"
     quote_tag:

--- a/config/locales/liquid_tags/pt.yml
+++ b/config/locales/liquid_tags/pt.yml
@@ -167,6 +167,7 @@ pt:
       no_args: "A tag features não aceita argumentos"
     feature_tag:
       missing_title: "A tag feature requer uma opção title"
+      invalid_icon: "Ícone '%{icon}' inválido para a tag feature. Use um emoji ou um dos seguintes: %{valid_icons}"
     offer_tag:
       default_button: "Saiba Mais"
     quote_tag:

--- a/spec/liquid_tags/feature_tag_spec.rb
+++ b/spec/liquid_tags/feature_tag_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe FeatureTag, type: :liquid_tag do
   before do
     Liquid::Template.register_tag("features", FeaturesTag)
-    Liquid::Template.register_tag("feature", FeatureTag)
+    Liquid::Template.register_tag("feature", described_class)
   end
 
   def render_feature(options)

--- a/spec/liquid_tags/feature_tag_spec.rb
+++ b/spec/liquid_tags/feature_tag_spec.rb
@@ -1,0 +1,155 @@
+require "rails_helper"
+
+RSpec.describe FeatureTag, type: :liquid_tag do
+  before do
+    Liquid::Template.register_tag("features", FeaturesTag)
+    Liquid::Template.register_tag("feature", FeatureTag)
+  end
+
+  def render_feature(options)
+    Liquid::Template.parse("{% features %}{% feature #{options} %}Body{% endfeature %}{% endfeatures %}").render
+  end
+
+  describe "the curated icon list" do
+    it "is frozen and non-empty" do
+      expect(described_class::ICONS).to be_frozen
+      expect(described_class::ICONS).not_to be_empty
+    end
+
+    it "contains only unique, slug-formatted names" do
+      expect(described_class::ICONS.uniq).to eq(described_class::ICONS)
+      expect(described_class::ICONS).to all(match(described_class::ICON_NAME_REGEXP))
+    end
+
+    it "maps every supported name to an existing root-level SVG asset" do
+      missing = described_class::ICONS.reject do |icon|
+        Rails.root.join("app/assets/images/#{icon}.svg").exist?
+      end
+
+      expect(missing).to be_empty, "Missing SVG assets for: #{missing.join(', ')}"
+    end
+
+    it "resolves every legacy alias to a supported icon" do
+      expect(described_class::LEGACY_ICON_ALIASES.values).to all(be_in(described_class::ICONS))
+    end
+  end
+
+  describe "supported icons" do
+    it "renders the matching crayons icon" do
+      result = render_feature('title="Fast" icon="lightning"')
+
+      expect(result).to include("ltag-feature__icon")
+      expect(result).to include("crayons-icon")
+      expect(result).to match(/<svg/)
+    end
+
+    it "renders every curated icon without error" do
+      expect do
+        described_class::ICONS.each { |icon| render_feature(%(title="T" icon="#{icon}")) }
+      end.not_to raise_error
+    end
+  end
+
+  describe "unsupported icons" do
+    it "raises a descriptive error naming the offending icon" do
+      expect do
+        render_feature('title="Broken" icon="not-a-real-icon"')
+      end.to raise_error(StandardError, /Invalid icon 'not-a-real-icon'/)
+    end
+
+    it "lists the supported icons in the error message" do
+      expect do
+        render_feature('title="Broken" icon="not-a-real-icon"')
+      end.to raise_error(StandardError, /#{Regexp.escape(described_class::ICONS.join(', '))}/)
+    end
+
+    it "points authors at the emoji escape hatch" do
+      expect do
+        render_feature('title="Broken" icon="totally-unknown"')
+      end.to raise_error(StandardError, /Use an emoji or one of/)
+    end
+
+    it "raises for a name that exists as an asset but is not curated" do
+      expect(Rails.root.join("app/assets/images/twitter.svg")).to exist
+      expect(described_class::ICONS).not_to include("twitter")
+
+      expect { render_feature('title="Off list" icon="twitter"') }
+        .to raise_error(StandardError, /Invalid icon 'twitter'/)
+    end
+
+    it "validates the title before the icon" do
+      expect { render_feature('icon="not-a-real-icon"') }
+        .to raise_error(StandardError, /requires a title/)
+    end
+  end
+
+  describe "features without an icon" do
+    it "renders the card and omits the icon container" do
+      result = render_feature('title="No Icon"')
+
+      expect(result).to include("ltag-feature__title")
+      expect(result).to include("No Icon")
+      expect(result).not_to include("ltag-feature__icon")
+    end
+  end
+
+  describe "backward compatibility" do
+    it "still accepts emoji icons verbatim" do
+      result = render_feature('title="Launch" icon="🚀"')
+
+      expect(result).to include("ltag-feature__icon")
+      expect(result).to include("🚀")
+    end
+
+    it "accepts the previously documented rocket icon" do
+      expect { render_feature('title="Fast" icon="rocket"') }.not_to raise_error
+    end
+
+    it "renders the rocket alias as a real icon instead of the heart fallback" do
+      result = render_feature('title="Fast" icon="rocket"')
+
+      expect(result).to include("ltag-feature__icon")
+      expect(result).to match(/<svg/)
+    end
+  end
+
+  describe "article integration" do
+    it "is valid when a supported icon is used" do
+      body = "{% features %}\n{% feature title=\"Fast\" icon=\"lightning\" %}Speed{% endfeature %}\n{% endfeatures %}"
+      article = build(:article, body_markdown: body)
+
+      expect(article).to be_valid
+      expect(article.processed_html).to include("ltag-feature__icon")
+    end
+
+    it "surfaces an authoring error when an unsupported icon is used" do
+      body = "{% features %}\n{% feature title=\"Fast\" icon=\"rocketship\" %}Speed{% endfeature %}\n{% endfeatures %}"
+      article = build(:article, body_markdown: body)
+
+      expect(article).not_to be_valid
+      expect(article.errors[:base].first).to match(/Invalid icon 'rocketship'/)
+    end
+
+    it "keeps previously published rocket markup saveable" do
+      body = "{% features %}\n{% feature title=\"Fast\" icon=\"rocket\" %}Speed{% endfeature %}\n{% endfeatures %}"
+      article = build(:article, body_markdown: body)
+
+      expect(article).to be_valid
+    end
+  end
+
+  describe "editor documentation" do
+    let(:help) { Rails.root.join("app/views/pages/_editor_liquid_help.en.html.erb").read }
+
+    it "documents the supported icons from the single source of truth" do
+      expect(help).to include("FeatureTag::ICONS")
+    end
+
+    it "only demonstrates icons that actually render" do
+      documented = help.scan(/\{%\s*feature\b[^%]*icon="([a-z0-9-]+)"/).flatten
+
+      expect(documented).not_to be_empty
+      expect(documented).to all(be_in(described_class::ICONS))
+    end
+  end
+end

--- a/spec/liquid_tags/feature_tag_spec.rb
+++ b/spec/liquid_tags/feature_tag_spec.rb
@@ -114,27 +114,38 @@ RSpec.describe FeatureTag, type: :liquid_tag do
   end
 
   describe "article integration" do
+    def article_with_icon(icon)
+      body = <<~MARKDOWN
+        ---
+        title: Feature tag icons
+        published: false
+        tags: javascript
+        ---
+
+        {% features %}
+        {% feature title="Fast" icon="#{icon}" %}Speed{% endfeature %}
+        {% endfeatures %}
+      MARKDOWN
+
+      build(:article, body_markdown: body)
+    end
+
     it "is valid when a supported icon is used" do
-      body = "{% features %}\n{% feature title=\"Fast\" icon=\"lightning\" %}Speed{% endfeature %}\n{% endfeatures %}"
-      article = build(:article, body_markdown: body)
+      article = article_with_icon("lightning")
 
       expect(article).to be_valid
       expect(article.processed_html).to include("ltag-feature__icon")
     end
 
     it "surfaces an authoring error when an unsupported icon is used" do
-      body = "{% features %}\n{% feature title=\"Fast\" icon=\"rocketship\" %}Speed{% endfeature %}\n{% endfeatures %}"
-      article = build(:article, body_markdown: body)
+      article = article_with_icon("rocketship")
 
       expect(article).not_to be_valid
       expect(article.errors[:base].first).to match(/Invalid icon 'rocketship'/)
     end
 
     it "keeps previously published rocket markup saveable" do
-      body = "{% features %}\n{% feature title=\"Fast\" icon=\"rocket\" %}Speed{% endfeature %}\n{% endfeatures %}"
-      article = build(:article, body_markdown: body)
-
-      expect(article).to be_valid
+      expect(article_with_icon("rocket")).to be_valid
     end
   end
 

--- a/spec/liquid_tags/features_tag_spec.rb
+++ b/spec/liquid_tags/features_tag_spec.rb
@@ -48,9 +48,11 @@ RSpec.describe "Features and Feature liquid tags", type: :liquid_tag do
     end
 
     it "raises a descriptive error for an unsupported icon name" do
-      expect do
-        parse('{% features %}{% feature icon="nonexistent-broken-icon-123" title="Broken" %}content{% endfeature %}{% endfeatures %}')
-      end.to raise_error(StandardError, /Invalid icon 'nonexistent-broken-icon-123'/)
+      template = '{% features %}{% feature icon="nonexistent-broken-icon-123" title="Broken" %}' \
+                 'content{% endfeature %}{% endfeatures %}'
+
+      expect { parse(template) }
+        .to raise_error(StandardError, /Invalid icon 'nonexistent-broken-icon-123'/)
     end
 
     it "preserves HTML content in body" do

--- a/spec/liquid_tags/features_tag_spec.rb
+++ b/spec/liquid_tags/features_tag_spec.rb
@@ -47,11 +47,10 @@ RSpec.describe "Features and Feature liquid tags", type: :liquid_tag do
       expect(result).to include("Launch")
     end
 
-    it "falls back to heart if a broken or missing SVG icon is provided" do
-      result = parse('{% features %}{% feature icon="nonexistent-broken-icon-123" title="Broken" %}content{% endfeature %}{% endfeatures %}').render
-      expect(result).not_to be_empty
-      expect(result).to include("Broken")
-      expect(result).to match(/<svg/)
+    it "raises a descriptive error for an unsupported icon name" do
+      expect do
+        parse('{% features %}{% feature icon="nonexistent-broken-icon-123" title="Broken" %}content{% endfeature %}{% endfeatures %}')
+      end.to raise_error(StandardError, /Invalid icon 'nonexistent-broken-icon-123'/)
     end
 
     it "preserves HTML content in body" do
@@ -85,7 +84,7 @@ RSpec.describe "Features and Feature liquid tags", type: :liquid_tag do
 
     it "raises error when title is missing" do
       expect do
-        parse('{% features %}{% feature icon="star-line" %}No title{% endfeature %}{% endfeatures %}')
+        parse('{% features %}{% feature icon="heart" %}No title{% endfeature %}{% endfeatures %}')
       end.to raise_error(StandardError, /requires a title/)
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Documentation Update

## Description

Addresses #23663.

The `feature` Liquid tag accepted any lowercase alphanumeric string as an `icon` and resolved it against the root SVG asset directory, so the effective authoring API was an incidental reflection of that directory. Unknown names fell back silently to the heart icon.

That silent fallback was not hypothetical. `app/views/pages/_editor_liquid_help.en.html.erb` documented `{% feature title="Fast" icon="rocket" %}`, but there is no `rocket.svg` among the 185 root-level assets, so the example Forem itself ships rendered a heart.

Changes:

- `FeatureTag::ICONS`, a curated frozen list of 29 names, each verified to have a matching `app/assets/images/*.svg`.
- Rendering, validation and the editor help all read that one constant, so the docs cannot drift from what actually renders.
- Unsupported names now raise a descriptive authoring error instead of silently substituting an unrelated icon.
- The broken `rocket` example is replaced.

I used a Ruby constant rather than YAML to match the sibling precedent of `ColTag::VALID_BACKGROUNDS` and `FeedTag::VALID_SORTS`. There is no non-Ruby consumer yet, so YAML would add indirection for no gain. If an icon picker lands later that changes.

### Backward compatibility

Three existing paths are preserved deliberately:

1. **Emoji icons** still pass through verbatim. There was already a spec covering `icon="🚀"` and a naive allowlist would have broken it.
2. **No icon** is unchanged.
3. **`rocket`** is aliased to `lightning` rather than raising, since it is the one off-list name Forem's own documentation told authors to copy.

The partial keeps its `rescue` as a genuine safety net for a missing asset, rather than as the primary path.

A parse-time raise is safe for published content because org READMEs render from stored `Page#processed_html` and articles from `Article#processed_html`, both computed in `before_validation`. Published content is not re-parsed on read, so this only affects content being authored or re-saved.

### One thing I could not do, flagging it explicitly

The issue asks to "audit existing content before enforcing a stricter allowlist." That needs production database access to grep published markdown for `{% feature ... icon=`, which I do not have. If names beyond `rocket` are in real use, they should be added to `ICONS` or `LEGACY_ICON_ALIASES` before this merges. I would rather surface that than quietly assume the alias covers everything.

Happy to swap the curated set for a different one; it is a single constant edit.

## Related Tickets & Documents

- Closes #23663

## QA Instructions, Screenshots, Recordings

1. In an org README or article, use `{% features %}{% feature title="Fast" icon="lightning" %}Speed{% endfeature %}{% endfeatures %}` and confirm the icon renders.
2. Swap `lightning` for an unsupported name such as `rocketship` and confirm you now get a descriptive error rather than a heart.
3. Confirm `icon="rocket"` still saves, and now renders a real icon instead of a heart.
4. Confirm a feature card with no icon, and one with an emoji icon, both still work.
5. The editor help page now lists the supported names, rendered from the constant.

## Added/updated tests?

- [x] Yes

`spec/liquid_tags/feature_tag_spec.rb` is new. Run locally on Ruby 3.3.0 with PostgreSQL 16:

```
$ bundle exec rspec spec/liquid_tags/feature_tag_spec.rb spec/liquid_tags/features_tag_spec.rb
31 examples, 0 failures
```

Note that I modified one existing example in `features_tag_spec.rb`. It asserted `"falls back to heart if a broken or missing SVG icon is provided"`, which is precisely the behaviour this issue asks to remove, so it now asserts the descriptive error instead.

## [optional] Are there any post deployment tasks we need to perform?

None, though see the content-audit note above before merging.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789414516&installation_model_id=424141&pr_number=23730&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23730&signature=40408d2e1a12f731791f15664dc7a1e8f665ceff9000608afa4f30cca72774df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->