### PR TITLE
Namespace Customer.io Track events with APP_NAME

### DIFF
--- a/app/mailers/concerns/deliverable.rb
+++ b/app/mailers/concerns/deliverable.rb
@@ -14,8 +14,10 @@ module Deliverable
   #                               message_data: { "comment" => ... })
   # A mailer that belongs to an event-triggered campaign rather than a
   # transactional message names the event instead, e.g.
-  #   customerio_delivery_options(customerio_event_name: "dev_digest_ready",
+  #   customerio_delivery_options(customerio_event_name: "digest_ready",
   #                               message_data: { "articles" => [...] })
+  # Name the event bare: DeliveryMethods::CustomerIoEvent splices in the
+  # deploy's APP_NAME before sending it.
   # Ignored unless the message routes through Customer.io.
   def customerio_delivery_options(options)
     @customerio_delivery_options = (@customerio_delivery_options || {}).merge(options)

--- a/app/mailers/digest_mailer.rb
+++ b/app/mailers/digest_mailer.rb
@@ -23,7 +23,9 @@ class DigestMailer < ApplicationMailer
     # renders the ActionMailer body instead, since no transactional message id
     # is declared.
     customerio_delivery_options(
-      customerio_event_name: "dev_digest_ready",
+      # Bare name: DeliveryMethods::CustomerIoEvent namespaces it with APP_NAME
+      # at send time, so this reaches Customer.io as "dev_prod_digest_ready".
+      customerio_event_name: "digest_ready",
       message_data: {
         "subject" => subject,
         "articles" => @articles.map { |article| digest_article_payload(article) },

--- a/app/services/delivery_methods/customer_io_event.rb
+++ b/app/services/delivery_methods/customer_io_event.rb
@@ -41,7 +41,10 @@ module DeliveryMethods
         # transactional path: the MLH Core uid where the account is linked,
         # falling back to email.
         identifiers: settings[:identifiers],
-        name: settings[:customerio_event_name],
+        # Mailers declare the bare event ("digest_ready"); the deploy's APP_NAME
+        # is spliced in here, at the boundary, exactly as the CDP adapter does.
+        # The campaign's trigger has to match the namespaced name.
+        name: Trackable::EventName.prefixed(settings[:customerio_event_name]),
         attributes: attributes(mail)
       }
     end

--- a/app/services/trackable/event_name.rb
+++ b/app/services/trackable/event_name.rb
@@ -1,0 +1,20 @@
+module Trackable
+  # Namespaces every event we emit to Customer.io with the deploy's APP_NAME
+  # (e.g. "dev_prod") so events from different environments or Forem instances
+  # writing into the same workspace stay distinct: "dev_prod_user_updated".
+  # When APP_NAME is unset the prefix falls back to "forem".
+  #
+  # Shared by both Customer.io paths -- CDP events (Trackers::CustomerioCdp)
+  # and campaign-triggering Track API events (DeliveryMethods::CustomerIoEvent)
+  # -- because a Track event name is also a campaign's trigger. Two copies of
+  # this rule that drifted apart would stop a campaign firing rather than just
+  # mislabel a metric, so there is only one.
+  module EventName
+    DEFAULT_APP_NAME = "forem".freeze
+
+    def self.prefixed(event_name)
+      prefix = ApplicationConfig["APP_NAME"].presence || DEFAULT_APP_NAME
+      "#{prefix}_#{event_name}"
+    end
+  end
+end

--- a/app/services/trackers/customerio_cdp.rb
+++ b/app/services/trackers/customerio_cdp.rb
@@ -16,9 +16,6 @@ module Trackers
     # row — possible because identity comes from the stable anonymous id and
     # the payload's own mlh_user_id, both knowable post-destruction.
     DESTRUCTIVE_EVENTS = ["user_gdpr_deleted"].freeze
-    # Fallback event-name namespace when APP_NAME is unset (see
-    # #prefixed_event_name): "forem_user_updated".
-    DEFAULT_APP_NAME = "forem".freeze
 
     def enabled?
       # Resolve the setting via the default subforem (like mailers do): the admin
@@ -41,7 +38,7 @@ module Trackers
       # capture is the fallback.
       linked_uids = Identity.where(provider: "mlh", user_id: ids).pluck(:user_id, :uid).to_h
 
-      event = prefixed_event_name(event_name)
+      event = Trackable::EventName.prefixed(event_name)
 
       ids.each do |id|
         attributes = {
@@ -57,15 +54,6 @@ module Trackers
     end
 
     private
-
-    # Namespace every CDP event with the deploy's APP_NAME (e.g. "dev_prod")
-    # so events from different environments/instances writing to the same
-    # Customer.io workspace stay distinct: "dev_prod_user_updated". When
-    # APP_NAME is unset the prefix falls back to "forem": "forem_user_updated".
-    def prefixed_event_name(event_name)
-      prefix = ApplicationConfig["APP_NAME"].presence || DEFAULT_APP_NAME
-      "#{prefix}_#{event_name}"
-    end
 
     def deliverable_ids(ids, destructive)
       return ids if destructive

--- a/spec/mailers/concerns/deliverable_spec.rb
+++ b/spec/mailers/concerns/deliverable_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Deliverable do
     # transactional message.
     describe "Track-event switching" do
       let(:event_options) do
-        { customerio_event_name: "dev_digest_ready", message_data: { "a" => 1 } }
+        { customerio_event_name: "digest_ready", message_data: { "a" => 1 } }
       end
 
       before do
@@ -127,7 +127,7 @@ RSpec.describe Deliverable do
         message = built_message(to: user.email, customerio_options: event_options)
 
         expect(message.delivery_method).to be_a(DeliveryMethods::CustomerIoEvent)
-        expect(message.delivery_method.settings[:customerio_event_name]).to eq("dev_digest_ready")
+        expect(message.delivery_method.settings[:customerio_event_name]).to eq("digest_ready")
         expect(message.delivery_method.settings[:identifiers]).to eq(email: user.email)
         expect(message.perform_deliveries).to be(true)
       end

--- a/spec/mailers/digest_mailer_spec.rb
+++ b/spec/mailers/digest_mailer_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe DigestMailer do
         email = described_class.with(user: user, articles: [article, article2], feed_config_id: 12_345).digest_email
 
         settings = email.message.delivery_method.settings
-        expect(settings[:customerio_event_name]).to eq("dev_digest_ready")
+        expect(settings[:customerio_event_name]).to eq("digest_ready")
 
         data = settings[:message_data]
         expect(data["subject"]).to eq(email.subject)

--- a/spec/services/delivery_methods/customer_io_event_spec.rb
+++ b/spec/services/delivery_methods/customer_io_event_spec.rb
@@ -11,7 +11,11 @@ RSpec.describe DeliveryMethods::CustomerIoEvent do
     )
   end
 
-  before { stub_const("CUSTOMERIO_TRACK_API", track_client) }
+  before do
+    stub_const("CUSTOMERIO_TRACK_API", track_client)
+    allow(ApplicationConfig).to receive(:[]).and_call_original
+    allow(ApplicationConfig).to receive(:[]).with("APP_NAME").and_return("dev_prod")
+  end
 
   def delivered_entity(options = {}, delivered_mail = mail)
     described_class.new(options).deliver!(delivered_mail)
@@ -23,14 +27,14 @@ RSpec.describe DeliveryMethods::CustomerIoEvent do
 
   it "emits a person event carrying the payload" do
     entity = delivered_entity(
-      customerio_event_name: "dev_digest_ready",
+      customerio_event_name: "digest_ready",
       identifiers: { id: "mlh-42" },
       message_data: { "articles" => [{ "title" => "A post" }] },
     )
 
     expect(entity[:type]).to eq("person")
     expect(entity[:action]).to eq("event")
-    expect(entity[:name]).to eq("dev_digest_ready")
+    expect(entity[:name]).to eq("dev_prod_digest_ready")
     expect(entity[:identifiers]).to eq(id: "mlh-42")
     expect(entity[:attributes]["articles"]).to eq([{ "title" => "A post" }])
   end
@@ -39,7 +43,7 @@ RSpec.describe DeliveryMethods::CustomerIoEvent do
   # not necessarily the DEV one, so the campaign cannot address the mail without
   # being told where it goes.
   it "sets recipient to the mail's own address, not the identifier" do
-    entity = delivered_entity(customerio_event_name: "dev_digest_ready", identifiers: { id: "mlh-42" })
+    entity = delivered_entity(customerio_event_name: "digest_ready", identifiers: { id: "mlh-42" })
 
     expect(entity[:attributes]["recipient"]).to eq("member@example.com")
     expect(entity[:attributes]["subject"]).to eq("Your digest")
@@ -47,11 +51,38 @@ RSpec.describe DeliveryMethods::CustomerIoEvent do
 
   it "lets message_data override the defaults" do
     entity = delivered_entity(
-      customerio_event_name: "dev_digest_ready",
+      customerio_event_name: "digest_ready",
       message_data: { "subject" => "Overridden" },
     )
 
     expect(entity[:attributes]["subject"]).to eq("Overridden")
+  end
+
+  # A Track event name is the campaign's trigger, so it carries the same
+  # APP_NAME namespace the CDP adapter applies -- one instance's digest must not
+  # trigger another's campaign in a shared workspace.
+  describe "APP_NAME event prefixing" do
+    it "namespaces the mailer's bare event name with APP_NAME" do
+      entity = delivered_entity(customerio_event_name: "digest_ready")
+
+      expect(entity[:name]).to eq("dev_prod_digest_ready")
+    end
+
+    it "falls back to the 'forem' prefix when APP_NAME is unset" do
+      allow(ApplicationConfig).to receive(:[]).with("APP_NAME").and_return(nil)
+
+      entity = delivered_entity(customerio_event_name: "digest_ready")
+
+      expect(entity[:name]).to eq("forem_digest_ready")
+    end
+
+    it "falls back to the 'forem' prefix when APP_NAME is blank" do
+      allow(ApplicationConfig).to receive(:[]).with("APP_NAME").and_return("")
+
+      entity = delivered_entity(customerio_event_name: "digest_ready")
+
+      expect(entity[:name]).to eq("forem_digest_ready")
+    end
   end
 
   it "raises when Customer.io rejects the event, so Ahoy records no send" do
@@ -70,7 +101,7 @@ RSpec.describe DeliveryMethods::CustomerIoEvent do
       mail.ahoy_data = { token: "tok123", campaign: nil }
 
       entity = delivered_entity(
-        customerio_event_name: "dev_digest_ready",
+        customerio_event_name: "digest_ready",
         message_data: { "url" => article_url },
       )
 
@@ -81,7 +112,7 @@ RSpec.describe DeliveryMethods::CustomerIoEvent do
 
     it "leaves message_data alone when Ahoy did not set a token" do
       entity = delivered_entity(
-        customerio_event_name: "dev_digest_ready",
+        customerio_event_name: "digest_ready",
         message_data: { "url" => article_url },
       )
 


### PR DESCRIPTION
## What

CDP events already get namespaced with the deploy's `APP_NAME` (`dev_prod_user_updated`) so that environments and instances sharing a Customer.io workspace stay distinct. The digest's Track event bypassed that and hardcoded `dev_digest_ready`.

This extracts the rule into `Trackable::EventName.prefixed` and applies it on both paths:

- **`app/services/trackable/event_name.rb`** (new) — holds the `APP_NAME ||= "forem"` rule, extracted verbatim from `Trackers::CustomerioCdp`.
- **`Trackers::CustomerioCdp`** — `prefixed_event_name` / `DEFAULT_APP_NAME` removed, now calls the shared module. No behavior change; its existing prefixing specs pass untouched.
- **`DeliveryMethods::CustomerIoEvent`** — splices the prefix in at the boundary, the same seam the CDP adapter uses.
- **`DigestMailer`** — declares the bare `"digest_ready"`. Mailers now name events environment-agnostically; `Deliverable`'s doc comment says so.

One copy of the rule matters more here than it does for CDP: a Track event name *is* a campaign's trigger, so two copies that drifted apart would stop a send rather than just mislabel a metric.

Net effect: the digest reaches Customer.io as `<APP_NAME>_digest_ready` — `dev_prod_digest_ready` on a deploy with `APP_NAME=dev_prod`.

## ⚠️ Deploy coordination — please read before merging

**1. The Customer.io campaign trigger must be renamed in lockstep.** The campaign listens for `dev_digest_ready` today. The moment this deploys, events arrive under the new name and the campaign stops firing — **the digest silently stops sending**. There is no Rails-side error to catch it: `CustomerIoEvent` only raises when the Track API *rejects* the event, and it won't reject an event no campaign happens to be listening for.

**2. Confirm `APP_NAME` is actually set on the prod dyno first.** If it's unset there the digest becomes `forem_digest_ready`, not `dev_prod_digest_ready`, and you'd rename the trigger to the wrong thing. `.env_sample:9` has it commented out. Worth a `heroku config:get APP_NAME` before touching the campaign.

## Testing

- Extended `spec/services/delivery_methods/customer_io_event_spec.rb` with an `APP_NAME` prefixing block covering set / unset / blank, mirroring the existing CDP spec.
- Existing specs updated for the renamed literal.
- `bundle exec rspec spec/services/delivery_methods/customer_io_event_spec.rb spec/services/trackers/customerio_cdp_spec.rb spec/mailers/digest_mailer_spec.rb spec/mailers/concerns/deliverable_spec.rb` → 76 examples, 0 failures. RuboCop clean.