### PR TITLE
Disable the custom mailer once Customer.io owns broadcast email

### DIFF
--- a/app/mailers/concerns/deliverable.rb
+++ b/app/mailers/concerns/deliverable.rb
@@ -26,6 +26,12 @@ module Deliverable
   end
 
   def set_delivery_options
+    # A mailer action may decline to send by returning before mail() -- Rails
+    # then swaps in a NullMail. Every branch below touches mail(), which with
+    # @_mail_was_called still false would render the message the action
+    # deliberately skipped, and blow up on its unset ivars.
+    return unless @_mail_was_called
+
     if deliver_via_customerio?
       # Deliverable on a Customer.io-only instance (no SMTP creds) must still
       # send, so the per-message flag overrides the SMTP-based default above.

--- a/app/mailers/custom_mailer.rb
+++ b/app/mailers/custom_mailer.rb
@@ -11,6 +11,14 @@ class CustomMailer < ApplicationMailer
 
 
   def custom_email
+    # Broadcasts, newsletters and the onboarding drip are authored in Customer.io
+    # after cutover -- this mailer is the one with no transactional template
+    # behind it, so a send that slipped past the guards in Email, the batch
+    # workers and Admin::EmailsController would go out as an unmanaged body
+    # passthrough. Returning before mail() yields a NullMail: nothing delivers
+    # and no ahoy_messages row is written.
+    return if ForemInstance.customerio_email_cutover?
+
     @user = params[:user]
     @content = Email.replace_merge_tags(params[:content], @user)
     @subject = Email.replace_merge_tags(params[:subject], @user)

--- a/app/views/admin/emails/show.html.erb
+++ b/app/views/admin/emails/show.html.erb
@@ -1,7 +1,15 @@
 <h1 class="crayons-title mb-4">
   <%= Email.replace_merge_tags(@email.subject, current_user) %> [<%= @email.status %>]
-  <%= link_to "Edit", edit_admin_email_path(@email), class: "crayons-btn ml-3" %>
+  <% unless ForemInstance.customerio_email_cutover? %>
+    <%= link_to "Edit", edit_admin_email_path(@email), class: "crayons-btn ml-3" %>
+  <% end %>
 </h1>
+
+<% if ForemInstance.customerio_email_cutover? %>
+  <div class="crayons-notice crayons-notice--warning mb-4" role="alert">
+    <%= t("admin.emails.customerio_cutover_notice") %>
+  </div>
+<% end %>
 <div class="crayons-card p-6 mb-4">
   <p>Type: <%= @email.type_of %></p>
   <p>User Query: <%= @email.user_query&.name || "No query selected" %></p>
@@ -27,15 +35,17 @@
   </pre>
 </div>
 
-<div class="crayons-card p-6 mb-4 mt-4">
-  <h2 class="crayons-title mb-4">Send test email</h2>
-  <%= form_with(model: [:admin, @email], local: true) do |f| %>
-    <div class="crayons-field">
-      <%= f.label :test_email_addresses, class: "crayons-field__label" %>
-      <%= f.text_field :test_email_addresses, class: "crayons-textfield", placeholder: "email@address.com, email2@other.com" %>
-    </div>
-    <div class="crayons-field mt-2">
-      <%= f.submit "Send Test Email", class: "crayons-btn crayons-btn--primary" %>
-    </div>
-  <% end %>
-</div>
+<% unless ForemInstance.customerio_email_cutover? %>
+  <div class="crayons-card p-6 mb-4 mt-4">
+    <h2 class="crayons-title mb-4">Send test email</h2>
+    <%= form_with(model: [:admin, @email], local: true) do |f| %>
+      <div class="crayons-field">
+        <%= f.label :test_email_addresses, class: "crayons-field__label" %>
+        <%= f.text_field :test_email_addresses, class: "crayons-textfield", placeholder: "email@address.com, email2@other.com" %>
+      </div>
+      <div class="crayons-field mt-2">
+        <%= f.submit "Send Test Email", class: "crayons-btn crayons-btn--primary" %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/spec/mailers/custom_mailer_spec.rb
+++ b/spec/mailers/custom_mailer_spec.rb
@@ -139,6 +139,30 @@ RSpec.describe CustomMailer, type: :mailer do
       include_examples "#renders_one_click_unsubscribe_headers"
     end
 
+    context "when the Customer.io cutover is complete" do
+      let(:email) { create(:email, type_of: "newsletter") }
+
+      before do
+        allow(ForemInstance).to receive_messages(smtp_enabled?: true, customerio_email_cutover?: true)
+      end
+
+      it "sends nothing -- broadcasts are authored in Customer.io" do
+        expect do
+          described_class.with(
+            user: user, content: content, subject: subject, email_id: email.id,
+          ).custom_email.deliver_now
+        end.not_to change(ActionMailer::Base.deliveries, :count)
+      end
+
+      it "does not record an ahoy message" do
+        expect do
+          described_class.with(
+            user: user, content: content, subject: subject, email_id: email.id,
+          ).custom_email.deliver_now
+        end.not_to change(EmailMessage, :count)
+      end
+    end
+
     context "when SendGrid is disabled" do
       before do
         allow(ForemInstance).to receive(:sendgrid_enabled?).and_return(false)


### PR DESCRIPTION
## What

`CustomMailer#custom_email` is the only mailer action with no Customer.io mapping — no `transactional_message_id`, no `customerio_event_name`. That is deliberate: after cutover, broadcasts, newsletters and the onboarding drip are authored in the Customer.io UI, not in Forem admin.

Every *sender* already knows this — `Email#deliver_to_users`, `Email#deliver_to_test_emails`, `Emails::EnqueueCustomBatchSendWorker`, `Emails::BatchCustomSendWorker`, `Emails::DripEmailWorker` and `Admin::EmailsController` all return early on `ForemInstance.customerio_email_cutover?`. The mailer itself did not. Anything that slipped past those guards would still send, as an unmanaged body passthrough through the App API — the one send path with no template and no campaign behind it.

## Changes

- **`CustomMailer#custom_email` returns before `mail()`** when `customerio_email_cutover?` is true. Rails swaps in a `NullMail`, so nothing delivers and no `ahoy_messages` row is written.
- **`Deliverable#set_delivery_options` bails when the action never called `mail()`.** This is what made the guard above possible: the after_action calls `mail()`, and with `@_mail_was_called` still false that *renders* the message the action just declined — which then dies on the unset ivars (`undefined method 'html_safe' for nil` out of `custom_email.html.erb`). Returning early is the general fix; any future mailer action that declines to send now behaves.
- **Admin email detail page** hides the Edit button and the Send-test-email form at cutover, and shows the same `customerio_cutover_notice` the index already carries. Previously the page still offered both, and clicking them bounced off the controller's `before_action` with a red flash.

## Testing

Two regression specs in `spec/mailers/custom_mailer_spec.rb`: at cutover a `custom_email` send adds no `ActionMailer::Base.deliveries` entry and no `EmailMessage` row.

`spec/mailers` is green (287 examples) apart from `application_mailer_spec.rb:8`, which fails on `main` already in a local env without SMTP settings. `spec/requests/admin/emails_spec.rb` is green (14 examples).

## Notes

This closes the cutover hole only. During a *partial* rollout — `:customerio_email_delivery` on for some actors but not globally — custom emails to flagged recipients still route through Customer.io as a body passthrough, because `Deliverable` decides per recipient while these guards key off the global flag. That is survivable (the ActionMailer render is what gets sent, and it delivers), and narrowing it would mean giving the batch senders a per-recipient dial they do not currently have.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789567666&installation_model_id=424141&pr_number=23739&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23739&signature=fdc2be34eea1f119e728f50651901683a02fe8431c66f307496c5f851a0a4617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->