### PR TITLE
Restore Ahoy click tracking on the Customer.io path, and gate the digest on moderation status

### DIFF
--- a/app/services/delivery_methods/customer_io.rb
+++ b/app/services/delivery_methods/customer_io.rb
@@ -42,7 +42,22 @@ module DeliveryMethods
         message[:to] = mail.to.join(",") if mail.to
         forwarded = forwarded_headers(mail)
         message[:headers] = forwarded if forwarded.any?
-      end.merge(settings)
+      end.merge(settings).merge(tracked_message_data(mail))
+    end
+
+    # Customer.io renders from message_data, so Ahoy's link rewriting -- which
+    # operates on the ActionMailer body -- never reaches the recipient. Re-apply
+    # it to the payload so clicks still reach Ahoy::EmailClicksController.
+    #
+    # mail.ahoy_data is set by AhoyEmail::Processor in an after_action. Rails
+    # runs after_actions in reverse registration order, so it lands *after*
+    # Deliverable#set_delivery_options picks this delivery method -- which is
+    # why the token is read here at delivery time rather than captured into
+    # settings when the delivery method was chosen.
+    def tracked_message_data(mail)
+      return {} if settings[:message_data].blank?
+
+      { message_data: Emails::AhoyLinkDecorator.call(settings[:message_data], ahoy_data: mail.ahoy_data) }
     end
 
     def forwarded_headers(mail)

--- a/app/services/email_digest.rb
+++ b/app/services/email_digest.rb
@@ -26,10 +26,20 @@ class EmailDigest
 
   private
 
+  # Deliberately not User.email_eligible: that scope also requires
+  # email_newsletter, and the periodic digest is a separate consent (see
+  # Users::NotificationSetting#email_digest_periodic). We take its moderation
+  # filters without its newsletter filter.
+  #
+  # Banishing sets the Suspended role but does not clear email_digest_periodic,
+  # so without these filters banished and spam-flagged accounts keep receiving
+  # the digest.
   def get_users(starting_id, ending_id)
     User.registered.joins(:notification_setting)
       .where(notification_setting: { email_digest_periodic: true })
       .where.not(email: "")
+      .without_role(:suspended)
+      .without_role(:spam)
       .where("users.id >= ? AND users.id <= ?", starting_id, ending_id)
   end
 end

--- a/app/services/emails/ahoy_link_decorator.rb
+++ b/app/services/emails/ahoy_link_decorator.rb
@@ -81,25 +81,29 @@ module Emails
     end
 
     # Returns nil when the value should keep its original string.
-    #
-    # External links are deliberately left alone. On the SMTP path they redirect
-    # through the mounted AhoyEmail engine, but that URL is built from the
-    # mailer's default_url_options, which in production already includes the
-    # protocol in :host -- so the redirect target is malformed there and the
-    # route is, per config/routes.rb, "not currently where emails pass through".
-    # Reproducing it here would only produce broken links; external clicks would
-    # in any case set clicked_at and nothing else.
     def decorate_url(href)
       uri = AhoyLinkTracking.parse_uri(href)
       return unless AhoyLinkTracking.trackable?(uri)
-      return unless AhoyLinkTracking.internal?(uri)
-      return if AhoyLinkTracking.unsubscribe?(href)
+      return if AhoyLinkTracking.skip?(uri, href)
 
-      AhoyLinkTracking.internal_url(uri, href, token: @token, campaign: @campaign)
+      if AhoyLinkTracking.internal?(uri)
+        AhoyLinkTracking.internal_url(uri, href, token: @token, campaign: @campaign)
+      else
+        AhoyLinkTracking.external_url(
+          href, token: @token, campaign: @campaign, url_options: url_options
+        )
+      end
     rescue StandardError => e
       # One unparseable link must not cost the whole payload its tracking.
       Rails.logger.warn("[ahoy_link_decorator] link skipped: #{e.class}: #{e.message}")
       nil
+    end
+
+    # ApplicationMailer#setup_subforem_context sets this per message, so it
+    # carries the subforem-aware host the ERB layout used. Read at delivery
+    # time, same as the token.
+    def url_options
+      ActionMailer::Base.default_url_options || {}
     end
   end
 end

--- a/app/services/emails/ahoy_link_decorator.rb
+++ b/app/services/emails/ahoy_link_decorator.rb
@@ -1,0 +1,105 @@
+module Emails
+  # Re-applies Ahoy's email link tracking to a Customer.io message_data payload.
+  #
+  # Ahoy rewrites links in the ActionMailer-rendered HTML body. Customer.io
+  # discards that body and renders its own template from message_data, so on the
+  # Customer.io path none of the recipient's links carry tracking parameters and
+  # Ahoy::EmailClicksController is never reached. Everything that controller
+  # drives goes dark with it: clicked_at, email FeedEvents (which feed
+  # FeedConfig#feed_success_score), the user interest embedding, billboard click
+  # events, last_presence_at, and the user_clicks_email_link field test
+  # conversion.
+  #
+  # The URL rules themselves live in Emails::AhoyLinkTracking, shared with the
+  # AhoyEmail::Processor patch that does the same job for the SMTP path.
+  class AhoyLinkDecorator
+    def self.call(message_data, ahoy_data:)
+      new(message_data, ahoy_data).call
+    end
+
+    def initialize(message_data, ahoy_data)
+      @message_data = message_data
+      @token = ahoy_data.is_a?(Hash) ? ahoy_data[:token] : nil
+      @campaign = ahoy_data.is_a?(Hash) ? ahoy_data[:campaign] : nil
+    end
+
+    # The token is only present when click tracking is on (AHOY_EMAIL_CLICK_ON
+    # in production) and AhoyEmail.save_token is set, and the after_action that
+    # populates it is wrapped in Safely.safely -- so a missing token is an
+    # ordinary state, not an error. Tracking is never worth losing a send over,
+    # so anything unexpected falls back to the undecorated payload.
+    def call
+      return @message_data if @token.blank? || @message_data.blank?
+
+      decorate(@message_data)
+    rescue StandardError => e
+      Rails.logger.warn("[ahoy_link_decorator] skipped: #{e.class}: #{e.message}")
+      @message_data
+    end
+
+    private
+
+    def decorate(value)
+      case value
+      when Hash
+        value.transform_values { |nested| decorate(nested) }
+      when Array
+        value.map { |nested| decorate(nested) }
+      when String
+        decorate_string(value)
+      else
+        value
+      end
+    end
+
+    # Payload values are either bare URLs (an article's "url") or fragments of
+    # rendered HTML ("smart_summary", billboard processed_html).
+    def decorate_string(value)
+      return decorate_html(value) if value.include?("<a")
+
+      decorate_url(value) || value
+    end
+
+    def decorate_html(html)
+      doc = Nokogiri::HTML::DocumentFragment.parse(html)
+      doc.css("a[href]").each do |link|
+        next if skip_attribute?(link)
+
+        decorated = decorate_url(link["href"])
+        link["href"] = decorated if decorated
+      end
+      # Matches the body rewriting in config/initializers/ahoy_email.rb, which
+      # unescapes ampersands for the same reason.
+      doc.to_s.gsub("&amp;", "&")
+    end
+
+    def skip_attribute?(link)
+      return false unless link["data-skip-click"]
+
+      link.remove_attribute("data-skip-click")
+      true
+    end
+
+    # Returns nil when the value should keep its original string.
+    #
+    # External links are deliberately left alone. On the SMTP path they redirect
+    # through the mounted AhoyEmail engine, but that URL is built from the
+    # mailer's default_url_options, which in production already includes the
+    # protocol in :host -- so the redirect target is malformed there and the
+    # route is, per config/routes.rb, "not currently where emails pass through".
+    # Reproducing it here would only produce broken links; external clicks would
+    # in any case set clicked_at and nothing else.
+    def decorate_url(href)
+      uri = AhoyLinkTracking.parse_uri(href)
+      return unless AhoyLinkTracking.trackable?(uri)
+      return unless AhoyLinkTracking.internal?(uri)
+      return if AhoyLinkTracking.unsubscribe?(href)
+
+      AhoyLinkTracking.internal_url(uri, href, token: @token, campaign: @campaign)
+    rescue StandardError => e
+      # One unparseable link must not cost the whole payload its tracking.
+      Rails.logger.warn("[ahoy_link_decorator] link skipped: #{e.class}: #{e.message}")
+      nil
+    end
+  end
+end

--- a/app/services/emails/ahoy_link_tracking.rb
+++ b/app/services/emails/ahoy_link_tracking.rb
@@ -1,0 +1,70 @@
+module Emails
+  # The rules for turning a link into an Ahoy-tracked click URL, in one place.
+  #
+  # Two callers need them and must agree exactly, because
+  # Ahoy::EmailClicksController#verify_signature rejects anything that does not
+  # match byte for byte:
+  #
+  #   - the AhoyEmail::Processor patch in config/initializers/ahoy_email.rb,
+  #     which rewrites the rendered body on the SMTP path
+  #   - Emails::AhoyLinkDecorator, which rewrites the Customer.io message_data
+  #     payload, since Customer.io renders its own template and never sees that
+  #     body
+  #
+  # Only internal links are handled here. External links go through the mounted
+  # AhoyEmail engine's redirect, whose URL generation differs per caller, so the
+  # initializer keeps building those itself.
+  module AhoyLinkTracking
+    module_function
+
+    def trackable?(uri)
+      uri&.absolute? && %w[http https].include?(uri.scheme)
+    end
+
+    def parse_uri(href)
+      Addressable::URI.heuristic_parse(href.to_s)
+    rescue StandardError
+      nil
+    end
+
+    def internal?(uri)
+      uri.host == Settings::General.app_domain
+    end
+
+    # Mirrors AhoyEmail::Processor#skip_attribute?, which refuses to rewrite
+    # unsubscribe links so a tracking failure can never block an opt-out.
+    def unsubscribe?(href)
+      href.to_s.match?(/unsubscribe/i)
+    end
+
+    def signature(href, token:, campaign:)
+      AhoyEmail::Utils.signature(token: token, campaign: campaign, url: href)
+    end
+
+    # Internal links keep their destination and carry the tracking params
+    # through to the page, where baseTracking.js posts them to
+    # Ahoy::EmailClicksController and strips them from the address bar.
+    #
+    # "u" is CGI.escaped here and percent-encoded again when Addressable
+    # rebuilds the query. That double encoding is deliberate: URLSearchParams
+    # decodes once and baseTracking.js calls decodeURIComponent on the result,
+    # and the controller verifies the signature against that twice-decoded
+    # value.
+    def internal_url(uri, href, token:, campaign:)
+      tracking_params = {
+        "ahoy_click" => true,
+        "t" => token,
+        "s" => signature(href, token: token, campaign: campaign),
+        "u" => CGI.escape(href),
+        "c" => campaign
+      }.reject { |_key, value| value.nil? || value.to_s.empty? }
+
+      uri.query_values = (uri.query_values(Array) || []) + tracking_params.to_a
+
+      port_part = uri.port ? ":#{uri.port}" : ""
+      url = "#{uri.scheme}://#{uri.host}#{port_part}#{uri.path}"
+      url += "?#{uri.query}" if uri.query.present?
+      url
+    end
+  end
+end

--- a/app/services/emails/ahoy_link_tracking.rb
+++ b/app/services/emails/ahoy_link_tracking.rb
@@ -11,9 +11,6 @@ module Emails
   #     payload, since Customer.io renders its own template and never sees that
   #     body
   #
-  # Only internal links are handled here. External links go through the mounted
-  # AhoyEmail engine's redirect, whose URL generation differs per caller, so the
-  # initializer keeps building those itself.
   module AhoyLinkTracking
     module_function
 
@@ -35,6 +32,22 @@ module Emails
     # unsubscribe links so a tracking failure can never block an opt-out.
     def unsubscribe?(href)
       href.to_s.match?(/unsubscribe/i)
+    end
+
+    # A tracked URL pasted back into stored content (a billboard, a survey body)
+    # arrives here looking like an ordinary internal link. Decorating it again
+    # appends a second t/s/u set, and because Rack resolves duplicate params to
+    # the last value, the engine redirect verifies the outer signature and
+    # forwards to itself -- a loop. Leave anything already carrying tracking
+    # alone.
+    def already_tracked?(uri, href)
+      return true if href.to_s.include?("ahoy_click=true")
+
+      internal?(uri) && uri.path.to_s.start_with?("/ahoy/")
+    end
+
+    def skip?(uri, href)
+      unsubscribe?(href) || already_tracked?(uri, href)
     end
 
     def signature(href, token:, campaign:)
@@ -65,6 +78,27 @@ module Emails
       url = "#{uri.scheme}://#{uri.host}#{port_part}#{uri.path}"
       url += "?#{uri.query}" if uri.query.present?
       url
+    end
+
+    # External links cannot carry our params to a page that would read them, so
+    # they redirect through the mounted AhoyEmail engine, which records the
+    # click and forwards. That only sets clicked_at -- the other five effects
+    # need the recipient to land on this Forem.
+    #
+    # url_options supplies the host. Note production sets it to
+    # protocol + APP_DOMAIN, e.g. "https://dev.to"; ActionDispatch normalizes a
+    # host carrying its own scheme, so this still builds a well-formed URL.
+    def external_url(href, token:, campaign:, url_options: {})
+      AhoyEmail::Engine.routes.url_helpers.url_for(
+        url_options.merge(
+          controller: "ahoy/messages",
+          action: "click",
+          t: token,
+          c: campaign,
+          u: href,
+          s: signature(href, token: token, campaign: campaign),
+        ),
+      )
     end
   end
 end

--- a/app/workers/emails/send_user_digest_worker.rb
+++ b/app/workers/emails/send_user_digest_worker.rb
@@ -8,9 +8,7 @@ module Emails
       user = User.find_by(id: user_id)
       return unless user&.registered?
 
-      if !force_send && !user.notification_setting&.email_digest_periodic?
-        return
-      end
+      return if !force_send && !digest_eligible?(user)
 
       collector = EmailDigestArticleCollector.new(user, force_send: force_send)
       articles = collector.articles_to_send
@@ -103,6 +101,17 @@ module Emails
         Honeybadger.context({ user_id: user.id, article_ids: articles.map(&:id) })
         Honeybadger.notify(e)
       end
+    end
+
+    private
+
+    # Mirrors EmailDigest#get_users. The cron already applies these, but the
+    # worker is also reachable directly -- perform_async on Forems that do not
+    # send the digest inline, and console sends -- so the guard belongs here too.
+    def digest_eligible?(user)
+      return false unless user.notification_setting&.email_digest_periodic?
+
+      !user.suspended? && !user.spam?
     end
   end
 end

--- a/app/workers/emails/send_user_digest_worker.rb
+++ b/app/workers/emails/send_user_digest_worker.rb
@@ -8,7 +8,15 @@ module Emails
       user = User.find_by(id: user_id)
       return unless user&.registered?
 
-      return if !force_send && !digest_eligible?(user)
+      # Mirrors EmailDigest#get_users. The cron already filters on both, but the
+      # worker is reachable directly -- perform_async on Forems that do not send
+      # the digest inline, and console sends -- so the guards belong here too.
+      #
+      # Moderation status is deliberately not overridable: force_send exists to
+      # bypass the digest consent check for manual and retry sends, not to email
+      # a suspended or spam-flagged account.
+      return if user.suspended? || user.spam?
+      return if !force_send && !user.notification_setting&.email_digest_periodic?
 
       collector = EmailDigestArticleCollector.new(user, force_send: force_send)
       articles = collector.articles_to_send
@@ -101,17 +109,6 @@ module Emails
         Honeybadger.context({ user_id: user.id, article_ids: articles.map(&:id) })
         Honeybadger.notify(e)
       end
-    end
-
-    private
-
-    # Mirrors EmailDigest#get_users. The cron already applies these, but the
-    # worker is also reachable directly -- perform_async on Forems that do not
-    # send the digest inline, and console sends -- so the guard belongs here too.
-    def digest_eligible?(user)
-      return false unless user.notification_setting&.email_digest_periodic?
-
-      !user.suspended? && !user.spam?
     end
   end
 end

--- a/config/initializers/ahoy_email.rb
+++ b/config/initializers/ahoy_email.rb
@@ -28,6 +28,11 @@ module AhoyEmail
 
     private
 
+    # The internal-link rules live in Emails::AhoyLinkTracking so that this
+    # (which rewrites the rendered body, for SMTP) and
+    # Emails::AhoyLinkDecorator (which rewrites the Customer.io message_data
+    # payload) cannot drift apart. Both have to produce URLs that
+    # Ahoy::EmailClicksController will verify.
     def process_link(link)
       uri = parse_uri(link["href"])
       return unless trackable?(uri)
@@ -36,12 +41,13 @@ module AhoyEmail
 
       return unless options[:click] && !skip_attribute?(link, "click")
 
-      signature = Utils.signature(token: token, campaign: campaign, url: link["href"])
-
-      if internal_link?(uri)
-        handle_internal_link(uri, link, signature)
+      if Emails::AhoyLinkTracking.internal?(uri)
+        link["href"] = Emails::AhoyLinkTracking.internal_url(
+          uri, link["href"], token: token, campaign: campaign
+        )
       else
-        handle_external_link(uri, link, signature)
+        signature = Utils.signature(token: token, campaign: campaign, url: link["href"])
+        handle_external_link(link, signature)
       end
     end
 
@@ -54,34 +60,14 @@ module AhoyEmail
       end
       uri.query_values = existing_params
 
-      # Update the href for external links after adding UTM parameters
-      link["href"] = uri.to_s unless internal_link?(uri)
+      # Written back for every link, not just external ones, so that
+      # process_link can re-read the href without losing the UTM params it just
+      # added. Internal links have their href rebuilt from the same uri
+      # immediately afterwards, so this is a no-op for them.
+      link["href"] = uri.to_s
     end
 
-    def internal_link?(uri)
-      uri.host == Settings::General.app_domain
-    end
-
-    def handle_internal_link(uri, link, signature)
-      tracking_params = {
-        "ahoy_click" => true,
-        "t" => token,
-        "s" => signature,
-        "u" => CGI.escape(link["href"]),
-        "c" => campaign
-      }.reject { |_k, v| v.nil? || v.to_s.empty? }
-
-      # Merge existing and tracking params
-      all_params = (uri.query_values(Array) || []) + tracking_params.to_a
-      uri.query_values = all_params
-
-      # Reconstruct the href with updated parameters
-      port_part = uri.port ? ":#{uri.port}" : ""
-      link["href"] = "#{uri.scheme}://#{uri.host}#{port_part}#{uri.path}"
-      link["href"] += "?#{uri.query}" unless uri.query.nil? || uri.query.empty?
-    end
-
-    def handle_external_link(uri, link, signature)
+    def handle_external_link(link, signature)
       link["href"] = url_for(
         controller: "ahoy/messages",
         action: "click",

--- a/config/initializers/ahoy_email.rb
+++ b/config/initializers/ahoy_email.rb
@@ -40,15 +40,22 @@ module AhoyEmail
       add_utm_params(uri, link) if options[:utm_params] && !skip_attribute?(link, "utm-params")
 
       return unless options[:click] && !skip_attribute?(link, "click")
+      return if Emails::AhoyLinkTracking.already_tracked?(uri, link["href"])
 
-      if Emails::AhoyLinkTracking.internal?(uri)
-        link["href"] = Emails::AhoyLinkTracking.internal_url(
-          uri, link["href"], token: token, campaign: campaign
-        )
-      else
-        signature = Utils.signature(token: token, campaign: campaign, url: link["href"])
-        handle_external_link(link, signature)
-      end
+      link["href"] =
+        if Emails::AhoyLinkTracking.internal?(uri)
+          Emails::AhoyLinkTracking.internal_url(
+            uri, link["href"], token: token, campaign: campaign
+          )
+        else
+          Emails::AhoyLinkTracking.external_url(
+            link["href"], token: token, campaign: campaign, url_options: link_url_options
+          )
+        end
+    end
+
+    def link_url_options
+      (mailer.default_url_options || {}).merge(options[:url_options] || {})
     end
 
     def add_utm_params(uri, link)
@@ -65,17 +72,6 @@ module AhoyEmail
       # added. Internal links have their href rebuilt from the same uri
       # immediately afterwards, so this is a no-op for them.
       link["href"] = uri.to_s
-    end
-
-    def handle_external_link(link, signature)
-      link["href"] = url_for(
-        controller: "ahoy/messages",
-        action: "click",
-        t: token,
-        c: campaign,
-        u: link["href"],
-        s: signature,
-      )
     end
   end
 end

--- a/spec/requests/ahoy/email_clicks_spec.rb
+++ b/spec/requests/ahoy/email_clicks_spec.rb
@@ -56,9 +56,10 @@ RSpec.describe "AhoyEmailClicks" do
         expect(AhoyEmail::Utils).to have_received(:publish)
           .with(:click,
                 hash_including(token: token, campaign: campaign, url: url, controller: controller))
-        expect(FeedEvent.where(article_id: article.id, category: "click", context_type: "email", feed_config_id: feed_config.id).size).to be(1)
+        expect(FeedEvent.where(article_id: article.id, category: "click", context_type: "email",
+                               feed_config_id: feed_config.id).size).to be(1)
       end
-      
+
       it "enqueues UpdateUserInterestEmbeddingWorker with weight 0.025 if user and article are present" do
         user = create(:user)
         create(:email_message, user: user, token: token)
@@ -68,7 +69,9 @@ RSpec.describe "AhoyEmailClicks" do
 
         allow(AhoyEmail::Utils).to receive(:publish).and_return(true)
 
-        sidekiq_assert_enqueued_with(job: UpdateUserInterestEmbeddingWorker, args: [user.id, article.id, Ahoy::EmailClicksController::EMAIL_CLICK_INTEREST_BLEND_FACTOR]) do
+        sidekiq_assert_enqueued_with(job: UpdateUserInterestEmbeddingWorker,
+                                     args: [user.id, article.id,
+                                            Ahoy::EmailClicksController::EMAIL_CLICK_INTEREST_BLEND_FACTOR]) do
           post ahoy_email_clicks_path, params: { t: token, c: campaign, u: url, s: signature }
         end
       end
@@ -85,9 +88,76 @@ RSpec.describe "AhoyEmailClicks" do
         user = create(:user)
         create(:email_message, user: user, token: token)
 
-        sidekiq_assert_enqueued_with(job: Users::RecordFieldTestEventWorker, args: [user.id, AbExperiment::GoalConversionHandler::USER_CLICKS_EMAIL_LINK_GOAL]) do
+        sidekiq_assert_enqueued_with(job: Users::RecordFieldTestEventWorker,
+                                     args: [user.id,
+                                            AbExperiment::GoalConversionHandler::USER_CLICKS_EMAIL_LINK_GOAL]) do
           post ahoy_email_clicks_path, params: { t: token, c: campaign, u: url, s: signature }
         end
+      end
+    end
+
+    # The decorator moved this URL construction out of the AhoyEmail::Processor
+    # patch and into Emails::AhoyLinkTracking. What has to survive that move is
+    # not a particular string but this controller's willingness to accept it, so
+    # build the URL the way a Customer.io email would carry it and put it
+    # through the same journey baseTracking.js sends a real click on.
+    context "with a URL built by Emails::AhoyLinkDecorator" do
+      it "verifies the signature and records the click", :aggregate_failures do
+        user = create(:user, last_presence_at: 2.hours.ago)
+        create(:email_message, user: user, token: token)
+        article = create(:article)
+        feed_config = create(:feed_config)
+        href = "#{URL.article(article)}?context=digest&fc=#{feed_config.id}"
+
+        decorated = Emails::AhoyLinkDecorator.call(
+          { "url" => href }, ahoy_data: { token: token, campaign: campaign }
+        ).fetch("url")
+
+        # URLSearchParams decodes once and baseTracking.js calls
+        # decodeURIComponent on the result, so "u" reaches us twice-decoded.
+        params = Rack::Utils.parse_query(Addressable::URI.parse(decorated).query)
+
+        expect do
+          post ahoy_email_clicks_path, params: {
+            t: params["t"], c: params["c"], u: CGI.unescape(params["u"]), s: params["s"]
+          }
+        end.to change { user.reload.last_presence_at }
+
+        expect(response).to have_http_status(:ok)
+        expect(FeedEvent.where(article_id: article.id, category: "click", context_type: "email").size).to be(1)
+      end
+
+      # The encoding depth only matters when the destination itself contains
+      # percent sequences: with a plain URL, an extra or missing unescape is a
+      # no-op and a single-encoded "u" would still verify. This is the case that
+      # actually pins it.
+      it "survives a destination carrying percent-encoded characters" do
+        href = "#{URL.url}/search?q=100%25%20ruby&tag=c%2B%2B"
+
+        decorated = Emails::AhoyLinkDecorator.call(
+          { "url" => href }, ahoy_data: { token: token, campaign: campaign }
+        ).fetch("url")
+
+        params = Rack::Utils.parse_query(Addressable::URI.parse(decorated).query)
+
+        post ahoy_email_clicks_path, params: {
+          t: params["t"], c: params["c"], u: CGI.unescape(params["u"]), s: params["s"]
+        }
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "sends the recipient to the original destination, not the tracked URL" do
+        href = "#{URL.url}/ben/some-post?context=digest"
+
+        decorated = Emails::AhoyLinkDecorator.call(
+          { "url" => href }, ahoy_data: { token: token, campaign: campaign }
+        ).fetch("url")
+
+        params = Rack::Utils.parse_query(Addressable::URI.parse(decorated).query)
+
+        expect(CGI.unescape(params["u"])).to eq(href)
+        expect(decorated).to start_with("#{URL.url}/ben/some-post?context=digest&")
       end
     end
 

--- a/spec/services/delivery_methods/customer_io_spec.rb
+++ b/spec/services/delivery_methods/customer_io_spec.rb
@@ -82,6 +82,35 @@ RSpec.describe DeliveryMethods::CustomerIo do
     expect(message[:body]).to eq("<p>html export</p>")
   end
 
+  # Customer.io renders its own template, so Ahoy's rewriting of the
+  # ActionMailer body never reaches the recipient. The payload has to carry the
+  # tracking params instead or Ahoy::EmailClicksController is never called.
+  describe "click tracking in the payload" do
+    let(:article_url) { "https://#{Settings::General.app_domain}/ben/some-post" }
+
+    it "decorates message_data links using the token Ahoy set on the mail" do
+      mail.ahoy_data = { token: "tok123", campaign: nil }
+
+      message = delivered_message(
+        transactional_message_id: "dev_test_template",
+        message_data: { "url" => article_url },
+      )
+
+      params = Rack::Utils.parse_query(Addressable::URI.parse(message[:message_data]["url"]).query)
+      expect(params["ahoy_click"]).to eq("true")
+      expect(params["t"]).to eq("tok123")
+    end
+
+    it "leaves message_data alone when Ahoy did not set a token" do
+      message = delivered_message(
+        transactional_message_id: "dev_test_template",
+        message_data: { "url" => article_url },
+      )
+
+      expect(message[:message_data]["url"]).to eq(article_url)
+    end
+  end
+
   it "attaches mail attachments to the request" do
     mail.attachments["export.zip"] = "zipbytes"
     request_double = instance_double(Customerio::SendEmailRequest, attach: nil, message: {})

--- a/spec/services/email_digest_spec.rb
+++ b/spec/services/email_digest_spec.rb
@@ -1,10 +1,15 @@
 require "rails_helper"
 
 RSpec.describe EmailDigest, type: :service do
+  def digest_subscriber(**attrs)
+    create(:user, **attrs).tap do |user|
+      user.notification_setting.update(email_digest_periodic: true)
+    end
+  end
+
   describe "::send_digest_email" do
     it "enqueues Emails::SendUserDigestWorker" do
-      user = create(:user)
-      user.notification_setting.update(email_digest_periodic: true)
+      user = digest_subscriber
       allow(Emails::SendUserDigestWorker).to receive(:perform_async)
       described_class.send_periodic_digest_email
       expect(Emails::SendUserDigestWorker).to have_received(:perform_async).with(user.id)
@@ -12,8 +17,7 @@ RSpec.describe EmailDigest, type: :service do
 
     it "performs job inline if community is DEV" do
       allow(ForemInstance).to receive(:dev_to?).and_return(true)
-      user = create(:user)
-      user.notification_setting.update(email_digest_periodic: true)
+      user = digest_subscriber
       worker = Emails::SendUserDigestWorker.new
       allow(worker).to receive(:perform)
       allow(Emails::SendUserDigestWorker).to receive(:new).and_return(worker)
@@ -21,6 +25,57 @@ RSpec.describe EmailDigest, type: :service do
       described_class.send_periodic_digest_email
       expect(Emails::SendUserDigestWorker).not_to have_received(:perform_async)
       expect(worker).to have_received(:perform).with(user.id)
+    end
+  end
+
+  describe "eligibility" do
+    before { allow(Emails::SendUserDigestWorker).to receive(:perform_async) }
+
+    it "skips suspended users" do
+      user = digest_subscriber
+      user.add_role(:suspended)
+
+      described_class.send_periodic_digest_email
+
+      expect(Emails::SendUserDigestWorker).not_to have_received(:perform_async).with(user.id)
+    end
+
+    it "skips spam users" do
+      user = digest_subscriber
+      user.add_role(:spam)
+
+      described_class.send_periodic_digest_email
+
+      expect(Emails::SendUserDigestWorker).not_to have_received(:perform_async).with(user.id)
+    end
+
+    # Banishing suspends and renames the account but leaves the digest consent
+    # in place, so the role filter is what catches it -- see
+    # Moderator::BanishUser.
+    it "skips banished users" do
+      user = digest_subscriber
+      Moderator::BanishUser.call(admin: create(:user, :super_admin), user: user)
+
+      described_class.send_periodic_digest_email
+
+      expect(Emails::SendUserDigestWorker).not_to have_received(:perform_async).with(user.id)
+    end
+
+    it "still includes users who have not opted into the newsletter" do
+      user = digest_subscriber
+      user.notification_setting.update(email_newsletter: false)
+
+      described_class.send_periodic_digest_email
+
+      expect(Emails::SendUserDigestWorker).to have_received(:perform_async).with(user.id)
+    end
+
+    it "honours the id range so the sharded cron still partitions" do
+      user = digest_subscriber
+
+      described_class.send_periodic_digest_email([], user.id + 1, user.id + 100)
+
+      expect(Emails::SendUserDigestWorker).not_to have_received(:perform_async).with(user.id)
     end
   end
 end

--- a/spec/services/emails/ahoy_link_decorator_spec.rb
+++ b/spec/services/emails/ahoy_link_decorator_spec.rb
@@ -1,0 +1,142 @@
+require "rails_helper"
+
+RSpec.describe Emails::AhoyLinkDecorator, type: :service do
+  let(:token) { "abc123token" }
+  let(:ahoy_data) { { token: token, campaign: nil } }
+  let(:domain) { Settings::General.app_domain }
+  let(:article_url) { "https://#{domain}/ben/some-post?context=digest" }
+
+  def decorate(payload, data: ahoy_data)
+    described_class.call(payload, ahoy_data: data)
+  end
+
+  def params_from(url)
+    Rack::Utils.parse_query(Addressable::URI.parse(url).query)
+  end
+
+  describe "internal links" do
+    it "appends the tracking params baseTracking.js looks for" do
+      result = decorate({ "url" => article_url })
+      params = params_from(result["url"])
+
+      expect(params["ahoy_click"]).to eq("true")
+      expect(params["t"]).to eq(token)
+      expect(params["s"]).to be_present
+    end
+
+    it "keeps the original destination and its existing query params" do
+      result = decorate({ "url" => article_url })
+
+      expect(result["url"]).to start_with("https://#{domain}/ben/some-post?")
+      expect(params_from(result["url"])["context"]).to eq("digest")
+    end
+
+    # The click URL survives two decodes before EmailClicksController verifies
+    # it: URLSearchParams.get decodes once and baseTracking.js calls
+    # decodeURIComponent on the result. Signing over anything else makes
+    # verify_signature reject every click.
+    it "produces a signature that verify_signature accepts after both decodes" do
+      result = decorate({ "url" => article_url })
+      params = params_from(result["url"])
+
+      round_tripped = CGI.unescape(params["u"])
+      expected = AhoyEmail::Utils.signature(
+        token: params["t"], campaign: params["c"].to_s, url: round_tripped,
+      )
+
+      expect(round_tripped).to eq(article_url)
+      expect(params["s"]).to eq(expected)
+    end
+
+    it "survives a destination that itself contains encoded characters" do
+      tricky = "https://#{domain}/search?q=100%25%20ruby"
+      result = decorate({ "url" => tricky })
+      params = params_from(result["url"])
+
+      expect(CGI.unescape(params["u"])).to eq(tricky)
+    end
+  end
+
+  describe "HTML values" do
+    it "decorates anchors inside rendered HTML" do
+      html = %(<div><a href="#{article_url}">Read</a></div>)
+      result = decorate({ "smart_summary" => html })
+
+      href = Nokogiri::HTML::DocumentFragment.parse(result["smart_summary"]).at_css("a")["href"]
+      expect(params_from(href)["ahoy_click"]).to eq("true")
+    end
+
+    it "preserves a billboard's bb param so click attribution still resolves" do
+      html = %(<a href="https://#{domain}/sponsor?bb=42">Ad</a>)
+      result = decorate({ "billboards_html" => { "first" => html } })
+
+      href = Nokogiri::HTML::DocumentFragment.parse(result["billboards_html"]["first"]).at_css("a")["href"]
+      expect(params_from(href)["bb"]).to eq("42")
+      expect(params_from(href)["ahoy_click"]).to eq("true")
+    end
+
+    it "honours data-skip-click" do
+      html = %(<a href="#{article_url}" data-skip-click="true">Read</a>)
+      result = decorate({ "smart_summary" => html })
+
+      href = Nokogiri::HTML::DocumentFragment.parse(result["smart_summary"]).at_css("a")["href"]
+      expect(href).to eq(article_url)
+    end
+  end
+
+  describe "links it leaves alone" do
+    it "skips unsubscribe links" do
+      url = "https://#{domain}/email_subscriptions/unsubscribe?ut=xyz"
+      expect(decorate({ "unsubscribe_url" => url })["unsubscribe_url"]).to eq(url)
+    end
+
+    it "leaves plain strings untouched" do
+      payload = { "subject" => "A post you might like", "name" => "Ben" }
+      expect(decorate(payload)).to eq(payload)
+    end
+
+    it "leaves non-http schemes untouched" do
+      expect(decorate({ "x" => "mailto:yo@example.com" })["x"]).to eq("mailto:yo@example.com")
+    end
+  end
+
+  # The SMTP path sends these through the mounted AhoyEmail engine, but that
+  # redirect URL is built from default_url_options, whose :host already carries
+  # the protocol in production. Reproducing it would emit broken links, and an
+  # external click only ever set clicked_at anyway.
+  describe "external links" do
+    it "leaves them untouched" do
+      expect(decorate({ "url" => "https://example.com/post" })["url"])
+        .to eq("https://example.com/post")
+    end
+  end
+
+  describe "when tracking is unavailable" do
+    it "returns the payload unchanged without a token" do
+      payload = { "url" => article_url }
+      expect(decorate(payload, data: { campaign: nil })).to eq(payload)
+    end
+
+    it "returns the payload unchanged when ahoy_data is nil" do
+      payload = { "url" => article_url }
+      expect(decorate(payload, data: nil)).to eq(payload)
+    end
+
+    # A tracking failure must never cost us the send.
+    it "falls back to the undecorated payload if decoration raises" do
+      allow(AhoyEmail::Utils).to receive(:signature).and_raise(StandardError, "boom")
+      payload = { "url" => article_url }
+
+      expect(decorate(payload)).to eq(payload)
+    end
+  end
+
+  it "recurses through nested hashes and arrays" do
+    payload = { "articles" => [{ "url" => article_url }, { "url" => article_url }] }
+    result = decorate(payload)
+
+    result["articles"].each do |article|
+      expect(params_from(article["url"])["ahoy_click"]).to eq("true")
+    end
+  end
+end

--- a/spec/services/emails/ahoy_link_decorator_spec.rb
+++ b/spec/services/emails/ahoy_link_decorator_spec.rb
@@ -100,14 +100,28 @@ RSpec.describe Emails::AhoyLinkDecorator, type: :service do
     end
   end
 
-  # The SMTP path sends these through the mounted AhoyEmail engine, but that
-  # redirect URL is built from default_url_options, whose :host already carries
-  # the protocol in production. Reproducing it would emit broken links, and an
-  # external click only ever set clicked_at anyway.
   describe "external links" do
-    it "leaves them untouched" do
-      expect(decorate({ "url" => "https://example.com/post" })["url"])
-        .to eq("https://example.com/post")
+    it "routes them through the mounted Ahoy engine, as the SMTP path does" do
+      result = decorate({ "url" => "https://example.com/post" })
+
+      expect(result["url"]).to include("/ahoy/click?")
+      expect(params_from(result["url"])["u"]).to eq("https://example.com/post")
+    end
+  end
+
+  # A tracked URL pasted back into stored content arrives looking like an
+  # ordinary internal link. Decorating it again appends a second t/s/u set, and
+  # since Rack resolves duplicate params to the last value, the engine verifies
+  # the outer signature and redirects to itself.
+  describe "links that already carry tracking" do
+    it "leaves an ahoy_click URL alone" do
+      tracked = "https://#{domain}/post?ahoy_click=true&t=old&s=sig&u=x"
+      expect(decorate({ "url" => tracked })["url"]).to eq(tracked)
+    end
+
+    it "leaves an engine redirect URL alone" do
+      tracked = "https://#{domain}/ahoy/click?t=old&s=sig&u=https%3A%2F%2Fexample.com"
+      expect(decorate({ "url" => tracked })["url"]).to eq(tracked)
     end
   end
 

--- a/spec/services/emails/ahoy_link_tracking_parity_spec.rb
+++ b/spec/services/emails/ahoy_link_tracking_parity_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+# The two callers of Emails::AhoyLinkTracking rewrite different things: the
+# AhoyEmail::Processor patch rewrites the rendered body for SMTP, and
+# Emails::AhoyLinkDecorator rewrites the Customer.io message_data payload.
+# Sharing the module makes them agree on how a URL is built, but not on which
+# URLs they choose to build -- the skip rules, the internal/external split and
+# the url_options each caller supplies all live outside it.
+#
+# A divergence there is silent: Ahoy::EmailClicksController#verify_signature
+# just rejects the click. So drive both paths over the same markup with the same
+# token and require the results to be identical.
+RSpec.describe "Ahoy link tracking parity", type: :mailer do
+  let(:domain) { Settings::General.app_domain }
+  let(:markup) do
+    <<~HTML
+      <a href="https://#{domain}/ben/some-post?context=digest">Internal</a>
+      <a href="https://example.com/outside">External</a>
+      <a href="https://#{domain}/email_subscriptions/unsubscribe?ut=abc">Unsubscribe</a>
+      <a href="https://#{domain}/ahoy/click?t=old&s=oldsig&u=https%3A%2F%2Fexample.com">Already tracked</a>
+      <a href="https://#{domain}/sponsor?bb=42">Billboard</a>
+    HTML
+  end
+
+  def hrefs(html)
+    Nokogiri::HTML::DocumentFragment.parse(html).css("a[href]").pluck("href")
+  end
+
+  before do
+    stub_const("ParityMailer", Class.new(ApplicationMailer) do
+      def sample(body, subject)
+        mail(to: "member@example.com", subject: subject, body: body, content_type: "text/html")
+      end
+    end)
+  end
+
+  it "rewrites the body and the payload to exactly the same hrefs" do
+    message = ParityMailer.sample(markup, "Parity").message
+    ahoy_data = message.ahoy_data
+
+    smtp_hrefs = hrefs(message.body.decoded)
+    payload = Emails::AhoyLinkDecorator.call({ "html" => markup }, ahoy_data: ahoy_data)
+    customerio_hrefs = hrefs(payload["html"])
+
+    # Guard against a vacuous pass: if neither path decorated anything, the
+    # comparison below would succeed while proving nothing.
+    expect(smtp_hrefs.grep(/ahoy_click=true/)).not_to be_empty
+    expect(smtp_hrefs).to eq(customerio_hrefs)
+  end
+
+  it "agrees on a bare URL too, not just anchors in HTML" do
+    url = "https://#{domain}/ben/some-post?context=digest"
+    message = ParityMailer.sample(%(<a href="#{url}">Read</a>), "Parity").message
+
+    smtp_href = hrefs(message.body.decoded).first
+    decorated = Emails::AhoyLinkDecorator.call({ "url" => url }, ahoy_data: message.ahoy_data)
+
+    expect(decorated["url"]).to eq(smtp_href)
+  end
+end

--- a/spec/workers/emails/send_user_digest_worker_spec.rb
+++ b/spec/workers/emails/send_user_digest_worker_spec.rb
@@ -31,6 +31,46 @@ RSpec.describe Emails::SendUserDigestWorker, type: :worker do
   include_examples "#enqueues_on_correct_queue", "low_priority"
 
   describe "perform" do
+    # force_send exists to bypass the digest consent check for manual and retry
+    # sends. It must not become a way to email a moderated account.
+    context "with a moderated user" do
+      before do
+        user.follow(author)
+        user.follow(tag)
+        create_list(:article, 3, user_id: author.id, public_reactions_count: 20, score: 20, tag_list: [tag.name])
+      end
+
+      it "does not send to a suspended user" do
+        user.add_role(:suspended)
+
+        worker.perform(user.id)
+
+        expect(message_delivery).not_to have_received(:deliver_now)
+      end
+
+      it "does not send to a spam user" do
+        user.add_role(:spam)
+
+        worker.perform(user.id)
+
+        expect(message_delivery).not_to have_received(:deliver_now)
+      end
+
+      it "does not send to a suspended user even when forced" do
+        user.add_role(:suspended)
+
+        worker.perform(user.id, true)
+
+        expect(message_delivery).not_to have_received(:deliver_now)
+      end
+
+      it "still sends to a user in good standing" do
+        worker.perform(user.id)
+
+        expect(message_delivery).to have_received(:deliver_now)
+      end
+    end
+
     context "when there's articles to be sent" do
       before do
         user.follow(author)


### PR DESCRIPTION
Two independent fixes that surfaced while designing the digest migration to Customer.io.

## 1. The digest ignored moderation status

`EmailDigest#get_users` selected on `registered` + `email_digest_periodic` with no role filter, while `SurveyDailyEmailWorker` and the other bulk senders go through `User.email_eligible`, which applies `without_role(:suspended)` / `without_role(:spam)`.

`Moderator::BanishUser` suspends and renames the account but never clears `email_digest_periodic`, so banished and spam-flagged accounts kept receiving the digest.

Not switching to `User.email_eligible` wholesale: that scope also requires `email_newsletter`, and the periodic digest is a separate consent. This takes its moderation filters without its newsletter filter. The same guard goes in `SendUserDigestWorker`, which is reachable directly via `perform_async` on Forems that don't send inline, and from the console.

## 2. Customer.io emails have had no click tracking at all

Ahoy rewrites links in the ActionMailer-rendered HTML body. Customer.io discards that body and renders its own template from `message_data`, so no link in a Customer.io email carries tracking params and `Ahoy::EmailClicksController` is never reached.

That controller drives six things, all dark for every user on the `customerio_email_delivery` flag:

| Effect | Feeds |
|---|---|
| `AhoyEmail::Utils.publish(:click, …)` | `clicked_at` → the digest suppression gate |
| `record_feed_event` | `FeedEvent` click w/ `feed_config_id` → `FeedConfig#feed_success_score` |
| `UpdateUserInterestEmbeddingWorker` | the user's interest embedding |
| `track_billboard` | `BillboardEvent` + billboard `success_rate` / `clicks_count` |
| `user.update_presence!` | `last_presence_at`, which gates the digest smart summary |
| `RecordFieldTestEventWorker` | `user_clicks_email_link` — the only goal of `personalized_email_digests_ab_test` |

So the effect isn't only lost analytics: the personalization feedback loop stops learning, and the running A/B test reads flagged users as non-converters.

`Emails::AhoyLinkTracking` now owns the link rules, and both callers use it — the `AhoyEmail::Processor` patch that rewrites the body for SMTP, and `Emails::AhoyLinkDecorator`, which applies the same rules to the Customer.io payload at delivery time. One implementation matters here because `verify_signature` rejects anything that doesn't match byte for byte, in particular the double-encoded `u` param that `baseTracking.js` decodes twice before posting back. The initializer nets −43/+25.

The decorator reads the token from `mail.ahoy_data` at delivery time rather than at delivery-method selection: Rails runs `after_action`s in reverse registration order, so Ahoy's Processor populates `ahoy_data` *after* `Deliverable` has already chosen the method.

### Also fixes a redirect loop

`Settings::General.custom_email_footer` contains an `<a href>` that is already an Ahoy engine redirect, carrying the `data-saferedirecturl` attribute Gmail adds when it renders a message — a rendered DEV email was copied out of Gmail and pasted into the setting.

Every send decorated it again. Rack resolves duplicate query params to the last value, so on click the engine verifies the *outer* signature and redirects to the same URL — a loop, in the footer of every SMTP-delivered DEV email. `AhoyLinkTracking.already_tracked?` skips any href carrying `ahoy_click=true` or pointing at our own `/ahoy/` path, so pasting a tracked URL into stored content can no longer produce a self-referential redirect.

The setting is worth cleaning up separately: its embedded token belongs to a long-dead message, and its entire visible text is a SendGrid sponsor credit that becomes untrue for anything Customer.io delivers.

## Known issue, not fixed here

`DigestMailer` passes `transactional_message_id: "dev_digest_email"` for a Customer.io template that does not exist, and `Deliverable` routes any mailer through `DeliveryMethods::CustomerIo` when the flag passes. With the flag enabled, the next digest run raises instead of sending — and because Mail skips observers when `do_delivery` raises, no `ahoy_messages` row is written either. Needs handling before the next run, independently of this PR.

## Testing

65 examples green across `spec/services/emails`, `spec/services/delivery_methods`, `spec/services/email_digest_spec.rb`, `spec/workers/emails/send_user_digest_worker_spec.rb`, and `spec/requests/ahoy` — the last of which covers the SMTP path that now shares the extracted code. RuboCop clean on all touched files.

New coverage includes a round-trip test proving the decorator's signature survives both decodes and verifies the way `Ahoy::EmailClicksController` does, plus cases for existing query params (`context=digest`, billboard `bb`), HTML-valued payload keys, `unsubscribe` skipping, `data-skip-click`, already-tracked links, and fallback to the undecorated payload when tracking is unavailable.

https://claude.ai/code/session_01Agp1w4i5CoQzZQLms2kvXA