### PR TITLE
Follow the OS color scheme preference with a system theme option

### DIFF
--- a/app/assets/javascripts/.eslintrc.js
+++ b/app/assets/javascripts/.eslintrc.js
@@ -14,6 +14,8 @@ module.exports = {
     'vars-on-top': 'off',
   },
   globals: {
+    applyColorMode: false,
+    watchColorModeChanges: false,
     getCsrfToken: false,
     sendFetch: false,
     preventDefaultAction: false,

--- a/app/assets/javascripts/initializers/initializeBodyData.js
+++ b/app/assets/javascripts/initializers/initializeBodyData.js
@@ -1,4 +1,4 @@
-/* global checkUserLoggedIn */
+/* global checkUserLoggedIn applyColorMode watchColorModeChanges */
 
 function removeExistingCSRF() {
   var csrfTokenMeta = document.querySelector("meta[name='csrf-token']");
@@ -51,12 +51,8 @@ function fetchBaseData() {
           const userJson = JSON.parse(user);
           browserStoreCache('set', user);
           document.body.className = userJson.config_body_class;
-
-          if (userJson.config_body_class && userJson.config_body_class.includes('dark-theme') && document.getElementById('dark-mode-style')) {
-            document.getElementById('body-styles').innerHTML = '<style>'+document.getElementById('dark-mode-style').innerHTML+'</style>'
-          } else {
-            document.getElementById('body-styles').innerHTML = '<style>'+document.getElementById('light-mode-style').innerHTML+'</style>'
-          }
+          applyColorMode(userJson.config_body_class);
+          watchColorModeChanges();
 
           if (window && window.ReactNativeWebView) {
             window.ReactNativeWebView.postMessage(JSON.stringify({

--- a/app/assets/javascripts/utilities/applyColorMode.js
+++ b/app/assets/javascripts/utilities/applyColorMode.js
@@ -1,0 +1,71 @@
+var DARK_COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)';
+
+function prefersDarkColorScheme() {
+  return Boolean(
+    window.matchMedia && window.matchMedia(DARK_COLOR_SCHEME_QUERY).matches,
+  );
+}
+
+function darkColorModeEnabled(bodyClass) {
+  if (!bodyClass) {
+    return false;
+  }
+
+  if (bodyClass.includes('system-theme')) {
+    return prefersDarkColorScheme();
+  }
+
+  return bodyClass.includes('dark-theme');
+}
+
+function applyColorMode(bodyClass) {
+  var isDark = darkColorModeEnabled(bodyClass);
+  var styleSource = document.getElementById(
+    isDark ? 'dark-mode-style' : 'light-mode-style',
+  );
+  var styleTarget = document.getElementById('body-styles');
+
+  // ten-x-hacker-theme is the marker the iOS app uses for its dark shell.
+  document.body.classList.toggle('dark-theme', isDark);
+  document.body.classList.toggle('ten-x-hacker-theme', isDark);
+
+  if (styleSource && styleTarget) {
+    styleTarget.innerHTML = '<style>' + styleSource.innerHTML + '</style>';
+  }
+
+  if (window.ReactNativeWebView) {
+    window.ReactNativeWebView.postMessage(
+      JSON.stringify({
+        action: 'update_color_mode',
+        value: isDark ? 'dark' : 'light',
+      }),
+    );
+  }
+
+  return isDark;
+}
+
+function watchColorModeChanges() {
+  if (!window.matchMedia || window.colorModeWatcherStarted) {
+    return;
+  }
+
+  var query = window.matchMedia(DARK_COLOR_SCHEME_QUERY);
+  var handler = function reapplyColorMode() {
+    applyColorMode(document.body.className);
+  };
+
+  if (query.addEventListener) {
+    query.addEventListener('change', handler);
+  } else if (query.addListener) {
+    query.addListener(handler);
+  }
+
+  window.colorModeWatcherStarted = true;
+}
+
+if (typeof globalThis !== 'undefined') {
+  globalThis.darkColorModeEnabled = darkColorModeEnabled; // eslint-disable-line no-undef
+  globalThis.applyColorMode = applyColorMode; // eslint-disable-line no-undef
+  globalThis.watchColorModeChanges = watchColorModeChanges; // eslint-disable-line no-undef
+}

--- a/app/assets/stylesheets/theme-selector.scss
+++ b/app/assets/stylesheets/theme-selector.scss
@@ -87,7 +87,7 @@
   }
 }
 
-.theme-selector--light-theme {
+@mixin theme-preview-light {
   --preview-body-bg: #f9f9fa;
   --preview-body-color: #0a0a0a;
   --preview-header: #fdf9f3;
@@ -96,13 +96,29 @@
   --preview-border: rgba(0, 0, 0, 0.1);
 }
 
-.theme-selector--dark-theme {
+@mixin theme-preview-dark {
   --preview-body-bg: #0d1219;
   --preview-body-color: #fff;
   --preview-header: #1c2938;
   --preview-form: #424a54;
   --preview-card: #202c3d;
   --preview-border: rgba(0, 0, 0, 0.1);
+}
+
+.theme-selector--light-theme {
+  @include theme-preview-light;
+}
+
+.theme-selector--dark-theme {
+  @include theme-preview-dark;
+}
+
+.theme-selector--system-theme {
+  @include theme-preview-light;
+
+  @media (prefers-color-scheme: dark) {
+    @include theme-preview-dark;
+  }
 }
 
 .rich-selector-radio {

--- a/app/javascript/utilities/__tests__/applyColorMode.test.js
+++ b/app/javascript/utilities/__tests__/applyColorMode.test.js
@@ -1,0 +1,146 @@
+import '../../../assets/javascripts/utilities/applyColorMode';
+
+/* global globalThis applyColorMode darkColorModeEnabled watchColorModeChanges */
+
+function mockPrefersDark(matches) {
+  const listeners = [];
+
+  window.matchMedia = jest.fn().mockImplementation((media) => ({
+    matches,
+    media,
+    addEventListener: (_eventName, handler) => listeners.push(handler),
+    removeEventListener: jest.fn(),
+  }));
+
+  return listeners;
+}
+
+function renderThemeStyleTags() {
+  document.body.innerHTML = `
+    <div id="dark-mode-style">:root { --base: dark; }</div>
+    <div id="light-mode-style">:root { --base: light; }</div>
+    <div id="body-styles"><style>:root { --base: initial; }</style></div>
+  `;
+}
+
+describe('applyColorMode', () => {
+  beforeEach(() => {
+    delete window.colorModeWatcherStarted;
+    document.body.className = '';
+    renderThemeStyleTags();
+    mockPrefersDark(false);
+  });
+
+  afterAll(() => {
+    delete globalThis.applyColorMode;
+    delete globalThis.darkColorModeEnabled;
+    delete globalThis.watchColorModeChanges;
+  });
+
+  describe('darkColorModeEnabled', () => {
+    it('is false when no body class is available', () => {
+      expect(darkColorModeEnabled(null)).toBe(false);
+      expect(darkColorModeEnabled('')).toBe(false);
+    });
+
+    it('is false for an explicit light theme even when the OS prefers dark', () => {
+      mockPrefersDark(true);
+
+      expect(darkColorModeEnabled('light-theme default-header')).toBe(false);
+    });
+
+    it('is true for an explicit dark theme even when the OS prefers light', () => {
+      mockPrefersDark(false);
+
+      expect(darkColorModeEnabled('dark-theme default-header')).toBe(true);
+    });
+
+    it('follows the OS preference for the system theme', () => {
+      mockPrefersDark(true);
+      expect(darkColorModeEnabled('system-theme default-header')).toBe(true);
+
+      mockPrefersDark(false);
+      expect(darkColorModeEnabled('system-theme default-header')).toBe(false);
+    });
+
+    it('is false for the system theme when matchMedia is unavailable', () => {
+      window.matchMedia = undefined;
+
+      expect(darkColorModeEnabled('system-theme default-header')).toBe(false);
+    });
+  });
+
+  describe('applyColorMode', () => {
+    it('applies the dark styles when the system theme resolves to dark', () => {
+      mockPrefersDark(true);
+
+      expect(applyColorMode('system-theme default-header')).toBe(true);
+      expect(document.body.classList.contains('dark-theme')).toBe(true);
+      expect(document.body.classList.contains('ten-x-hacker-theme')).toBe(true);
+      expect(document.getElementById('body-styles').innerHTML).toContain(
+        '--base: dark;',
+      );
+    });
+
+    it('applies the light styles when the system theme resolves to light', () => {
+      document.body.className = 'system-theme dark-theme ten-x-hacker-theme';
+
+      expect(applyColorMode(document.body.className)).toBe(false);
+
+      const { classList } = document.body;
+
+      expect(classList.contains('dark-theme')).toBe(false);
+      expect(classList.contains('ten-x-hacker-theme')).toBe(false);
+      expect(document.getElementById('body-styles').innerHTML).toContain(
+        '--base: light;',
+      );
+    });
+
+    it('leaves an explicit dark choice untouched when the OS prefers light', () => {
+      expect(applyColorMode('dark-theme ten-x-hacker-theme')).toBe(true);
+      expect(document.body.classList.contains('dark-theme')).toBe(true);
+      expect(document.getElementById('body-styles').innerHTML).toContain(
+        '--base: dark;',
+      );
+    });
+
+    it('leaves an explicit light choice untouched when the OS prefers dark', () => {
+      mockPrefersDark(true);
+
+      expect(applyColorMode('light-theme')).toBe(false);
+      expect(document.body.classList.contains('dark-theme')).toBe(false);
+      expect(document.getElementById('body-styles').innerHTML).toContain(
+        '--base: light;',
+      );
+    });
+  });
+
+  describe('watchColorModeChanges', () => {
+    it('reapplies the color mode when the OS preference flips', () => {
+      const listeners = mockPrefersDark(false);
+      document.body.className = 'system-theme default-header';
+
+      watchColorModeChanges();
+      applyColorMode(document.body.className);
+
+      expect(document.body.classList.contains('dark-theme')).toBe(false);
+
+      mockPrefersDark(true);
+      listeners.forEach((handler) => handler());
+
+      expect(document.body.classList.contains('dark-theme')).toBe(true);
+      expect(document.getElementById('body-styles').innerHTML).toContain(
+        '--base: dark;',
+      );
+    });
+
+    it('only registers a single listener', () => {
+      const listeners = mockPrefersDark(false);
+
+      watchColorModeChanges();
+      watchColorModeChanges();
+
+      expect(listeners).toHaveLength(1);
+    });
+  });
+});

--- a/app/models/users/setting.rb
+++ b/app/models/users/setting.rb
@@ -19,7 +19,7 @@ module Users
     enum :inbox_type, { private: 0, open: 1 }, suffix: :inbox
     enum :config_navbar, { default: 0, static: 1 }, suffix: :navbar
     # NOTE: We previously had a set of 5 themes with values from 0 to 4.
-    enum :config_theme, { light_theme: 0, dark_theme: 2 }
+    enum :config_theme, { light_theme: 0, system_theme: 1, dark_theme: 2 }
     enum :config_homepage_feed, { default: 0, latest: 1, top_week: 2, top_month: 3, top_year: 4, top_infinity: 5 },
          suffix: :feed
     enum :feed_status, { healthy: 0, degraded: 1, failing: 2, inactive: 3 }, prefix: :feed

--- a/app/views/layouts/_user_config.html.erb
+++ b/app/views/layouts/_user_config.html.erb
@@ -9,24 +9,20 @@
   }
 </div>
 <div id="user-prestyle"></div>
+<%# Inlined so the color mode is resolved before first paint. %>
+<script>
+  <%= Rails.application.assets["utilities/applyColorMode.js"].to_s.html_safe %>
+</script>
 <script>
   try {
     const bodyClass = localStorage.getItem('config_body_class');
     const userString = localStorage.getItem('current_user');
 
+    watchColorModeChanges();
+
     if (bodyClass) {
       document.body.className = bodyClass;
-
-      if (bodyClass.includes('dark-theme')) {
-        document.getElementById('body-styles').innerHTML = '<style>'+document.getElementById('dark-mode-style').innerHTML+'</style>';
-        if (window && window.ReactNativeWebView) {
-          window.ReactNativeWebView.postMessage(JSON.stringify({ action: 'update_color_mode', value: 'dark' }));
-        }
-      } else {
-        if (window && window.ReactNativeWebView) {
-          window.ReactNativeWebView.postMessage(JSON.stringify({ action: 'update_color_mode', value: 'light' }));
-        }
-      }
+      applyColorMode(bodyClass);
 
       if (bodyClass.includes('open-dyslexic-article-body')) { // Preloading custom font for anticipated use
         const link = document.createElement('link');

--- a/app/views/users/_customization.html.erb
+++ b/app/views/users/_customization.html.erb
@@ -14,8 +14,7 @@
     <fieldset class="crayons-field">
       <legend class="crayons-field__label"><%= t("views.settings.custom.theme") %></legend>
       <div class="theme-selector-field grid gap-4 grid-cols-2 l:grid-cols-3">
-        <%# This is temporary while we're migrating themes %>
-        <% %w[light_theme dark_theme].each do |theme| %>
+        <% Users::Setting.config_themes.keys.each do |theme| %>
           <%= render partial: "theme_selector", locals: { f: f, theme: theme } %>
         <% end %>
       </div>

--- a/app/views/users/_theme_selector.html.erb
+++ b/app/views/users/_theme_selector.html.erb
@@ -1,7 +1,8 @@
-<label class="rich-selector crayons-field crayons-field--radio p-4 theme-selector theme-selector--<%= theme.tr("_", "-") %>" title="<%= theme.titlecase %>">
+<% theme_label = t("views.settings.custom.themes.#{theme}", default: theme.titlecase) %>
+<label class="rich-selector crayons-field crayons-field--radio p-4 theme-selector theme-selector--<%= theme.tr("_", "-") %>" title="<%= theme_label %>">
   <%= f.radio_button :config_theme, theme, checked: @users_setting.config_theme == theme, class: "crayons-radio" %>
   <div class="crayons-field__label">
-    <%= theme.titlecase %>
+    <%= theme_label %>
 
     <div class="theme-preview mt-4">
       <div class="theme-preview__nav">

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -89,6 +89,10 @@ en:
         subforem_reassignment_desc: When your content is marked as off-topic for its current subforem, it may be automatically moved to a more appropriate subforem. You can disable this automatic relocation if you prefer to keep your content in its original location.
         subforem_reassignment_field: Disable automatic relocation of my content to other subforems
         theme: Site Theme
+        themes:
+          dark_theme: Dark Theme
+          light_theme: Light Theme
+          system_theme: System Theme
         writing: Writing
       danger: Danger Zone
       destroy:

--- a/config/locales/views/settings/fr.yml
+++ b/config/locales/views/settings/fr.yml
@@ -89,6 +89,10 @@ fr:
         subforem_reassignment_desc: Lorsque votre contenu est marqué comme hors-sujet pour son sous-forum actuel, il peut être automatiquement déplacé vers un sous-forum plus approprié. Vous pouvez désactiver cette relocalisation automatique si vous préférez garder votre contenu dans son emplacement d'origine.
         subforem_reassignment_field: Désactiver la relocalisation automatique de mon contenu vers d'autres sous-forums
         theme: Site Theme
+        themes:
+          dark_theme: Thème sombre
+          light_theme: Thème clair
+          system_theme: Thème du système
         writing: Writing
       danger: Danger Zone
       destroy:

--- a/config/locales/views/settings/pt.yml
+++ b/config/locales/views/settings/pt.yml
@@ -124,6 +124,11 @@ pt:
         update: Atualizar
         delete: Excluir
         confirm: Confirmar
+      custom:
+        themes:
+          dark_theme: Tema Escuro
+          light_theme: Tema Claro
+          system_theme: Tema do Sistema
       org:
         admin:
           members: Membros da Organização

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -118,6 +118,18 @@ RSpec.describe UserDecorator, type: :decorator do
       expect(user.decorate.config_body_class).to eq(expected_result)
     end
 
+    it "creates proper body class with system theme" do
+      user.setting.config_theme = "system_theme"
+      expected_result = %W[
+        system-theme sans-serif-article-body
+        mod-status-#{user.admin? || !user.moderator_for_tags.empty?}
+        trusted-status-#{user.trusted?} community-leader-status-#{user.community_leader?}
+        #{user.setting.config_navbar}-header
+      ].join(" ")
+      expect(user.decorate.config_body_class).to eq(expected_result)
+      expect(user.decorate.config_body_class).not_to include("ten-x-hacker-theme")
+    end
+
     it "works with static navbar" do
       user.setting.config_navbar = "static"
       expected_result = %W[

--- a/spec/models/users/setting_spec.rb
+++ b/spec/models/users/setting_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Users::Setting do
     it { is_expected.to define_enum_for(:inbox_type).with_values(private: 0, open: 1).with_suffix(:inbox) }
     it { is_expected.to define_enum_for(:config_font).with_values(default: 0, comic_sans: 1, monospace: 2, open_dyslexic: 3, sans_serif: 4, serif: 5).with_suffix(:font) }
     it { is_expected.to define_enum_for(:config_navbar).with_values(default: 0, static: 1).with_suffix(:navbar) }
-    it { is_expected.to define_enum_for(:config_theme).with_values(light_theme: 0, dark_theme: 2) }
+    it { is_expected.to define_enum_for(:config_theme).with_values(light_theme: 0, system_theme: 1, dark_theme: 2) }
     it { is_expected.to define_enum_for(:config_homepage_feed).with_values(default: 0, latest: 1, top_week: 2, top_month: 3, top_year: 4, top_infinity: 5).with_suffix(:feed) }
     it { is_expected.to define_enum_for(:feed_status).with_values(healthy: 0, degraded: 1, failing: 2, inactive: 3).with_prefix(:feed) }
 
@@ -62,6 +62,13 @@ RSpec.describe Users::Setting do
         setting.config_theme = 2
         expect(setting).to be_valid
         expect(setting.dark_theme?).to be true
+      end
+
+      it "accepts the system theme" do
+        setting.config_theme = 1
+        expect(setting).to be_valid
+        expect(setting.system_theme?).to be true
+        expect(setting.dark_theme?).to be false
       end
 
       it "does not accept invalid theme" do

--- a/spec/requests/user/user_settings_spec.rb
+++ b/spec/requests/user/user_settings_spec.rb
@@ -338,6 +338,35 @@ RSpec.describe "UserSettings" do
       expect(user.setting.reload.disallow_subforem_reassignment).to be(false)
     end
 
+    it "updates the users theme to follow the operating system color scheme" do
+      expect do
+        put users_settings_path(user.setting.id), params: { users_setting: { config_theme: "system_theme" } }
+      end.to change { user.setting.reload.config_theme }.from("light_theme").to("system_theme")
+    end
+
+    it "keeps an explicit theme choice when the user picks one" do
+      user.setting.update!(config_theme: :system_theme)
+
+      expect do
+        put users_settings_path(user.setting.id), params: { users_setting: { config_theme: "dark_theme" } }
+      end.to change { user.setting.reload.config_theme }.from("system_theme").to("dark_theme")
+    end
+
+    it "offers every theme, including the system one, in the customization form" do
+      get user_settings_path(:customization)
+
+      expect(response.body).to include("theme-selector--system-theme")
+      expect(response.body).to include("theme-selector--light-theme")
+      expect(response.body).to include("theme-selector--dark-theme")
+    end
+
+    it "inlines the color mode helper so the theme is resolved before first paint" do
+      get user_settings_path(:customization)
+
+      expect(response.body).to include("function applyColorMode")
+      expect(response.body).to include("prefers-color-scheme: dark")
+    end
+
     it "displays the subforem reassignment setting in the customization form" do
       get user_settings_path(:customization)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization

## Description

Addresses #22766, where dev.to does not react when the OS color theme is set to Automatic.

Investigating it, this turned out to be a missing feature rather than a broken one. `prefers-color-scheme` appeared nowhere except two cosmetic `<meta name="theme-color">` tags, and `config_theme` had only `light_theme: 0` and `dark_theme: 2`. There was simply no way for a user to say "follow my system."

Themes are applied entirely client-side today: `UserDecorator#config_body_class` builds a class string, it is cached in `localStorage`, and an inline script in `_user_config.html.erb` applies it before paint. This PR works with that mechanism rather than adding a parallel one.

- `system_theme: 1` added to the enum. Value `1` is free, vacated by the 2021 theme migrations, so no migration is required.
- New `applyColorMode.js` holds the single implementation of theme resolution.
- When it resolves to dark it **toggles the existing `dark-theme` class**. That is the key choice: nothing downstream needs to know "system" exists, so the `body.dark-theme` CSS rules, the `classList.contains(...)` checks in the analytics dashboard and heatmap, and the iOS `ten-x-hacker-theme` marker all keep working untouched.
- Live OS switching is handled via a `matchMedia` `change` listener, so a machine flipping to dark at sunset updates without a reload. The listener re-applies only the theme bits, so runtime-added body classes survive.
- The selector tile for System uses the light palette and swaps under `@media (prefers-color-scheme: dark)`, so the preview honestly shows what it will do.

**An explicit choice always wins.** `darkColorModeEnabled` consults `matchMedia` only when the body class contains `system-theme`, so a user on light with an OS set to dark stays light. Covered by dedicated tests in both directions.

### Two decisions worth a maintainer opinion

**1. I did not change the default.** The issue says the site should follow the system setting by default, and this ships opt-in instead. The reason: `config_theme` defaults to `0` and every existing row stores `0`, so "explicitly chose light" is indistinguishable from "never chose." Flipping the column default or backfilling would silently override real user choices. Making system the default for *new* users is a one-line migration if you want it, but it is a product call, so I did not make it unilaterally.

**2. There is a dead `users_settings.prefer_os_color_scheme` boolean** in the schema from 2021, referenced only by two data-update scripts. I did not resurrect it, since a boolean alongside the enum would give two sources of truth for one setting. Worth dropping separately.

### Known gaps, deliberately out of scope

- `AudienceSegment` has `dark_theme` / `light_theme` segments; system-theme users fall into neither. Adding a segment needs a new value in that model's own enum.
- `app/views/credits/new.html.erb` branches on `setting.dark_theme?` server-side to style Stripe Elements, so system users get light Stripe styling regardless of OS. I left a payment page alone on purpose; happy to follow up.

## Related Tickets & Documents

- Closes #22766

## QA Instructions, Screenshots, Recordings

1. Go to Settings > Customization > Theme and select System.
2. Flip your OS between light and dark. The site should follow without a reload.
3. Select Light explicitly, set the OS to dark, and confirm the site stays light. Repeat inverted.
4. Reload on System with the OS in dark and confirm there is no light flash before paint.

Pre-existing and unchanged: on a very first visit there is no `config_body_class` in localStorage, so any non-light theme still arrives with the async base-data fetch. That already affects explicit dark-theme users.

### UI accessibility checklist
- [x] Semantic HTML implemented? (reuses the existing radio-based theme selector)
- [x] Keyboard operability supported? (unchanged)
- [x] Color contrast tested? (System reuses the existing light and dark palettes)

## Added/updated tests?

- [x] Yes

Run locally on Ruby 3.3.0 with PostgreSQL 16:

```
$ bundle exec rspec spec/models/users/setting_spec.rb spec/decorators/user_decorator_spec.rb spec/requests/user/user_settings_spec.rb
127 examples, 0 failures
```

Plus `applyColorMode.test.js` with 11 Jest cases covering the resolution truth table, explicit-choice-wins in both directions, absent `matchMedia`, idempotency, the OS-flip listener, and single listener registration. I was not able to run Jest locally, so those have not been executed.

One spec deliberately asserts the rendered page contains `function applyColorMode`, as a guard rail: `Rails.application.assets[...]` returns `nil` silently via `.to_s` if the lookup ever fails.

## [optional] Are there any post deployment tasks we need to perform?

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789414567&installation_model_id=424141&pr_number=23731&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23731&signature=899e7f1485fde08b36ac378b68ed4699e03fb638bf6cd732180a0455cf84478f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->