### PR TITLE
Ship the mailer footer data on every trackable event

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -907,7 +907,7 @@ class User < ApplicationRecord
       "email_newsletter" => notification_setting&.email_newsletter,
       "email_digest_periodic" => notification_setting&.email_digest_periodic,
       "mlh_user_id" => identities.where(provider: "mlh").pick(:uid)
-    }
+    }.merge(Users::EmailFooterPayload.call(self))
   end
 
   # Invited accounts (registered: false) have not consented to anything yet,

--- a/app/services/users/email_footer_payload.rb
+++ b/app/services/users/email_footer_payload.rb
@@ -1,0 +1,77 @@
+module Users
+  # The footer block `layouts/mailer.html.erb` renders at the bottom of DEV's
+  # own mail, as plain data, so a Customer.io campaign can render the same
+  # thing. Mirrors `Deliverable#layout_message_data`, which supplies the
+  # identical keys on the transactional path.
+  #
+  # Shipped on EVERY trackable event, unconditionally, and never conditionally
+  # omitted: Customer.io validates a template's `event.<attr>` references
+  # against the triggering event's own schema and fails the ENTIRE body render
+  # for an attribute the event does not carry. It fails on the first such
+  # reference, so a partial set only moves the error along. A key that is
+  # sometimes missing is far worse than one that is sometimes blank.
+  #
+  # The unsubscribe link is deliberately the same signed, one-click token the
+  # SMTP path sends (see `ApplicationMailer#generate_unsubscribe_token`): it
+  # flips `users_notification_settings.email_newsletter`, which is what DEV
+  # treats as the source of truth and what Core learns from via the
+  # `user_newsletter_subscribed` / `_unsubscribed` events. A Customer.io
+  # subscription topic would unsubscribe in Customer.io only, leaving DEV
+  # believing the person is still subscribed.
+  module EmailFooterPayload
+    module_function
+
+    BLANK = {
+      "signed_up_with_html" => "",
+      "unsubscribe_url" => "",
+      "notification_settings_url" => ""
+    }.freeze
+
+    # 31 days comfortably covers the onboarding drip's 9 day span.
+    TOKEN_TTL = 31.days
+
+    def call(user)
+      host = Subforem.cached_id_to_domain_hash[user.onboarding_subforem_id]
+
+      {
+        "signed_up_with_html" => view_context.signed_up_with(user),
+        "unsubscribe_url" => unsubscribe_url(user, host),
+        "notification_settings_url" => URL.url("/settings/notifications", host)
+      }
+    rescue StandardError => e
+      # Never let footer generation take down the Core sync. The keys still
+      # ship, blank, so a template referencing them renders rather than failing.
+      Rails.logger.warn("EmailFooterPayload failed for user #{user.id}: #{e.message}")
+      BLANK.dup
+    end
+
+    # Built by concatenation rather than URL.url: the signed token is already
+    # percent-escaped by the route helper, and URL.url runs the result through
+    # Addressable's #normalize, which unescapes it and corrupts the signature.
+    def unsubscribe_url(user, host)
+      path = Rails.application.routes.url_helpers
+        .email_subscriptions_unsubscribe_path(ut: unsubscribe_token(user))
+
+      "#{URL.url(nil, host)}#{path}"
+    end
+
+    def unsubscribe_token(user)
+      Rails.application.message_verifier(:unsubscribe).generate({
+                                                                  user_id: user.id,
+                                                                  email_type: "email_newsletter",
+                                                                  expires_at: TOKEN_TTL.from_now.iso8601
+                                                                })
+    end
+
+    # AuthenticationHelper#signed_up_with needs both the helper and the route
+    # helpers; ApplicationController.helpers carries only the former, which is
+    # why ApplicationMailer declares them together.
+    def view_context
+      @view_context ||= Class.new do
+        include Rails.application.routes.url_helpers
+        include ActionView::Helpers::TranslationHelper
+        include AuthenticationHelper
+      end.new
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -71,8 +71,48 @@ RSpec.describe User do
       user = create(:user)
       expect(user.trackable_payload.keys).to contain_exactly(
         "id", "username", "email", "name", "registered_at", "confirmed_at", "email_newsletter",
-        "email_digest_periodic", "mlh_user_id"
+        "email_digest_periodic", "mlh_user_id",
+        "signed_up_with_html", "unsubscribe_url", "notification_settings_url"
       )
+    end
+
+    # Customer.io fails the ENTIRE body render of a template that references an
+    # event attribute the triggering event does not carry, and fails on the first
+    # such reference -- so these three must always be present, even when blank.
+    it "always carries the three email footer keys, whatever else is missing" do
+      user = create(:user)
+      allow(Users::EmailFooterPayload).to receive(:unsubscribe_token).and_raise(StandardError, "boom")
+
+      payload = user.trackable_payload
+
+      expect(payload).to include(
+        "signed_up_with_html" => "",
+        "unsubscribe_url" => "",
+        "notification_settings_url" => "",
+      )
+    end
+
+    it "carries a one-click unsubscribe url that the unsubscribe controller accepts" do
+      user = create(:user)
+
+      url = user.trackable_payload["unsubscribe_url"]
+      token = Rack::Utils.parse_query(URI.parse(url).query)["ut"]
+      verified = Rails.application.message_verifier(:unsubscribe).verify(token).with_indifferent_access
+
+      expect(URI.parse(url).path).to eq("/email_subscriptions/unsubscribe")
+      expect(verified[:user_id]).to eq(user.id)
+      expect(verified[:email_type]).to eq("email_newsletter")
+      expect(Time.zone.parse(verified[:expires_at])).to be > Time.current
+    end
+
+    it "points the footer at the user's onboarding subforem" do
+      subforem = create(:subforem, domain: "onboarding.example.com")
+      user = create(:user, onboarding_subforem_id: subforem.id)
+
+      payload = user.trackable_payload
+
+      expect(URI.parse(payload["unsubscribe_url"]).host).to eq("onboarding.example.com")
+      expect(payload["notification_settings_url"]).to end_with("/settings/notifications")
     end
 
     it "reflects registration, confirmation, and email consent state in the payload" do


### PR DESCRIPTION
## Why

A Customer.io campaign triggered by a CDP event cannot render DEV's standard email footer. `dev_prod_user_created` carries no unsubscribe URL, so the shared `c-dev-footer` component's `event.signed_up_with_html` reference took down **every send in the DEV onboarding drip**:

```
undefined variable: event.signed_up_with_html, line:221, col:77
```

Customer.io validates a template's `event.<attr>` references against the *triggering event's own schema* and fails the entire body render for an attribute the event does not carry. Verified against live deliveries:

| context | `trigger.missing` | `event.missing` |
|---|---|---|
| transactional message | nil, safe | nil, safe (no event at all) |
| event-triggered automation | nil, safe | **render fails** |

It fails on the *first* such reference, so supplying one key just moves the error to the next. Neither `event["literal"]` nor `event[variableKey]` evades it in a body. (Subjects render leniently and give a false pass — only a real delivery's `failure_message` is trustworthy.)

## What

`User#trackable_payload` now merges `Users::EmailFooterPayload`, adding three keys to every trackable event:

- `signed_up_with_html`
- `unsubscribe_url`
- `notification_settings_url`

These are the same three `Deliverable#layout_message_data` already supplies on the transactional path, and the same block `layouts/mailer.html.erb` renders at the bottom of DEV's own mail. They ship **unconditionally** — blank rather than absent if generation fails — because a key that is sometimes missing takes the whole send down, while one that is sometimes blank just renders nothing.

**The unsubscribe link is deliberately the existing signed, one-click token** (`ApplicationMailer#generate_unsubscribe_token`), not a Customer.io subscription topic. It flips `users_notification_settings.email_newsletter`, which is what DEV treats as the source of truth and what Core learns from via `user_newsletter_subscribed` / `_unsubscribed`. A Customer.io topic would unsubscribe in Customer.io only and let the two sides silently diverge — the wrong answer while DEV/Core/Customer.io topic sync is still in flight.

## Two things for review

- **`signed_up_with` needs the route helpers alongside it.** `ApplicationController.helpers` carries `AuthenticationHelper` but not `new_magic_link_url`, which is why `ApplicationMailer` declares both. The service builds a view context including both.
- **The unsubscribe URL is concatenated, not passed through `URL.url`.** `URL.url` runs the result through Addressable's `#normalize`, which unescapes the percent-encoded token and corrupts the signature. There is a regression test that verifies the emitted URL round-trips through `message_verifier(:unsubscribe)`.

## Testing

Four new specs in `spec/models/user_spec.rb`: the key set, the always-present-even-on-failure guarantee, a full verify of the emitted unsubscribe token (path, `user_id`, `email_type`, expiry), and subforem-aware hosts.

`spec/models/user_spec.rb` (359), `spec/models/concerns/trackable_spec.rb`, `spec/services/trackers`, `spec/mailers/concerns`, `spec/workers/trackable` — all green (71 in the latter group). RuboCop clean on the new file and on the added spec lines.

## Note

Every CDP event now carries a 31-day unsubscribe capability token in its properties, stored on the Customer.io event record. Same exposure class as the address itself, but worth a conscious nod. Core ignores keys it does not consume.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789573382&installation_model_id=424141&pr_number=23741&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23741&signature=57a915e3fd28cef37dcc7480fef362eb0441557294d929f4eb461c9e3052213f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->