### PR TITLE
Give the email footer view context an explicit host

### DIFF
--- a/app/services/users/email_footer_payload.rb
+++ b/app/services/users/email_footer_payload.rb
@@ -34,7 +34,7 @@ module Users
       host = Subforem.cached_id_to_domain_hash[user.onboarding_subforem_id]
 
       {
-        "signed_up_with_html" => view_context.signed_up_with(user),
+        "signed_up_with_html" => ViewContext.new(URL.domain(host)).signed_up_with(user),
         "unsubscribe_url" => unsubscribe_url(user, host),
         "notification_settings_url" => URL.url("/settings/notifications", host)
       }
@@ -66,12 +66,26 @@ module Users
     # AuthenticationHelper#signed_up_with needs both the helper and the route
     # helpers; ApplicationController.helpers carries only the former, which is
     # why ApplicationMailer declares them together.
-    def view_context
-      @view_context ||= Class.new do
-        include Rails.application.routes.url_helpers
-        include ActionView::Helpers::TranslationHelper
-        include AuthenticationHelper
-      end.new
+    #
+    # The host must be passed in explicitly. Production sets
+    # Rails.application.routes.default_url_options to the protocol ALONE
+    # (config/environments/production.rb), so new_magic_link_url raises
+    # "Missing host to link to!" without it -- while the test and development
+    # envs both set a host there, which is exactly why a spec relying on the
+    # ambient default cannot catch this. See the spec that stubs the production
+    # shape.
+    class ViewContext
+      include Rails.application.routes.url_helpers
+      include ActionView::Helpers::TranslationHelper
+      include AuthenticationHelper
+
+      def initialize(host)
+        @host = host
+      end
+
+      def default_url_options
+        Rails.application.routes.default_url_options.merge(host: @host)
+      end
     end
   end
 end

--- a/app/services/users/email_footer_payload.rb
+++ b/app/services/users/email_footer_payload.rb
@@ -31,10 +31,11 @@ module Users
     TOKEN_TTL = 31.days
 
     def call(user)
-      host = Subforem.cached_id_to_domain_hash[user.onboarding_subforem_id]
+      subforem_id = user.onboarding_subforem_id
+      host = Subforem.cached_id_to_domain_hash[subforem_id]
 
       {
-        "signed_up_with_html" => ViewContext.new(URL.domain(host)).signed_up_with(user),
+        "signed_up_with_html" => ViewContext.new(URL.domain(host), subforem_id).signed_up_with(user),
         "unsubscribe_url" => unsubscribe_url(user, host),
         "notification_settings_url" => URL.url("/settings/notifications", host)
       }
@@ -79,8 +80,15 @@ module Users
       include ActionView::Helpers::TranslationHelper
       include AuthenticationHelper
 
-      def initialize(host)
+      # signed_up_with resolves the community name from `try(:subforem_id)`, so
+      # this has to answer to it or the copy says "DEV Community" while the URLs
+      # beside it point at the user's own subforem. ApplicationMailer exposes the
+      # same reader as a helper_method for exactly this reason.
+      attr_reader :subforem_id
+
+      def initialize(host, subforem_id = nil)
         @host = host
+        @subforem_id = subforem_id
       end
 
       def default_url_options

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -130,6 +130,18 @@ RSpec.describe User do
       expect(payload["notification_settings_url"]).to end_with("/settings/notifications")
     end
 
+    # signed_up_with resolves the community name from try(:subforem_id), so the
+    # copy has to follow the same subforem as the URLs beside it rather than
+    # falling back to the default community.
+    it "names the user's own subforem community in the signed-up-with copy" do
+      subforem = create(:subforem, domain: "onboarding.example.com")
+      user = create(:user, onboarding_subforem_id: subforem.id)
+      allow(Settings::Community).to receive(:community_name)
+        .with(subforem_id: subforem.id).and_return("Onboarding Community")
+
+      expect(user.trackable_payload["signed_up_with_html"]).to include("Onboarding Community")
+    end
+
     it "reflects registration, confirmation, and email consent state in the payload" do
       user = create(:user)
       user.notification_setting.update!(email_newsletter: true, email_digest_periodic: true)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -105,6 +105,21 @@ RSpec.describe User do
       expect(Time.zone.parse(verified[:expires_at])).to be > Time.current
     end
 
+    # Production sets Rails.application.routes.default_url_options to the
+    # protocol alone, while test and development both set a host there. Relying
+    # on the ambient default therefore passes locally and blanks every key in
+    # production, which is exactly what happened -- so pin the production shape.
+    it "still builds the footer when only a protocol is configured, as in production" do
+      user = create(:user)
+      allow(Rails.application.routes).to receive(:default_url_options).and_return({ protocol: "https" })
+
+      payload = user.trackable_payload
+
+      expect(payload["signed_up_with_html"]).to be_present
+      expect(payload["unsubscribe_url"]).to include("/email_subscriptions/unsubscribe?ut=")
+      expect(payload["notification_settings_url"]).to end_with("/settings/notifications")
+    end
+
     it "points the footer at the user's onboarding subforem" do
       subforem = create(:subforem, domain: "onboarding.example.com")
       user = create(:user, onboarding_subforem_id: subforem.id)


### PR DESCRIPTION
## The bug

#23741 is live and shipping **blank**. Every one of the three keys comes back `""`:

```
KEYS=12
UNSUB=
```

`AuthenticationHelper#signed_up_with` calls `new_magic_link_url`, which raises `ArgumentError: Missing host to link to!`, and `EmailFooterPayload`'s rescue turns that into the blank fallback.

## Why the spec did not catch it

Production sets the route defaults to the **protocol alone**:

```ruby
# config/environments/production.rb
Rails.application.routes.default_url_options = {
  protocol: ENV.fetch("APP_PROTOCOL", "http://").delete_suffix("://")
}
```

while test and development both set a **host**:

```ruby
# config/environments/test.rb
Rails.application.routes.default_url_options = { host: Rails.application.config.app_domain }
```

So the url helpers resolve a host under test and cannot in production. Any spec that leans on the ambient default passes locally and proves nothing about the environment that matters. Confirmed against prod:

```
ROUTES_DUO={:protocol=>"https"}
```

## The fix

Pass the host in explicitly, derived the same subforem-aware way as the rest of the payload, via a named `ViewContext` that overrides `default_url_options`.

The new spec stubs `default_url_options` down to a bare protocol, reproducing the production shape. **Mutation tested** — reverted the `merge(host:)` and the spec fails on exactly that line; restored and it passes:

```
39 examples, 1 failure
rspec ./spec/models/user_spec.rb:112 # ... still builds the footer when only a protocol is configured, as in production
--- restored ---
39 examples, 0 failures
```

## Note

The rescue in `EmailFooterPayload` is doing its job — the sync never broke — but it is also what let this ship silently, twice. It logs at `warn`. Worth deciding separately whether it should notify instead; I have left the behaviour alone here since the invariant it protects (the keys are always present) is what keeps Customer.io renders from failing outright.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789586362&installation_model_id=424141&pr_number=23744&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23744&signature=53a14f23b16f42a42aad7b3095ce37a5f8d596536913e50be0ad626851e50ed4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->