### PR TITLE
Emit article, comment, and reaction activity events to the Customer.io CDP

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -8,6 +8,7 @@ class Article < ApplicationRecord
   include PgSearch::Model
   include AlgoliaSearchable
   include WebpageTrackable
+  include ActivityTrackable
 
   acts_as_taggable_on :tags
   resourcify
@@ -58,6 +59,15 @@ class Article < ApplicationRecord
   BIDI_CONTROL_CHARACTERS = /[\u061C\u200E\u200F\u202a-\u202e\u2066-\u2069]/
 
   MAX_TAG_LIST_SIZE = 4
+
+  # Author-visible edits, for the article_updated CDP event. Article rows churn
+  # constantly on score recalcs, counter caches and last_comment_at; without
+  # this allowlist article_updated would fire orders of magnitude more often
+  # than real edits. Mirrors User::SYNC_TRIGGER_KEYS.
+  TRACKABLE_UPDATE_KEYS = %w[
+    title body_markdown cached_tag_list main_image description canonical_url
+    edited_at collection_id subforem_id
+  ].freeze
 
   # Filter out anything that isn't a word, space, punctuation mark,
   # recognized emoji, and other auxiliary marks.
@@ -1766,6 +1776,90 @@ class Article < ApplicationRecord
       Organizations::RecompilePagesWorker.perform_async(org_id)
     end
   end
+
+  # === ActivityTrackable (DEV → Customer.io CDP activity events) ===
+  # Emits article_published / article_boosted / article_updated. Drafts,
+  # unpublishes and deletions stay silent.
+
+  def trackable_actor
+    user
+  end
+
+  # Curated payload — the articles row is wide and body_markdown alone can be
+  # hundreds of KB, so never ship as_json across the boundary. String keys keep
+  # the job arguments JSON-safe for Sidekiq.strict_args!.
+  def trackable_payload
+    {
+      "id" => id,
+      "title" => title,
+      "path" => path,
+      "type_of" => type_of,
+      "published_at" => published_at&.iso8601,
+      "tag_list" => cached_tag_list.to_s.split(", "),
+      "organization_id" => organization_id,
+      "subforem_id" => subforem_id,
+      "user_id" => user_id
+    }
+  end
+
+  def enqueue_trackable_event_created
+    return unless published?
+
+    enqueue_publication_event
+  end
+
+  # Drafts emit nothing until they go live, so the publish event fires from the
+  # update path too. Edits to an already-published post emit article_updated,
+  # but only for the author-visible changes in TRACKABLE_UPDATE_KEYS.
+  def enqueue_trackable_event_updated
+    changed_keys = trackable_changed_keys
+
+    if changed_keys.include?("published")
+      enqueue_publication_event if published?
+      return
+    end
+
+    return unless published?
+    return unless changed_keys.intersect?(TRACKABLE_UPDATE_KEYS)
+
+    enqueue_trackable_event("article_updated")
+  end
+
+  # Deletion is intentionally out of scope: the CDP consumer does not handle
+  # removals, so suppress the concern's default article_destroyed emission.
+  def enqueue_trackable_event_destroyed(*)
+    nil
+  end
+
+  # A boost is the quickie composer on an article page (see
+  # articleReactions.js) posting a status whose body embeds the boosted
+  # article, so it emits article_boosted instead of article_published.
+  def enqueue_publication_event
+    boosted_id = boosted_article_id
+    return enqueue_trackable_event("article_published") unless boosted_id
+
+    enqueue_trackable_event(
+      "article_boosted",
+      properties_override: {
+        "boosted_article_id" => boosted_id,
+        "boosted_article_user_id" => Article.where(id: boosted_id).pick(:user_id)
+      },
+    )
+  end
+
+  # body_url is an attr_accessor populated during the create request, so this
+  # only resolves on the create path — a status published later (rare; the
+  # composer always posts published) falls back to article_published.
+  # LiquidEmbedExtractor maps an internal article URL to its record without
+  # rendering Liquid or making network calls.
+  def boosted_article_id
+    return unless status? && body_url.present?
+
+    type, id = LiquidEmbedExtractor.derive_reference("embed", body_url)
+    id if type == "Article"
+  end
+  private :enqueue_trackable_event_created, :enqueue_trackable_event_updated,
+          :enqueue_trackable_event_destroyed, :enqueue_publication_event, :boosted_article_id
 
   private
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1786,7 +1786,7 @@ class Article < ApplicationRecord
       "path" => path,
       "type_of" => type_of,
       "published_at" => published_at&.iso8601,
-      "tag_list" => cached_tag_list.to_s.split(", "),
+      "tag_list" => cached_tag_list.to_s.split(",").map(&:strip).reject(&:blank?),
       "organization_id" => organization_id,
       "subforem_id" => subforem_id
     }

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1779,23 +1779,16 @@ class Article < ApplicationRecord
   # article_published / _boosted / _updated / _unpublished / _deleted.
   # Drafts stay silent until they go live.
 
-  def trackable_actor
-    user
-  end
-
-  # Curated: the row is wide and body_markdown can be hundreds of KB. String
-  # keys keep the job arguments JSON-safe for Sidekiq.strict_args!.
-  def trackable_payload
+  # body_markdown is deliberately absent; it can run to hundreds of KB.
+  def trackable_activity_payload
     {
-      "id" => id,
       "title" => title,
       "path" => path,
       "type_of" => type_of,
       "published_at" => published_at&.iso8601,
       "tag_list" => cached_tag_list.to_s.split(", "),
       "organization_id" => organization_id,
-      "subforem_id" => subforem_id,
-      "user_id" => user_id
+      "subforem_id" => subforem_id
     }
   end
 
@@ -1836,7 +1829,8 @@ class Article < ApplicationRecord
     type, id = LiquidEmbedExtractor.derive_reference("embed", body_url)
     id if type == "Article"
   end
-  private :trackable_activity_event, :trackable_update_event, :publication_event, :boosted_article_id
+  private :trackable_activity_payload, :trackable_activity_event, :trackable_update_event,
+          :publication_event, :boosted_article_id
 
   private
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1799,46 +1799,33 @@ class Article < ApplicationRecord
     }
   end
 
-  def enqueue_trackable_event_created
-    return unless published?
-
-    enqueue_publication_event
-  end
-
-  def enqueue_trackable_event_updated
-    changed_keys = trackable_changed_keys
-
-    if changed_keys.include?("published")
-      published? ? enqueue_publication_event : enqueue_trackable_event("article_unpublished")
-      return
+  # A draft was never announced, so neither its edits nor its deletion emit.
+  def trackable_activity_event(phase)
+    case phase
+    when :created then publication_event if published?
+    when :updated then trackable_update_event
+    when :destroyed then "article_deleted" if published?
     end
-
-    return unless published?
-    return unless changed_keys.intersect?(TRACKABLE_UPDATE_KEYS)
-
-    enqueue_trackable_event("article_updated")
   end
 
-  # A draft was never announced, so its deletion is noise.
-  def enqueue_trackable_event_destroyed(*)
+  def trackable_update_event
+    changed_keys = trackable_changed_keys
+    return (published? ? publication_event : "article_unpublished") if changed_keys.include?("published")
     return unless published?
 
-    enqueue_trackable_event("article_deleted", user_ids: @_trackable_destroyed_user_ids)
+    "article_updated" if changed_keys.intersect?(TRACKABLE_UPDATE_KEYS)
   end
 
   # The quickie composer (articleReactions.js) posts a status embedding the
   # boosted article, which emits article_boosted instead of article_published.
-  def enqueue_publication_event
+  def publication_event
     boosted_id = boosted_article_id
-    return enqueue_trackable_event("article_published") unless boosted_id
+    return "article_published" unless boosted_id
 
-    enqueue_trackable_event(
-      "article_boosted",
-      properties_override: {
-        "boosted_article_id" => boosted_id,
-        "boosted_article_user_id" => Article.where(id: boosted_id).pick(:user_id)
-      },
-    )
+    ["article_boosted", {
+      "boosted_article_id" => boosted_id,
+      "boosted_article_user_id" => Article.where(id: boosted_id).pick(:user_id)
+    }]
   end
 
   # body_url is an attr_accessor set during the create request, so this only
@@ -1849,8 +1836,7 @@ class Article < ApplicationRecord
     type, id = LiquidEmbedExtractor.derive_reference("embed", body_url)
     id if type == "Article"
   end
-  private :enqueue_trackable_event_created, :enqueue_trackable_event_updated,
-          :enqueue_trackable_event_destroyed, :enqueue_publication_event, :boosted_article_id
+  private :trackable_activity_event, :trackable_update_event, :publication_event, :boosted_article_id
 
   private
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -60,10 +60,8 @@ class Article < ApplicationRecord
 
   MAX_TAG_LIST_SIZE = 4
 
-  # Author-visible edits, for the article_updated CDP event. Article rows churn
-  # constantly on score recalcs, counter caches and last_comment_at; without
-  # this allowlist article_updated would fire orders of magnitude more often
-  # than real edits. Mirrors User::SYNC_TRIGGER_KEYS.
+  # Author-visible edits, for the article_updated CDP event. Rows churn on score
+  # recalcs, counter caches and last_comment_at. Mirrors User::SYNC_TRIGGER_KEYS.
   TRACKABLE_UPDATE_KEYS = %w[
     title body_markdown cached_tag_list main_image description canonical_url
     edited_at collection_id subforem_id
@@ -1777,17 +1775,16 @@ class Article < ApplicationRecord
     end
   end
 
-  # === ActivityTrackable (DEV → Customer.io CDP activity events) ===
-  # Emits article_published / article_boosted / article_updated. Drafts,
-  # unpublishes and deletions stay silent.
+  # === ActivityTrackable (Customer.io CDP activity events) ===
+  # article_published / _boosted / _updated / _unpublished / _deleted.
+  # Drafts stay silent until they go live.
 
   def trackable_actor
     user
   end
 
-  # Curated payload — the articles row is wide and body_markdown alone can be
-  # hundreds of KB, so never ship as_json across the boundary. String keys keep
-  # the job arguments JSON-safe for Sidekiq.strict_args!.
+  # Curated: the row is wide and body_markdown can be hundreds of KB. String
+  # keys keep the job arguments JSON-safe for Sidekiq.strict_args!.
   def trackable_payload
     {
       "id" => id,
@@ -1808,9 +1805,6 @@ class Article < ApplicationRecord
     enqueue_publication_event
   end
 
-  # Drafts emit nothing until they go live, so the publish event fires from the
-  # update path too. Edits to an already-published post emit article_updated,
-  # but only for the author-visible changes in TRACKABLE_UPDATE_KEYS.
   def enqueue_trackable_event_updated
     changed_keys = trackable_changed_keys
 
@@ -1825,18 +1819,15 @@ class Article < ApplicationRecord
     enqueue_trackable_event("article_updated")
   end
 
-  # Only a published article's removal tells the CDP anything: a draft was
-  # never announced, so its deletion would be noise. Uses the concern's
-  # before_destroy snapshot rather than re-reading the association.
+  # A draft was never announced, so its deletion is noise.
   def enqueue_trackable_event_destroyed(*)
     return unless published?
 
     enqueue_trackable_event("article_deleted", user_ids: @_trackable_destroyed_user_ids)
   end
 
-  # A boost is the quickie composer on an article page (see
-  # articleReactions.js) posting a status whose body embeds the boosted
-  # article, so it emits article_boosted instead of article_published.
+  # The quickie composer (articleReactions.js) posts a status embedding the
+  # boosted article, which emits article_boosted instead of article_published.
   def enqueue_publication_event
     boosted_id = boosted_article_id
     return enqueue_trackable_event("article_published") unless boosted_id
@@ -1850,11 +1841,8 @@ class Article < ApplicationRecord
     )
   end
 
-  # body_url is an attr_accessor populated during the create request, so this
-  # only resolves on the create path — a status published later (rare; the
-  # composer always posts published) falls back to article_published.
-  # LiquidEmbedExtractor maps an internal article URL to its record without
-  # rendering Liquid or making network calls.
+  # body_url is an attr_accessor set during the create request, so this only
+  # resolves on create; a status published later falls back to _published.
   def boosted_article_id
     return unless status? && body_url.present?
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1815,7 +1815,7 @@ class Article < ApplicationRecord
     changed_keys = trackable_changed_keys
 
     if changed_keys.include?("published")
-      enqueue_publication_event if published?
+      published? ? enqueue_publication_event : enqueue_trackable_event("article_unpublished")
       return
     end
 
@@ -1825,10 +1825,13 @@ class Article < ApplicationRecord
     enqueue_trackable_event("article_updated")
   end
 
-  # Deletion is intentionally out of scope: the CDP consumer does not handle
-  # removals, so suppress the concern's default article_destroyed emission.
+  # Only a published article's removal tells the CDP anything: a draft was
+  # never announced, so its deletion would be noise. Uses the concern's
+  # before_destroy snapshot rather than re-reading the association.
   def enqueue_trackable_event_destroyed(*)
-    nil
+    return unless published?
+
+    enqueue_trackable_event("article_deleted", user_ids: @_trackable_destroyed_user_ids)
   end
 
   # A boost is the quickie composer on an article page (see

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -276,15 +276,22 @@ class Comment < ApplicationRecord
   # counters, spaminess_rating and semantic_embedding, none of which are the
   # author doing something.
   def enqueue_trackable_event_updated
-    return unless trackable_changed_keys.include?("body_markdown")
+    changed_keys = trackable_changed_keys
+
+    # CommentsController#destroy soft deletes when the comment has replies and
+    # hard destroys when it does not, so removal has to be caught on both paths.
+    if changed_keys.include?("deleted")
+      enqueue_trackable_event("comment_deleted") if deleted?
+      return
+    end
+
+    return unless changed_keys.include?("body_markdown")
 
     enqueue_trackable_event("comment_updated")
   end
 
-  # Deletion is intentionally out of scope: the CDP consumer does not handle
-  # removals, so suppress the concern's default comment_destroyed emission.
   def enqueue_trackable_event_destroyed(*)
-    nil
+    enqueue_trackable_event("comment_deleted", user_ids: @_trackable_destroyed_user_ids)
   end
   private :enqueue_trackable_event_updated, :enqueue_trackable_event_destroyed
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -250,16 +250,15 @@ class Comment < ApplicationRecord
     commentable&.subforem_id
   end
 
-  # === ActivityTrackable (DEV → Customer.io CDP activity events) ===
-  # Emits comment_created / comment_updated. Comments have no draft state, so
-  # creation is publication. Deletions and hides stay silent.
+  # === ActivityTrackable (Customer.io CDP activity events) ===
+  # comment_created / _updated / _deleted. No draft state, so create publishes.
 
   def trackable_actor
     user
   end
 
-  # Curated payload with string keys, JSON-safe for Sidekiq.strict_args!. The
-  # comment body is deliberately absent — the CDP consumer keys off the ids.
+  # Curated, string keys for Sidekiq.strict_args!. The body is deliberately
+  # absent; the CDP consumer keys off the ids.
   def trackable_payload
     {
       "id" => id,
@@ -272,14 +271,12 @@ class Comment < ApplicationRecord
     }
   end
 
-  # Only a body edit counts. Comment rows churn on score, the three reaction
-  # counters, spaminess_rating and semantic_embedding, none of which are the
-  # author doing something.
+  # Only a body edit counts; rows churn on scores, counters and embeddings.
+  # CommentsController#destroy soft deletes a comment with replies and hard
+  # destroys one without, so removal is caught on both paths.
   def enqueue_trackable_event_updated
     changed_keys = trackable_changed_keys
 
-    # CommentsController#destroy soft deletes when the comment has replies and
-    # hard destroys when it does not, so removal has to be caught on both paths.
     if changed_keys.include?("deleted")
       enqueue_trackable_event("comment_deleted") if deleted?
       return

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -7,6 +7,7 @@ class Comment < ApplicationRecord
   include PgSearch::Model
   include Reactable
   include AlgoliaSearchable
+  include ActivityTrackable
 
   BODY_MARKDOWN_SIZE_RANGE = (1..25_000)
 
@@ -248,6 +249,44 @@ class Comment < ApplicationRecord
   def subforem_id
     commentable&.subforem_id
   end
+
+  # === ActivityTrackable (DEV → Customer.io CDP activity events) ===
+  # Emits comment_created / comment_updated. Comments have no draft state, so
+  # creation is publication. Deletions and hides stay silent.
+
+  def trackable_actor
+    user
+  end
+
+  # Curated payload with string keys, JSON-safe for Sidekiq.strict_args!. The
+  # comment body is deliberately absent — the CDP consumer keys off the ids.
+  def trackable_payload
+    {
+      "id" => id,
+      "commentable_type" => commentable_type,
+      "commentable_id" => commentable_id,
+      "commentable_user_id" => commentable.try(:user_id),
+      "parent_id" => parent_id,
+      "path" => path,
+      "user_id" => user_id
+    }
+  end
+
+  # Only a body edit counts. Comment rows churn on score, the three reaction
+  # counters, spaminess_rating and semantic_embedding, none of which are the
+  # author doing something.
+  def enqueue_trackable_event_updated
+    return unless trackable_changed_keys.include?("body_markdown")
+
+    enqueue_trackable_event("comment_updated")
+  end
+
+  # Deletion is intentionally out of scope: the CDP consumer does not handle
+  # removals, so suppress the concern's default comment_destroyed emission.
+  def enqueue_trackable_event_destroyed(*)
+    nil
+  end
+  private :enqueue_trackable_event_updated, :enqueue_trackable_event_destroyed
 
   private
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -253,21 +253,14 @@ class Comment < ApplicationRecord
   # === ActivityTrackable (Customer.io CDP activity events) ===
   # comment_created / _updated / _deleted. No draft state, so create publishes.
 
-  def trackable_actor
-    user
-  end
-
-  # Curated, string keys for Sidekiq.strict_args!. The body is deliberately
-  # absent; the CDP consumer keys off the ids.
-  def trackable_payload
+  # The body is deliberately absent; the CDP consumer keys off the ids.
+  def trackable_activity_payload
     {
-      "id" => id,
       "commentable_type" => commentable_type,
       "commentable_id" => commentable_id,
       "commentable_user_id" => commentable.try(:user_id),
       "parent_id" => parent_id,
-      "path" => path,
-      "user_id" => user_id
+      "path" => path
     }
   end
 
@@ -288,7 +281,7 @@ class Comment < ApplicationRecord
 
     "comment_updated" if changed_keys.include?("body_markdown")
   end
-  private :trackable_activity_event, :trackable_update_event
+  private :trackable_activity_payload, :trackable_activity_event, :trackable_update_event
 
   private
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -271,26 +271,24 @@ class Comment < ApplicationRecord
     }
   end
 
-  # Only a body edit counts; rows churn on scores, counters and embeddings.
   # CommentsController#destroy soft deletes a comment with replies and hard
   # destroys one without, so removal is caught on both paths.
-  def enqueue_trackable_event_updated
-    changed_keys = trackable_changed_keys
-
-    if changed_keys.include?("deleted")
-      enqueue_trackable_event("comment_deleted") if deleted?
-      return
+  def trackable_activity_event(phase)
+    case phase
+    when :created then "comment_created"
+    when :updated then trackable_update_event
+    when :destroyed then "comment_deleted"
     end
-
-    return unless changed_keys.include?("body_markdown")
-
-    enqueue_trackable_event("comment_updated")
   end
 
-  def enqueue_trackable_event_destroyed(*)
-    enqueue_trackable_event("comment_deleted", user_ids: @_trackable_destroyed_user_ids)
+  # Only a body edit counts; rows churn on scores, counters and embeddings.
+  def trackable_update_event
+    changed_keys = trackable_changed_keys
+    return (deleted? ? "comment_deleted" : nil) if changed_keys.include?("deleted")
+
+    "comment_updated" if changed_keys.include?("body_markdown")
   end
-  private :enqueue_trackable_event_updated, :enqueue_trackable_event_destroyed
+  private :trackable_activity_event, :trackable_update_event
 
   private
 

--- a/app/models/concerns/activity_trackable.rb
+++ b/app/models/concerns/activity_trackable.rb
@@ -1,6 +1,6 @@
 # Shared gate for the Article/Comment/Reaction activity events sent to the
-# Customer.io CDP. Adopters implement #trackable_actor and
-# #trackable_activity_event, which names the event for a lifecycle phase.
+# Customer.io CDP. Adopters implement #trackable_activity_event, which names the
+# event for a lifecycle phase, and #trackable_activity_payload, its properties.
 module ActivityTrackable
   extend ActiveSupport::Concern
 
@@ -24,12 +24,23 @@ module ActivityTrackable
   end
 
   # Events are actor-keyed; the content's author rides along in properties.
+  # Every adopter so far acts as its own user — override if that changes.
   def trackable_actor
-    raise NotImplementedError, "#{self.class.name} must implement #trackable_actor"
+    user
   end
 
   def trackable_user_ids
     [trackable_actor&.id]
+  end
+
+  # Curated: these rows are wide and never shipped wholesale. String keys keep
+  # the job arguments JSON-safe for Sidekiq.strict_args!.
+  def trackable_payload
+    { "id" => id, "user_id" => user_id }.merge(trackable_activity_payload)
+  end
+
+  def trackable_activity_payload
+    raise NotImplementedError, "#{self.class.name} must implement #trackable_activity_payload"
   end
 
   # Returns an event name, a [name, properties] pair, or nil to stay silent.

--- a/app/models/concerns/activity_trackable.rb
+++ b/app/models/concerns/activity_trackable.rb
@@ -1,0 +1,89 @@
+# Shared gate for the content-activity events (article / comment / reaction)
+# that DEV emits to the Customer.io CDP. Wraps Trackable with the suppressions
+# every activity event needs, so the three adopting models do not each
+# re-implement them:
+#
+#   * the customerio_cdp_enabled master switch, resolved via the default
+#     subforem the way mailers do — the admin panel saves the setting
+#     subforem-scoped, and model callbacks may run with no request context.
+#   * non-human actors (community_bot / member_bot), matching the User sync.
+#   * moderated accounts. User#track_engagement! already suppresses engagement
+#     for spam/suspended users so a pruned Customer.io profile is not
+#     resurrected by their activity; a comment or reaction from the same
+#     account would resurrect it just as effectively, so activity events honour
+#     the same rule. It also keeps the content-farm tail — 8% of authors
+#     produce 61% of published articles — from dominating the event stream.
+#
+# The checks are ordered cheapest-first: the master switch is a cached Setting
+# read, member? is an enum predicate, and only then do we reach
+# spam_or_suspended?, which hits the authorizer.
+#
+# Adopters must implement #trackable_actor.
+module ActivityTrackable
+  extend ActiveSupport::Concern
+
+  # Declared as a Concern dependency rather than included from an `included`
+  # block: ActiveSupport::Concern mixes dependencies into the adopter *before*
+  # this module, so ActivityTrackable lands nearer in the ancestor chain and
+  # its overrides win. Including Trackable from `included` would invert that
+  # and leave Trackable's NotImplementedError stubs in front.
+  include Trackable
+
+  included do
+    # Registered from here, so it lands ahead of the adopting model's own
+    # after_save hooks and observes the dirty state before they disturb it.
+    after_save :snapshot_trackable_changed_keys
+
+    # Discard the snapshot once the commit hooks for that save have run. This
+    # registers after Trackable's (ActiveSupport::Concern mixes the dependency
+    # in first) and Rails 7.1+ runs after_commit callbacks in definition order,
+    # so the event callbacks still see it. Without this the snapshot outlives
+    # its save: a later bare touch on the same instance — a comment touching
+    # its article's last_comment_at — fires an update commit hook that would
+    # re-read the create's keys and republish the article.
+    after_commit :clear_trackable_changed_keys
+    after_rollback :clear_trackable_changed_keys
+  end
+
+  # The change keys from the save that triggered the event. Commit hooks cannot
+  # read saved_changes/previous_changes directly on these models: Comment
+  # touches itself from an after_save hook (#expire_root_fragment) and touch
+  # calls changes_applied, so by the time after_commit runs the dirty state has
+  # collapsed to ["updated_at"] and every real edit looks like a no-op. touch
+  # does not fire after_save, so a snapshot taken here survives it.
+  def trackable_changed_keys
+    @trackable_changed_keys || saved_changes.keys
+  end
+
+  # The User whose activity this is. Activity events are actor-keyed; the
+  # content's author travels in properties instead (see each model's payload),
+  # so downstream can still fan out on it.
+  def trackable_actor
+    raise NotImplementedError, "#{self.class.name} must implement #trackable_actor"
+  end
+
+  def trackable_user_ids
+    [trackable_actor&.id]
+  end
+
+  private
+
+  def snapshot_trackable_changed_keys
+    @trackable_changed_keys = saved_changes.keys
+  end
+
+  def clear_trackable_changed_keys
+    @trackable_changed_keys = nil
+  end
+
+  def trackable_events_skipped?
+    return true unless Settings::General.customerio_cdp_enabled(subforem_id: Subforem.cached_default_id)
+
+    actor = trackable_actor
+    return true if actor.nil?
+    return true unless actor.member?
+    return true if actor.spam_or_suspended?
+
+    super
+  end
+end

--- a/app/models/concerns/activity_trackable.rb
+++ b/app/models/concerns/activity_trackable.rb
@@ -1,63 +1,28 @@
-# Shared gate for the content-activity events (article / comment / reaction)
-# that DEV emits to the Customer.io CDP. Wraps Trackable with the suppressions
-# every activity event needs, so the three adopting models do not each
-# re-implement them:
-#
-#   * the customerio_cdp_enabled master switch, resolved via the default
-#     subforem the way mailers do — the admin panel saves the setting
-#     subforem-scoped, and model callbacks may run with no request context.
-#   * non-human actors (community_bot / member_bot), matching the User sync.
-#   * moderated accounts. User#track_engagement! already suppresses engagement
-#     for spam/suspended users so a pruned Customer.io profile is not
-#     resurrected by their activity; a comment or reaction from the same
-#     account would resurrect it just as effectively, so activity events honour
-#     the same rule. It also keeps the content-farm tail — 8% of authors
-#     produce 61% of published articles — from dominating the event stream.
-#
-# The checks are ordered cheapest-first: the master switch is a cached Setting
-# read, member? is an enum predicate, and only then do we reach
-# spam_or_suspended?, which hits the authorizer.
-#
-# Adopters must implement #trackable_actor.
+# Shared gate for the Article/Comment/Reaction activity events sent to the
+# Customer.io CDP. Adopters must implement #trackable_actor.
 module ActivityTrackable
   extend ActiveSupport::Concern
 
-  # Declared as a Concern dependency rather than included from an `included`
-  # block: ActiveSupport::Concern mixes dependencies into the adopter *before*
-  # this module, so ActivityTrackable lands nearer in the ancestor chain and
-  # its overrides win. Including Trackable from `included` would invert that
-  # and leave Trackable's NotImplementedError stubs in front.
+  # A Concern dependency, not an `included` block: dependencies mix in first, so
+  # this module stays ahead of Trackable's NotImplementedError stubs.
   include Trackable
 
   included do
-    # Registered from here, so it lands ahead of the adopting model's own
-    # after_save hooks and observes the dirty state before they disturb it.
     after_save :snapshot_trackable_changed_keys
-
-    # Discard the snapshot once the commit hooks for that save have run. This
-    # registers after Trackable's (ActiveSupport::Concern mixes the dependency
-    # in first) and Rails 7.1+ runs after_commit callbacks in definition order,
-    # so the event callbacks still see it. Without this the snapshot outlives
-    # its save: a later bare touch on the same instance — a comment touching
-    # its article's last_comment_at — fires an update commit hook that would
-    # re-read the create's keys and republish the article.
+    # Cleared after the commit hooks read it, or a later touch replays the
+    # stale keys. Registers after Trackable's, which run first (Rails 7.1+).
     after_commit :clear_trackable_changed_keys
     after_rollback :clear_trackable_changed_keys
   end
 
-  # The change keys from the save that triggered the event. Commit hooks cannot
-  # read saved_changes/previous_changes directly on these models: Comment
-  # touches itself from an after_save hook (#expire_root_fragment) and touch
-  # calls changes_applied, so by the time after_commit runs the dirty state has
-  # collapsed to ["updated_at"] and every real edit looks like a no-op. touch
-  # does not fire after_save, so a snapshot taken here survives it.
+  # Commit hooks can't read saved_changes here: Comment touches itself from an
+  # after_save hook and touch calls changes_applied, collapsing the dirty state
+  # to ["updated_at"]. touch doesn't fire after_save, so the snapshot survives.
   def trackable_changed_keys
     @trackable_changed_keys || saved_changes.keys
   end
 
-  # The User whose activity this is. Activity events are actor-keyed; the
-  # content's author travels in properties instead (see each model's payload),
-  # so downstream can still fan out on it.
+  # Events are actor-keyed; the content's author rides along in properties.
   def trackable_actor
     raise NotImplementedError, "#{self.class.name} must implement #trackable_actor"
   end
@@ -76,6 +41,8 @@ module ActivityTrackable
     @trackable_changed_keys = nil
   end
 
+  # Cheapest check first. Moderated actors stay silent for the same reason as
+  # User#track_engagement!: a pruned Customer.io profile must not be resurrected.
   def trackable_events_skipped?
     return true unless Settings::General.customerio_cdp_enabled(subforem_id: Subforem.cached_default_id)
 

--- a/app/models/concerns/activity_trackable.rb
+++ b/app/models/concerns/activity_trackable.rb
@@ -1,5 +1,6 @@
 # Shared gate for the Article/Comment/Reaction activity events sent to the
-# Customer.io CDP. Adopters must implement #trackable_actor.
+# Customer.io CDP. Adopters implement #trackable_actor and
+# #trackable_activity_event, which names the event for a lifecycle phase.
 module ActivityTrackable
   extend ActiveSupport::Concern
 
@@ -31,7 +32,33 @@ module ActivityTrackable
     [trackable_actor&.id]
   end
 
+  # Returns an event name, a [name, properties] pair, or nil to stay silent.
+  def trackable_activity_event(_phase)
+    raise NotImplementedError, "#{self.class.name} must implement #trackable_activity_event"
+  end
+
   private
+
+  def enqueue_trackable_event_created
+    emit_activity_event(:created)
+  end
+
+  def enqueue_trackable_event_updated
+    emit_activity_event(:updated)
+  end
+
+  # The concern snapshots user ids before_destroy, since the row is gone by the
+  # time the commit hook runs.
+  def enqueue_trackable_event_destroyed(*)
+    emit_activity_event(:destroyed, user_ids: @_trackable_destroyed_user_ids)
+  end
+
+  def emit_activity_event(phase, user_ids: nil)
+    name, properties = trackable_activity_event(phase)
+    return unless name
+
+    enqueue_trackable_event(name, user_ids: user_ids, properties_override: properties || {})
+  end
 
   def snapshot_trackable_changed_keys
     @trackable_changed_keys = saved_changes.keys

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -226,23 +226,13 @@ class Reaction < ApplicationRecord
     }
   end
 
-  def enqueue_trackable_event_created
-    event = trackable_event_name
-    return unless event
-
-    enqueue_trackable_event(event)
-  end
-
-  # Never meaningfully edited; status flips are moderation bookkeeping.
-  def enqueue_trackable_event_updated
-    nil
-  end
-
-  def enqueue_trackable_event_destroyed(*)
-    event = trackable_event_name(removed: true)
-    return unless event
-
-    enqueue_trackable_event(event, user_ids: @_trackable_destroyed_user_ids)
+  # No :updated branch — reactions are created or destroyed, never edited;
+  # status flips are moderation bookkeeping.
+  def trackable_activity_event(phase)
+    case phase
+    when :created then trackable_event_name
+    when :destroyed then trackable_event_name(removed: true)
+    end
   end
 
   # Privileged categories (vomit, thumbsup, thumbsdown) are moderation, not
@@ -263,8 +253,7 @@ class Reaction < ApplicationRecord
       removed ? "comment_unreacted" : "comment_reacted"
     end
   end
-  private :enqueue_trackable_event_created, :enqueue_trackable_event_updated,
-          :enqueue_trackable_event_destroyed, :trackable_event_name
+  private :trackable_activity_event, :trackable_event_name
 
   private
 

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -240,8 +240,13 @@ class Reaction < ApplicationRecord
     nil
   end
 
+  # Toggling a reaction off destroys the row. Without this the CDP's "has
+  # saved" / "has reacted" sets would only ever grow.
   def enqueue_trackable_event_destroyed(*)
-    nil
+    event = trackable_event_name(removed: true)
+    return unless event
+
+    enqueue_trackable_event(event, user_ids: @_trackable_destroyed_user_ids)
   end
 
   # Privileged categories (vomit, thumbsup, thumbsdown) are moderation
@@ -250,14 +255,18 @@ class Reaction < ApplicationRecord
   # never leave the box. readinglist is excluded from visible_to_public? too
   # (published: false in reactions.yml, since saves are private), so the gate
   # is privileged?, not visible_to_public?.
-  def trackable_event_name
+  def trackable_event_name(removed: false)
     return if reaction_category.nil? || reaction_category.privileged?
 
     case reactable_type
     when "Article"
-      category == "readinglist" ? "article_saved" : "article_reacted"
+      if category == "readinglist"
+        removed ? "article_unsaved" : "article_saved"
+      else
+        removed ? "article_unreacted" : "article_reacted"
+      end
     when "Comment"
-      "comment_reacted"
+      removed ? "comment_unreacted" : "comment_reacted"
     end
   end
   private :enqueue_trackable_event_created, :enqueue_trackable_event_updated,

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -228,12 +228,13 @@ class Reaction < ApplicationRecord
     end
   end
 
-  # Privileged categories (vomit, thumbsup, thumbsdown) are moderation, not
-  # member activity, and vomit alone outnumbers every public reaction combined.
-  # Gated on privileged? rather than visible_to_public? because readinglist is
-  # published: false in reactions.yml.
+  # Public reactions plus readinglist, the same set as .for_analytics. Excludes
+  # privileged moderation categories (vomit alone outnumbers every public
+  # reaction combined) and retired ones (thinking, hands), which are all
+  # published: false in reactions.yml — as is readinglist, hence the explicit
+  # allowance for saves.
   def trackable_event_name(removed: false)
-    return if reaction_category.nil? || reaction_category.privileged?
+    return unless reaction_category&.visible_to_public? || category == "readinglist"
 
     case reactable_type
     when "Article"

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -207,15 +207,14 @@ class Reaction < ApplicationRecord
     end
   end
 
-  # === ActivityTrackable (DEV → Customer.io CDP activity events) ===
-  # Emits article_reacted / article_saved / comment_reacted on create only.
-  # Toggling a reaction off destroys the row and emits nothing.
+  # === ActivityTrackable (Customer.io CDP activity events) ===
+  # article_reacted / _saved / comment_reacted, plus their un- counterparts.
 
   def trackable_actor
     user
   end
 
-  # Curated payload with string keys, JSON-safe for Sidekiq.strict_args!.
+  # Curated, string keys for Sidekiq.strict_args!.
   def trackable_payload
     {
       "id" => id,
@@ -234,14 +233,11 @@ class Reaction < ApplicationRecord
     enqueue_trackable_event(event)
   end
 
-  # Reactions are only ever created or destroyed, never meaningfully edited;
-  # status flips are moderation bookkeeping.
+  # Never meaningfully edited; status flips are moderation bookkeeping.
   def enqueue_trackable_event_updated
     nil
   end
 
-  # Toggling a reaction off destroys the row. Without this the CDP's "has
-  # saved" / "has reacted" sets would only ever grow.
   def enqueue_trackable_event_destroyed(*)
     event = trackable_event_name(removed: true)
     return unless event
@@ -249,12 +245,10 @@ class Reaction < ApplicationRecord
     enqueue_trackable_event(event, user_ids: @_trackable_destroyed_user_ids)
   end
 
-  # Privileged categories (vomit, thumbsup, thumbsdown) are moderation
-  # signals, not member activity, and they dominate raw reaction volume — on a
-  # typical day vomit alone outnumbers every public reaction combined. They
-  # never leave the box. readinglist is excluded from visible_to_public? too
-  # (published: false in reactions.yml, since saves are private), so the gate
-  # is privileged?, not visible_to_public?.
+  # Privileged categories (vomit, thumbsup, thumbsdown) are moderation, not
+  # member activity, and vomit alone outnumbers every public reaction combined.
+  # Gated on privileged? rather than visible_to_public? because readinglist is
+  # published: false in reactions.yml.
   def trackable_event_name(removed: false)
     return if reaction_category.nil? || reaction_category.privileged?
 

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -1,4 +1,6 @@
 class Reaction < ApplicationRecord
+  include ActivityTrackable
+
   REACTABLE_TYPES = %w[Comment Article User].freeze
   STATUSES = %w[valid invalid confirmed archived].freeze
 
@@ -204,6 +206,62 @@ class Reaction < ApplicationRecord
       I18n.l(created_at, format: :short_with_yy)
     end
   end
+
+  # === ActivityTrackable (DEV → Customer.io CDP activity events) ===
+  # Emits article_reacted / article_saved / comment_reacted on create only.
+  # Toggling a reaction off destroys the row and emits nothing.
+
+  def trackable_actor
+    user
+  end
+
+  # Curated payload with string keys, JSON-safe for Sidekiq.strict_args!.
+  def trackable_payload
+    {
+      "id" => id,
+      "category" => category,
+      "reactable_type" => reactable_type,
+      "reactable_id" => reactable_id,
+      "reactable_user_id" => reactable.try(:user_id),
+      "user_id" => user_id
+    }
+  end
+
+  def enqueue_trackable_event_created
+    event = trackable_event_name
+    return unless event
+
+    enqueue_trackable_event(event)
+  end
+
+  # Reactions are only ever created or destroyed, never meaningfully edited;
+  # status flips are moderation bookkeeping.
+  def enqueue_trackable_event_updated
+    nil
+  end
+
+  def enqueue_trackable_event_destroyed(*)
+    nil
+  end
+
+  # Privileged categories (vomit, thumbsup, thumbsdown) are moderation
+  # signals, not member activity, and they dominate raw reaction volume — on a
+  # typical day vomit alone outnumbers every public reaction combined. They
+  # never leave the box. readinglist is excluded from visible_to_public? too
+  # (published: false in reactions.yml, since saves are private), so the gate
+  # is privileged?, not visible_to_public?.
+  def trackable_event_name
+    return if reaction_category.nil? || reaction_category.privileged?
+
+    case reactable_type
+    when "Article"
+      category == "readinglist" ? "article_saved" : "article_reacted"
+    when "Comment"
+      "comment_reacted"
+    end
+  end
+  private :enqueue_trackable_event_created, :enqueue_trackable_event_updated,
+          :enqueue_trackable_event_destroyed, :trackable_event_name
 
   private
 

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -210,19 +210,12 @@ class Reaction < ApplicationRecord
   # === ActivityTrackable (Customer.io CDP activity events) ===
   # article_reacted / _saved / comment_reacted, plus their un- counterparts.
 
-  def trackable_actor
-    user
-  end
-
-  # Curated, string keys for Sidekiq.strict_args!.
-  def trackable_payload
+  def trackable_activity_payload
     {
-      "id" => id,
       "category" => category,
       "reactable_type" => reactable_type,
       "reactable_id" => reactable_id,
-      "reactable_user_id" => reactable.try(:user_id),
-      "user_id" => user_id
+      "reactable_user_id" => reactable.try(:user_id)
     }
   end
 
@@ -253,7 +246,7 @@ class Reaction < ApplicationRecord
       removed ? "comment_unreacted" : "comment_reacted"
     end
   end
-  private :trackable_activity_event, :trackable_event_name
+  private :trackable_activity_payload, :trackable_activity_event, :trackable_event_name
 
   private
 

--- a/spec/models/concerns/activity_trackable_spec.rb
+++ b/spec/models/concerns/activity_trackable_spec.rb
@@ -14,9 +14,7 @@ RSpec.describe ActivityTrackable do
 
   around { |ex| with_trackable_events { ex.run } }
 
-  # Setting up a subject usually emits events of its own (creating an article
-  # to comment on emits article_published), so discard whatever the arrangement
-  # produced and return only what the block itself emitted.
+  # Arrangement emits events of its own, so return only what the block emitted.
   def emitted
     events.clear
     yield
@@ -90,9 +88,8 @@ RSpec.describe ActivityTrackable do
       expect(result).to be_empty
     end
 
-    # published and title both come from the body_markdown front matter, which
-    # before_validation re-parses on every save, so assigning them directly is
-    # silently reverted. Edit the markdown the way the real editor does.
+    # published and title come from the front matter, which before_validation
+    # re-parses, so assigning them directly is silently reverted.
     it "emits article_published when a draft goes live" do
       article = create(:article, user: user, published: false)
 
@@ -185,8 +182,7 @@ RSpec.describe ActivityTrackable do
       )
     end
 
-    # A status with no body_url must have a blank (but non-nil) body_markdown:
-    # validate_status_post rejects a body, and the length validation rejects nil.
+    # A status without body_url needs a blank but non-nil body_markdown.
     it "emits article_published for a status that embeds nothing internal" do
       result = emitted do
         Article.create!(
@@ -224,8 +220,7 @@ RSpec.describe ActivityTrackable do
       expect(result).to be_empty
     end
 
-    # CommentsController#destroy soft deletes a comment with replies and hard
-    # destroys one without, so both paths have to report the removal.
+    # The controller soft deletes a comment with replies, hard destroys one without.
     it "emits comment_deleted when a comment is soft deleted" do
       comment = create(:comment, user: user, commentable: article)
 
@@ -286,8 +281,7 @@ RSpec.describe ActivityTrackable do
       expect(names(result)).to eq(["comment_reacted"])
     end
 
-    # vomit outnumbers every public reaction combined on a typical day, so this
-    # exclusion is what keeps the event stream affordable.
+    # vomit alone outnumbers every public reaction combined on a typical day.
     it "stays silent for privileged moderation reactions" do
       trusted = create(:user, :trusted)
 
@@ -333,9 +327,7 @@ RSpec.describe ActivityTrackable do
       expect(result).to be_empty
     end
 
-    # Reactable declares has_many :reactions, dependent: :destroy, so deleting
-    # an article withdraws every reader's reaction too. Those events are keyed
-    # to the reactors, not the author.
+    # Reactions are dependent: :destroy, and their events key to the reactors.
     it "emits removals for reactions cascaded by an article deletion" do
       reactor = create(:user)
       create(:reaction, user: reactor, reactable: article, category: "like")
@@ -359,10 +351,8 @@ RSpec.describe ActivityTrackable do
     end
   end
 
-  # Banishing an account and deleting one both remove content with .delete /
-  # .delete_all / update_all, which bypass callbacks entirely, so none of these
-  # events fire on those paths regardless of the gate. Locking that in: a change
-  # to destroy would otherwise silently turn one banish into thousands of events.
+  # These paths use .delete / .delete_all / update_all, so no callbacks run and
+  # nothing fires. Locked in: switching one to destroy would flood the CDP.
   describe "bulk moderation paths" do
     it "emits nothing when a user's articles and comments are bulk deleted" do
       article = create(:article, user: user)

--- a/spec/models/concerns/activity_trackable_spec.rb
+++ b/spec/models/concerns/activity_trackable_spec.rb
@@ -1,0 +1,302 @@
+require "rails_helper"
+
+RSpec.describe ActivityTrackable do
+  let(:user) { create(:user) }
+  let(:events) { [] }
+
+  before do
+    allow(Trackable::Registry).to receive(:active_names).and_return([:any])
+    allow(Trackable::DispatchWorker).to receive(:perform_async) do |_adapter, name, ids, props, _ts|
+      events << { name: name, user_ids: ids, properties: props }
+    end
+    Settings::General.customerio_cdp_enabled = true
+  end
+
+  around { |ex| with_trackable_events { ex.run } }
+
+  # Setting up a subject usually emits events of its own (creating an article
+  # to comment on emits article_published), so discard whatever the arrangement
+  # produced and return only what the block itself emitted.
+  def emitted
+    events.clear
+    yield
+    events
+  end
+
+  def names(emitted_events)
+    emitted_events.pluck(:name)
+  end
+
+  describe "the shared gate" do
+    let!(:article) { create(:article) }
+
+    it "emits when the master switch is on" do
+      result = emitted { create(:comment, user: user, commentable: article) }
+
+      expect(names(result)).to eq(["comment_created"])
+    end
+
+    it "stays silent when customerio_cdp_enabled is off" do
+      article
+      Settings::General.customerio_cdp_enabled = false
+
+      result = emitted { create(:comment, user: user, commentable: article) }
+
+      expect(result).to be_empty
+    end
+
+    it "stays silent for bot actors" do
+      bot = create(:user, type_of: :community_bot)
+
+      result = emitted { create(:comment, user: bot, commentable: article) }
+
+      expect(result).to be_empty
+    end
+
+    it "stays silent for spam accounts" do
+      user.add_role(:spam)
+
+      result = emitted { create(:comment, user: user, commentable: article) }
+
+      expect(result).to be_empty
+    end
+
+    it "stays silent for suspended accounts" do
+      user.add_role(:suspended)
+
+      result = emitted { create(:comment, user: user, commentable: article) }
+
+      expect(result).to be_empty
+    end
+
+    it "keys events to the actor rather than the content author" do
+      result = emitted { create(:comment, user: user, commentable: article) }
+
+      expect(result.first[:user_ids]).to eq([user.id])
+      expect(user.id).not_to eq(article.user_id)
+    end
+  end
+
+  describe "Article" do
+    it "emits article_published when a published article is created" do
+      result = emitted { create(:article, user: user) }
+
+      expect(names(result)).to eq(["article_published"])
+    end
+
+    it "stays silent while an article is only a draft" do
+      result = emitted { create(:article, user: user, published: false) }
+
+      expect(result).to be_empty
+    end
+
+    # published and title both come from the body_markdown front matter, which
+    # before_validation re-parses on every save, so assigning them directly is
+    # silently reverted. Edit the markdown the way the real editor does.
+    it "emits article_published when a draft goes live" do
+      article = create(:article, user: user, published: false)
+
+      result = emitted do
+        article.update!(body_markdown: article.body_markdown.sub("published: false", "published: true"))
+      end
+
+      expect(names(result)).to eq(["article_published"])
+    end
+
+    it "emits article_updated when a published article's title changes" do
+      article = create(:article, user: user)
+
+      result = emitted do
+        article.update!(body_markdown: article.body_markdown.sub(article.title, "A brand new title"))
+      end
+
+      expect(names(result)).to eq(["article_updated"])
+    end
+
+    it "ignores churn outside TRACKABLE_UPDATE_KEYS" do
+      article = create(:article, user: user)
+
+      result = emitted { article.update!(score: 50) }
+
+      expect(result).to be_empty
+    end
+
+    it "stays silent when a draft is edited" do
+      article = create(:article, user: user, published: false)
+
+      result = emitted do
+        article.update!(body_markdown: article.body_markdown.sub(article.title, "Still a draft"))
+      end
+
+      expect(result).to be_empty
+    end
+
+    it "stays silent when an article is unpublished" do
+      article = create(:article, user: user)
+
+      result = emitted do
+        article.update!(body_markdown: article.body_markdown.sub("published: true", "published: false"))
+      end
+
+      expect(result).to be_empty
+    end
+
+    it "stays silent when an article is destroyed" do
+      article = create(:article, user: user)
+
+      result = emitted { article.destroy }
+
+      expect(result).to be_empty
+    end
+
+    it "ships a curated payload rather than the full row" do
+      article = create(:article, user: user)
+
+      expect(article.trackable_payload.keys).to contain_exactly(
+        "id", "title", "path", "type_of", "published_at", "tag_list",
+        "organization_id", "subforem_id", "user_id"
+      )
+      expect(article.trackable_payload.keys).to all(be_a(String))
+    end
+
+    it "emits article_boosted with the boosted article when a status embeds one" do
+      boosted = create(:article)
+
+      result = emitted do
+        Article.create!(
+          user: user, title: "Great post", type_of: "status",
+          published: true, body_url: URL.article(boosted)
+        )
+      end
+
+      expect(names(result)).to eq(["article_boosted"])
+      expect(result.first[:properties]).to include(
+        "boosted_article_id" => boosted.id,
+        "boosted_article_user_id" => boosted.user_id,
+      )
+    end
+
+    # A status with no body_url must have a blank (but non-nil) body_markdown:
+    # validate_status_post rejects a body, and the length validation rejects nil.
+    it "emits article_published for a status that embeds nothing internal" do
+      result = emitted do
+        Article.create!(
+          user: user, title: "Just a thought", type_of: "status",
+          published: true, body_markdown: ""
+        )
+      end
+
+      expect(names(result)).to eq(["article_published"])
+    end
+  end
+
+  describe "Comment" do
+    let!(:article) { create(:article) }
+
+    it "emits comment_created on creation" do
+      result = emitted { create(:comment, user: user, commentable: article) }
+
+      expect(names(result)).to eq(["comment_created"])
+    end
+
+    it "emits comment_updated when the body changes" do
+      comment = create(:comment, user: user, commentable: article)
+
+      result = emitted { comment.update!(body_markdown: "Rewritten entirely") }
+
+      expect(names(result)).to eq(["comment_updated"])
+    end
+
+    it "ignores reaction counter churn" do
+      comment = create(:comment, user: user, commentable: article)
+
+      result = emitted { comment.update!(score: 42) }
+
+      expect(result).to be_empty
+    end
+
+    it "stays silent when a comment is soft deleted" do
+      comment = create(:comment, user: user, commentable: article)
+
+      result = emitted { comment.update!(deleted: true) }
+
+      expect(result).to be_empty
+    end
+
+    it "stays silent when a comment is destroyed" do
+      comment = create(:comment, user: user, commentable: article)
+
+      result = emitted { comment.destroy }
+
+      expect(result).to be_empty
+    end
+
+    it "carries the commented-on article and its author in the payload" do
+      comment = create(:comment, user: user, commentable: article)
+
+      expect(comment.trackable_payload).to include(
+        "commentable_type" => "Article",
+        "commentable_id" => article.id,
+        "commentable_user_id" => article.user_id,
+        "user_id" => user.id,
+      )
+    end
+  end
+
+  describe "Reaction" do
+    let!(:article) { create(:article) }
+
+    it "emits article_reacted for a public reaction on an article" do
+      result = emitted { create(:reaction, user: user, reactable: article, category: "like") }
+
+      expect(names(result)).to eq(["article_reacted"])
+    end
+
+    it "emits article_saved for a readinglist reaction" do
+      result = emitted { create(:reading_reaction, user: user, reactable: article) }
+
+      expect(names(result)).to eq(["article_saved"])
+    end
+
+    it "emits comment_reacted for a reaction on a comment" do
+      comment = create(:comment, commentable: article)
+
+      result = emitted { create(:reaction, user: user, reactable: comment, category: "like") }
+
+      expect(names(result)).to eq(["comment_reacted"])
+    end
+
+    # vomit outnumbers every public reaction combined on a typical day, so this
+    # exclusion is what keeps the event stream affordable.
+    it "stays silent for privileged moderation reactions" do
+      trusted = create(:user, :trusted)
+
+      result = emitted do
+        create(:vomit_reaction, user: trusted, reactable: article)
+        create(:thumbsdown_reaction, user: trusted, reactable: article)
+      end
+
+      expect(result).to be_empty
+    end
+
+    it "stays silent when a reaction is toggled off" do
+      reaction = create(:reaction, user: user, reactable: article, category: "like")
+
+      result = emitted { reaction.destroy }
+
+      expect(result).to be_empty
+    end
+
+    it "carries the reacted-on record and its author in the payload" do
+      reaction = create(:reaction, user: user, reactable: article, category: "unicorn")
+
+      expect(reaction.trackable_payload).to include(
+        "category" => "unicorn",
+        "reactable_type" => "Article",
+        "reactable_id" => article.id,
+        "reactable_user_id" => article.user_id,
+        "user_id" => user.id,
+      )
+    end
+  end
+end

--- a/spec/models/concerns/activity_trackable_spec.rb
+++ b/spec/models/concerns/activity_trackable_spec.rb
@@ -318,6 +318,25 @@ RSpec.describe ActivityTrackable do
       expect(names(result)).to eq(["comment_unreacted"])
     end
 
+    # Retired categories (published: false in reactions.yml, last created in
+    # 2018) are still reachable on the destroy path when an old article goes.
+    it "stays silent for retired reaction categories" do
+      result = emitted do
+        create(:reaction, user: user, reactable: article, category: "thinking")
+        create(:reaction, user: user, reactable: article, category: "hands")
+      end
+
+      expect(result).to be_empty
+    end
+
+    it "stays silent when a retired reaction is removed" do
+      reaction = create(:reaction, user: user, reactable: article, category: "thinking")
+
+      result = emitted { reaction.destroy }
+
+      expect(result).to be_empty
+    end
+
     it "stays silent when a privileged reaction is removed" do
       trusted = create(:user, :trusted)
       reaction = create(:vomit_reaction, user: trusted, reactable: article)

--- a/spec/models/concerns/activity_trackable_spec.rb
+++ b/spec/models/concerns/activity_trackable_spec.rb
@@ -131,18 +131,27 @@ RSpec.describe ActivityTrackable do
       expect(result).to be_empty
     end
 
-    it "stays silent when an article is unpublished" do
+    it "emits article_unpublished when an article goes back to draft" do
       article = create(:article, user: user)
 
       result = emitted do
         article.update!(body_markdown: article.body_markdown.sub("published: true", "published: false"))
       end
 
-      expect(result).to be_empty
+      expect(names(result)).to eq(["article_unpublished"])
     end
 
-    it "stays silent when an article is destroyed" do
+    it "emits article_deleted when a published article is destroyed" do
       article = create(:article, user: user)
+
+      result = emitted { article.destroy }
+
+      expect(names(result)).to eq(["article_deleted"])
+    end
+
+    # The CDP was never told the draft existed, so its removal is noise.
+    it "stays silent when a draft is destroyed" do
+      article = create(:article, user: user, published: false)
 
       result = emitted { article.destroy }
 
@@ -215,18 +224,29 @@ RSpec.describe ActivityTrackable do
       expect(result).to be_empty
     end
 
-    it "stays silent when a comment is soft deleted" do
+    # CommentsController#destroy soft deletes a comment with replies and hard
+    # destroys one without, so both paths have to report the removal.
+    it "emits comment_deleted when a comment is soft deleted" do
       comment = create(:comment, user: user, commentable: article)
 
       result = emitted { comment.update!(deleted: true) }
 
-      expect(result).to be_empty
+      expect(names(result)).to eq(["comment_deleted"])
     end
 
-    it "stays silent when a comment is destroyed" do
+    it "emits comment_deleted when a comment is destroyed" do
       comment = create(:comment, user: user, commentable: article)
 
       result = emitted { comment.destroy }
+
+      expect(names(result)).to eq(["comment_deleted"])
+    end
+
+    it "stays silent when a soft deleted comment is restored" do
+      comment = create(:comment, user: user, commentable: article)
+      comment.update!(deleted: true)
+
+      result = emitted { comment.update!(deleted: false) }
 
       expect(result).to be_empty
     end
@@ -279,12 +299,51 @@ RSpec.describe ActivityTrackable do
       expect(result).to be_empty
     end
 
-    it "stays silent when a reaction is toggled off" do
+    it "emits article_unreacted when a reaction is toggled off" do
       reaction = create(:reaction, user: user, reactable: article, category: "like")
 
       result = emitted { reaction.destroy }
 
+      expect(names(result)).to eq(["article_unreacted"])
+    end
+
+    it "emits article_unsaved when a readinglist reaction is removed" do
+      reaction = create(:reading_reaction, user: user, reactable: article)
+
+      result = emitted { reaction.destroy }
+
+      expect(names(result)).to eq(["article_unsaved"])
+    end
+
+    it "emits comment_unreacted when a comment reaction is removed" do
+      comment = create(:comment, commentable: article)
+      reaction = create(:reaction, user: user, reactable: comment, category: "like")
+
+      result = emitted { reaction.destroy }
+
+      expect(names(result)).to eq(["comment_unreacted"])
+    end
+
+    it "stays silent when a privileged reaction is removed" do
+      trusted = create(:user, :trusted)
+      reaction = create(:vomit_reaction, user: trusted, reactable: article)
+
+      result = emitted { reaction.destroy }
+
       expect(result).to be_empty
+    end
+
+    # Reactable declares has_many :reactions, dependent: :destroy, so deleting
+    # an article withdraws every reader's reaction too. Those events are keyed
+    # to the reactors, not the author.
+    it "emits removals for reactions cascaded by an article deletion" do
+      reactor = create(:user)
+      create(:reaction, user: reactor, reactable: article, category: "like")
+
+      result = emitted { article.destroy }
+
+      expect(names(result)).to include("article_unreacted")
+      expect(result.detect { |e| e[:name] == "article_unreacted" }[:user_ids]).to eq([reactor.id])
     end
 
     it "carries the reacted-on record and its author in the payload" do
@@ -297,6 +356,29 @@ RSpec.describe ActivityTrackable do
         "reactable_user_id" => article.user_id,
         "user_id" => user.id,
       )
+    end
+  end
+
+  # Banishing an account and deleting one both remove content with .delete /
+  # .delete_all / update_all, which bypass callbacks entirely, so none of these
+  # events fire on those paths regardless of the gate. Locking that in: a change
+  # to destroy would otherwise silently turn one banish into thousands of events.
+  describe "bulk moderation paths" do
+    it "emits nothing when a user's articles and comments are bulk deleted" do
+      article = create(:article, user: user)
+      create(:comment, user: user, commentable: article)
+
+      result = emitted { Users::DeleteArticles.call(user.reload) }
+
+      expect(result).to be_empty
+    end
+
+    it "emits nothing when auto-suspend unpublishes every post" do
+      create(:article, user: user)
+
+      result = emitted { user.articles.update_all(published: false) }
+
+      expect(result).to be_empty
     end
   end
 end


### PR DESCRIPTION
Sends CDP events to Customer.io when a logged-in member posts, comments, reacts, saves, or boosts.

## Approach

The `Trackable` pipeline already exists and is in production for the DEV → Core user sync (`user_created`, `user_updated`, `user_engaged`). This reuses it as-is: `after_commit` → `Trackable::DispatchWorker` → `Trackers::CustomerioCdp`. No new adapter, worker, gem, or endpoint.

`Article`, `Comment` and `Reaction` adopt a new `ActivityTrackable` concern that wraps `Trackable` with the gate every activity event needs, so the three models don't each re-implement it.

## Events

| Event | Fires when |
|---|---|
| `article_published` | create with `published: true`, or `published` flips `false→true` |
| `article_boosted` | same, but a `status` post whose `body_url` resolves to an internal article — emitted *instead of* `article_published` |
| `article_updated` | published article, changes intersect `Article::TRACKABLE_UPDATE_KEYS` |
| `comment_created` | create (comments have no draft state) |
| `comment_updated` | `body_markdown` changed |
| `article_reacted` | public non-`readinglist` reaction on an article |
| `article_saved` | `readinglist` reaction |
| `comment_reacted` | public reaction on a comment |
| `article_unpublished` | `published` flips `true→false` |
| `article_deleted` | a published article is destroyed |
| `comment_deleted` | `deleted` flips `false→true`, or hard destroy |
| `article_unreacted` / `article_unsaved` / `comment_unreacted` | the matching reaction is destroyed |

Boost detection reuses `LiquidEmbedExtractor.derive_reference("embed", url)`, which already maps an internal article URL to its record without rendering Liquid or making network calls.

Payloads are curated per model with string keys (JSON-safe for `Sidekiq.strict_args!`) — never `as_json`, since `articles` is wide and `body_markdown` alone can be hundreds of KB. `trackable_user_ids` is always the actor; the content author travels in properties so downstream can still fan out on it.

## Gating

`Settings::General.customerio_cdp_enabled` (the existing master switch, resolved via the default subforem the way mailers do), plus two suppressions:

- **Non-human actors** (`community_bot` / `member_bot`), matching the user sync.
- **Moderated accounts.** `User#track_engagement!` already suppresses engagement for spam/suspended users so a pruned Customer.io profile isn't resurrected by their activity. A comment or reaction from the same account would resurrect it just as effectively, so activity events honour the same rule.

Checks are ordered cheapest-first: cached `Setting` read, then an enum predicate, then the authorizer.

## Volume

Measured against production, 24h window:

| Event | Per day |
|---|---|
| `article_published` | ~6,500–7,100 |
| `article_updated` | ~600–900 |
| `article_boosted` | ≤34 |
| `comment_created` | 669 |
| `comment_updated` | ~30 |
| `article_reacted` | 1,820 |
| `article_saved` | 193 |
| `comment_reacted` | 1,029 |
| **Total** | **~11,000–11,700/day** (≈340k/month) |

Two allowlists hold this down:

- **Privileged reaction categories** (`vomit`, `thumbsup`, `thumbsdown`) never emit. They're 4,431 of 7,473 daily reactions — 59% — and are moderation signals, not member activity.
- **`TRACKABLE_UPDATE_KEYS`** limits `article_updated`/`comment_updated` to author-visible edits. Both tables churn constantly on score recalcs, counter caches, `last_comment_at`, `spaminess_rating` and embeddings; without the allowlist these would fire orders of magnitude more often than real edits.

The spam/suspended skip also matters for volume: 172 authors (8.3%) produce 4,337 of 7,140 daily published articles — 61% — and that farm tail would otherwise dominate the stream.

## One non-obvious detail

Commit hooks **cannot** read `saved_changes`/`previous_changes` on these models. `Comment#expire_root_fragment` touches the comment from an `after_save` hook, and `touch` calls `changes_applied`, so by the time `after_commit` runs the dirty state has collapsed to `["updated_at"]` and every real edit looks like a no-op.

`ActivityTrackable` snapshots the change keys in an `after_save` (registered ahead of the models' own hooks; `touch` doesn't fire `after_save`, so the snapshot survives it) and clears them in an `after_commit` once the event callbacks have run. The clear is load-bearing: without it a later bare touch on the same instance — a comment touching its article's `last_comment_at` — fires an update commit hook that replays the create's snapshot and republishes the article.

Worth flagging separately: `Comment`'s own `after_update_commit :update_notifications, if: proc { |comment| comment.saved_changes.include? "body_markdown" }` (`app/models/comment.rb:96`) appears to be dead for the same reason. Not touched here.

## Removals

Every create has a counterpart, so segments built on "has published", "has commented", "has saved" or "has reacted" stay accurate rather than growing forever — the rows are gone, so this can't be reconciled retroactively.

Unpublish is tracked alongside delete because it's the more common way an article leaves public view (mods unpublish; authors revert to draft), so delete alone would close only part of the drift. Drafts stay silent on both creation and deletion — the CDP was never told they existed.

Cascaded reaction removals do emit: `Reactable` declares `has_many :reactions, dependent: :destroy`, so deleting an article withdraws every reader's reaction. Those events are keyed to the reactors, not the author. `Article has_many :comments, dependent: :nullify`, so comments are orphaned rather than destroyed and don't cascade.

**Moderation paths can't flood.** `Moderator::BanishUser` and `Users::Delete` remove content with `.delete` / `.delete_all`, and `Spam::Handler.suspend!` unpublishes with `update_all` — all callback-free, so none of these events fire there at all, independent of the actor gate. Specs lock that in, because switching any of them to `destroy` would silently turn one banish into thousands of events. The spam/suspended actor gate covers everything else.

## Out of scope

Share tracking (client-side only today — would need a new beacon endpoint) and `comment_hidden`.

## Testing

37 examples in `spec/models/concerns/activity_trackable_spec.rb` covering the gate (master switch, bots, spam, suspended), each event, and the negative cases: draft creation and draft deletion silent, counter-cache churn silent, privileged reactions silent on both create and remove, soft-delete restore silent, and the bulk moderation paths silent.

Verified `spec/models/comment_spec.rb`, `spec/models/reaction_spec.rb`, `spec/models/article_spec.rb`, `spec/models/user_spec.rb` and the `Trackable` concern specs. Two failures in that set (`Invalid GitHub` liquid tag credentials, and the Mailchimp worker enqueue) reproduce on a clean `origin/main` checkout and are unrelated.
