### PR TITLE
Accept an allowlist of notification settings in the admin API

### DIFF
--- a/app/controllers/concerns/api/admin/users_controller.rb
+++ b/app/controllers/concerns/api/admin/users_controller.rb
@@ -115,12 +115,12 @@ module Api
         render json: { id: @user_record.id, status: status }
       end
 
-      # Lets MLH Core push consent changes (its dev-newsletter opt-outs) back
-      # onto the DEV account's local notification settings, which DEV's own
-      # senders (digest, newsletter) key off. Writes through the model so the
-      # normal callbacks fire (Mailchimp sync, and the CDP newsletter events
-      # once enabled) - the resulting echo event is value-idempotent on the
-      # Core side.
+      # Lets an external system of record push consent changes (its
+      # dev-newsletter opt-outs) back onto the DEV account's local
+      # notification settings, which DEV's own senders (digest, newsletter)
+      # key off. Writes through the model so the normal callbacks fire
+      # (Mailchimp sync, and the CDP newsletter events once enabled) - the
+      # resulting echo event is value-idempotent on that system's side.
       def update_notification_settings
         @user_record = User.find(params[:id])
         # Handle the missing wrapper here rather than via params.require, so
@@ -135,12 +135,13 @@ module Api
         end
 
         setting = @user_record.notification_setting
-        # This endpoint carries MLH Core's OWN consent state (its dev
-        # newsletter opt-outs/opt-ins). Emitting the CDP newsletter events
-        # here would make Core consume its own push as a user consent
-        # change — destroying the layered global-unsubscribe vs
-        # list-preference distinction. Model callbacks that aren't CDP
-        # emission (Mailchimp sync, base_email_eligible) still run.
+        # This endpoint carries an external system of record's OWN consent
+        # state (its dev newsletter opt-outs/opt-ins). Emitting the CDP
+        # newsletter events here would make that system consume its own push
+        # as a user consent change — destroying the layered
+        # global-unsubscribe vs list-preference distinction. Model callbacks
+        # that aren't CDP emission (Mailchimp sync, base_email_eligible)
+        # still run.
         User.skip_trackable_events { setting.update!(updates) }
 
         audit!(slug: "update_notification_settings",

--- a/app/controllers/concerns/api/admin/users_controller.rb
+++ b/app/controllers/concerns/api/admin/users_controller.rb
@@ -11,6 +11,18 @@ module Api
         "Good standing", "Suspended", "Spam", "Warned",
         "Comment Suspended", "Trusted", "Limited"
       ].freeze
+      # User-consent email columns Core may write through this endpoint. Mobile
+      # and in-app columns, and the role-driven mod newsletters, are deliberately
+      # excluded: they are not consent Core owns.
+      ALLOWED_NOTIFICATION_SETTINGS = %i[
+        email_newsletter
+        email_digest_periodic
+        email_comment_notifications
+        email_follower_notifications
+        email_mention_notifications
+        email_unread_notifications
+        email_badge_notifications
+      ].freeze
 
       def index
         users = filtered_users
@@ -113,7 +125,7 @@ module Api
         # the caller gets the admin API error_code instead of a generic
         # ParameterMissing 422.
         wrapper = params[:notification_setting]
-        updates = wrapper.respond_to?(:permit) ? wrapper.permit(:email_newsletter) : {}
+        updates = wrapper.respond_to?(:permit) ? wrapper.permit(*ALLOWED_NOTIFICATION_SETTINGS) : {}
         if updates.blank?
           raise Api::Admin::ApiError.new(:invalid_notification_settings,
                                          I18n.t("admin_api.errors.invalid_notification_settings"),
@@ -132,10 +144,10 @@ module Api
         audit!(slug: "update_notification_settings",
                data: {
                  "target_user_id" => @user_record.id,
-                 "changes" => setting.saved_changes.slice("email_newsletter")
+                 "changes" => setting.saved_changes.slice(*ALLOWED_NOTIFICATION_SETTINGS.map(&:to_s))
                })
         render json: { id: @user_record.id,
-                       notification_setting: { email_newsletter: setting.email_newsletter } }
+                       notification_setting: setting.slice(*ALLOWED_NOTIFICATION_SETTINGS) }
       end
 
       def merge

--- a/app/controllers/concerns/api/admin/users_controller.rb
+++ b/app/controllers/concerns/api/admin/users_controller.rb
@@ -11,9 +11,11 @@ module Api
         "Good standing", "Suspended", "Spam", "Warned",
         "Comment Suspended", "Trusted", "Limited"
       ].freeze
-      # User-consent email columns Core may write through this endpoint. Mobile
-      # and in-app columns, and the role-driven mod newsletters, are deliberately
-      # excluded: they are not consent Core owns.
+      # Email notification columns writable through this endpoint. These are
+      # the user-consent settings an external system of record may push back
+      # onto the account. Mobile and in-app columns are excluded, as are the
+      # moderator newsletters, which are driven by role changes rather than by
+      # the user's own choice.
       ALLOWED_NOTIFICATION_SETTINGS = %i[
         email_newsletter
         email_digest_periodic

--- a/spec/requests/api/v1/admin/users_spec.rb
+++ b/spec/requests/api/v1/admin/users_spec.rb
@@ -424,6 +424,53 @@ RSpec.describe "/api/admin/users" do
 
       expect(response).to have_http_status(:not_found)
     end
+
+    it "updates email_digest_periodic" do
+      target.notification_setting.update!(email_digest_periodic: true)
+
+      put_settings({ notification_setting: { email_digest_periodic: false } })
+
+      expect(response).to have_http_status(:ok)
+      expect(target.notification_setting.reload.email_digest_periodic).to be(false)
+    end
+
+    it "updates several allowlisted keys in one call" do
+      target.notification_setting.update!(email_newsletter: true, email_digest_periodic: true)
+
+      put_settings({ notification_setting: { email_newsletter: false,
+                                             email_digest_periodic: false } })
+
+      setting = target.notification_setting.reload
+      expect(setting.email_newsletter).to be(false)
+      expect(setting.email_digest_periodic).to be(false)
+    end
+
+    it "returns every allowlisted key in the response" do
+      put_settings({ notification_setting: { email_digest_periodic: true } })
+
+      body = response.parsed_body["notification_setting"]
+      expect(body.keys).to match_array(
+        Api::Admin::UsersController::ALLOWED_NOTIFICATION_SETTINGS.map(&:to_s),
+      )
+    end
+
+    it "rejects a payload of only unknown keys" do
+      put_settings({ notification_setting: { mobile_comment_notifications: false } })
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(target.notification_setting.reload.mobile_comment_notifications).to be(true)
+    end
+
+    it "audits digest changes too" do
+      target.notification_setting.update!(email_digest_periodic: true)
+
+      expect do
+        put_settings({ notification_setting: { email_digest_periodic: false } })
+      end.to change(AuditLog, :count).by(1)
+
+      audit = AuditLog.last
+      expect(audit.data["changes"]).to eq("email_digest_periodic" => [true, false])
+    end
   end
 
   describe "PUT /api/admin/users/:id/status" do

--- a/spec/requests/api/v1/admin/users_spec.rb
+++ b/spec/requests/api/v1/admin/users_spec.rb
@@ -384,9 +384,9 @@ RSpec.describe "/api/admin/users" do
     end
 
     # Core pushes ITS OWN consent state through this endpoint; if the write
-    # emitted the CDP newsletter events, Core would consume its own push as
-    # a user consent change (destroying the layered global-unsubscribe /
-    # list-preference distinction).
+    # emitted the CDP newsletter/digest events, Core would consume its own
+    # push as a user consent change (destroying the layered
+    # global-unsubscribe / list-preference distinction).
     it "does not emit CDP newsletter events for admin-API writes" do
       allow(Trackable::Registry).to receive(:active_names).and_return([:any])
       allow(Trackable::DispatchWorker).to receive(:perform_async)
@@ -401,6 +401,28 @@ RSpec.describe "/api/admin/users" do
       expect(target.notification_setting.reload.email_newsletter).to be(false)
       expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
         .with(anything, /user_newsletter/, anything, anything, anything)
+    ensure
+      FeatureFlag.remove(:dev_core_user_sync)
+    end
+
+    # Same suppression, driven by the OTHER independent consent this endpoint
+    # can write: the digest events must not fire back at Core either, or a
+    # digest-only admin-API write would be consumed as a user-originated
+    # digest change.
+    it "does not emit CDP digest events for admin-API writes" do
+      allow(Trackable::Registry).to receive(:active_names).and_return([:any])
+      allow(Trackable::DispatchWorker).to receive(:perform_async)
+      Settings::General.customerio_cdp_enabled = true
+      FeatureFlag.enable(:dev_core_user_sync, FeatureFlag::Actor[target])
+      target.notification_setting.update!(email_digest_periodic: true)
+
+      with_trackable_events do
+        put_settings({ notification_setting: { email_digest_periodic: false } })
+      end
+
+      expect(target.notification_setting.reload.email_digest_periodic).to be(false)
+      expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+        .with(anything, /user_digest/, anything, anything, anything)
     ensure
       FeatureFlag.remove(:dev_core_user_sync)
     end

--- a/spec/requests/api/v1/docs/users_spec.rb
+++ b/spec/requests/api/v1/docs/users_spec.rb
@@ -343,7 +343,7 @@ RSpec.describe "Api::V1::Docs::Users" do
     path "/api/admin/users/{id}/notification_settings" do
       put "Update user notification settings (Admin)" do
         tags "users", "admin"
-        description "Update a user's email notification preferences (e.g., unsubscribing them from the system newsletter). Requires Super Admin credentials."
+        description "Update a user's email notification preferences (e.g., unsubscribing them from the system newsletter or the periodic digest). Any subset of the listed properties may be supplied; at least one is required. Requires Super Admin credentials."
         consumes "application/json"
         produces "application/json"
         parameter name: :id, in: :path, required: true,
@@ -357,7 +357,13 @@ RSpec.describe "Api::V1::Docs::Users" do
                       notification_setting: {
                         type: :object,
                         properties: {
-                          email_newsletter: { type: :boolean }
+                          email_newsletter: { type: :boolean },
+                          email_digest_periodic: { type: :boolean },
+                          email_comment_notifications: { type: :boolean },
+                          email_follower_notifications: { type: :boolean },
+                          email_mention_notifications: { type: :boolean },
+                          email_unread_notifications: { type: :boolean },
+                          email_badge_notifications: { type: :boolean }
                         }
                       }
                     },
@@ -368,6 +374,16 @@ RSpec.describe "Api::V1::Docs::Users" do
           let(:"api-key") { api_secret.secret }
           let(:id) { banned_user.id }
           let(:settings_params) { { notification_setting: { email_newsletter: false } } }
+          add_examples
+          run_test!
+        end
+
+        response "200", "successful (multiple settings)" do
+          let(:"api-key") { api_secret.secret }
+          let(:id) { banned_user.id }
+          let(:settings_params) do
+            { notification_setting: { email_newsletter: false, email_digest_periodic: false } }
+          end
           add_examples
           run_test!
         end

--- a/spec/requests/api/v1/docs/users_spec.rb
+++ b/spec/requests/api/v1/docs/users_spec.rb
@@ -378,7 +378,7 @@ RSpec.describe "Api::V1::Docs::Users" do
           run_test!
         end
 
-        response "200", "successful (multiple settings)" do
+        response "200", "successful" do
           let(:"api-key") { api_secret.secret }
           let(:id) { banned_user.id }
           let(:settings_params) do

--- a/swagger/v1/api_v1.json
+++ b/swagger/v1/api_v1.json
@@ -5281,7 +5281,7 @@
           "users",
           "admin"
         ],
-        "description": "Update a user's email notification preferences (e.g., unsubscribing them from the system newsletter). Requires Super Admin credentials.",
+        "description": "Update a user's email notification preferences (e.g., unsubscribing them from the system newsletter or the periodic digest). Any subset of the listed properties may be supplied; at least one is required. Requires Super Admin credentials.",
         "parameters": [
           {
             "name": "id",
@@ -5295,7 +5295,7 @@
         ],
         "responses": {
           "200": {
-            "description": "successful"
+            "description": "successful (multiple settings)"
           }
         },
         "requestBody": {
@@ -5308,6 +5308,24 @@
                     "type": "object",
                     "properties": {
                       "email_newsletter": {
+                        "type": "boolean"
+                      },
+                      "email_digest_periodic": {
+                        "type": "boolean"
+                      },
+                      "email_comment_notifications": {
+                        "type": "boolean"
+                      },
+                      "email_follower_notifications": {
+                        "type": "boolean"
+                      },
+                      "email_mention_notifications": {
+                        "type": "boolean"
+                      },
+                      "email_unread_notifications": {
+                        "type": "boolean"
+                      },
+                      "email_badge_notifications": {
                         "type": "boolean"
                       }
                     }

--- a/swagger/v1/api_v1.json
+++ b/swagger/v1/api_v1.json
@@ -5295,7 +5295,7 @@
         ],
         "responses": {
           "200": {
-            "description": "successful (multiple settings)"
+            "description": "successful"
           }
         },
         "requestBody": {


### PR DESCRIPTION
## What

`PUT /api/admin/users/:id/notification_settings` currently permits exactly one column, `email_newsletter`. That makes it impossible for an external system of record to push back any other email preference — notably `email_digest_periodic`, which is a separate consent that `EmailDigest` selects on independently of the newsletter flag.

This widens the endpoint to an allowlist of the user-consent email columns:

```ruby
ALLOWED_NOTIFICATION_SETTINGS = %i[
  email_newsletter
  email_digest_periodic
  email_comment_notifications
  email_follower_notifications
  email_mention_notifications
  email_unread_notifications
  email_badge_notifications
].freeze
```

Any subset may be supplied; at least one is required. The audit entry and the JSON response both cover the full allowlist.

## What is deliberately excluded

- **Mobile and in-app columns** (`mobile_*`, `reaction_notifications`, `welcome_notifications`) — not email consent.
- **The moderator newsletters** (`email_community_mod_newsletter`, `email_tag_mod_newsletter`, `email_membership_newsletter`) — these are driven by role changes in `TagModerators::Add` and `Moderator::ManageActivityAndRoles`, not by the user's own choice, so an external system should not be writing them.

## Backward compatibility

Additive. The previous single-key body still works unchanged, and no existing spec asserts an exclusive set of response keys, so the widened response cannot break a current caller.

`User.skip_trackable_events` still wraps the write, so this endpoint continues not to emit CDP consent events — a caller pushing its own consent state must not have that read back as a user-initiated change.

## Docs

Per `AGENTS.md`, the rswag spec is updated and `swagger/v1/api_v1.json` regenerated. The schema diff is scoped to `/api/admin/users/{id}/notification_settings` only.

## Testing

- `spec/requests/api/v1/admin/users_spec.rb` — 56 examples, 0 failures. Five new tests cover the digest column, a multi-key write, the full response shape, rejection of a payload containing only non-allowlisted keys, and the audit payload for a digest change.
- `spec/requests/api/v1/docs/users_spec.rb` — passing; full swaggerize run 4309 examples, 0 failures.
- RuboCop clean.

The unknown-key test uses `mobile_comment_notifications` — a real column that is deliberately excluded — so it exercises the allowlist boundary rather than a typo.

---
https://claude.ai/code/session_01AhRkaB1MrjRyDrPxexxoTs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789572476&installation_model_id=424141&pr_number=23740&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23740&signature=69181d2b3c767e943110cf4d3ee435dd891637d8cdc64c8652609ac1cec20d1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->