### PR TITLE
Safely create AI disclosure indexes concurrently without unconditional drop

### DIFF
--- a/db/migrate/20260814130100_add_index_to_articles_and_comments_ai_disclosure_level.rb
+++ b/db/migrate/20260814130100_add_index_to_articles_and_comments_ai_disclosure_level.rb
@@ -2,28 +2,26 @@ class AddIndexToArticlesAndCommentsAiDisclosureLevel < ActiveRecord::Migration[8
   disable_ddl_transaction!
 
   def up
-    safety_assured do
-      db_user = connection.query_value("SELECT current_user")
-      begin
-        execute "ALTER ROLE \"#{db_user}\" SET statement_timeout = 0;"
-        execute "SET statement_timeout = 0;"
-
-        # Drop in case a previous deploy timed out and left an invalid index
-        remove_index :articles, name: "index_articles_on_ai_disclosure_level", if_exists: true, algorithm: :concurrently
-        add_index :articles, :ai_disclosure_level, algorithm: :concurrently
-
-        remove_index :comments, name: "index_comments_on_ai_disclosure_level", if_exists: true, algorithm: :concurrently
-        add_index :comments, :ai_disclosure_level, algorithm: :concurrently
-      ensure
-        execute "ALTER ROLE \"#{db_user}\" RESET statement_timeout;"
-      end
+    # Drop leftover invalid indexes if a previous attempt was interrupted
+    if connection.select_value("SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid WHERE c.relname = 'index_articles_on_ai_disclosure_level' AND NOT i.indisvalid")
+      connection.execute "SET statement_timeout = 0;"
+      connection.execute "DROP INDEX CONCURRENTLY IF EXISTS index_articles_on_ai_disclosure_level;"
     end
+
+    if connection.select_value("SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid WHERE c.relname = 'index_comments_on_ai_disclosure_level' AND NOT i.indisvalid")
+      connection.execute "SET statement_timeout = 0;"
+      connection.execute "DROP INDEX CONCURRENTLY IF EXISTS index_comments_on_ai_disclosure_level;"
+    end
+
+    connection.execute "SET statement_timeout = 0;"
+    add_index :articles, :ai_disclosure_level, algorithm: :concurrently unless index_exists?(:articles, :ai_disclosure_level)
+
+    connection.execute "SET statement_timeout = 0;"
+    add_index :comments, :ai_disclosure_level, algorithm: :concurrently unless index_exists?(:comments, :ai_disclosure_level)
   end
 
   def down
-    safety_assured do
-      remove_index :articles, name: "index_articles_on_ai_disclosure_level", if_exists: true, algorithm: :concurrently
-      remove_index :comments, name: "index_comments_on_ai_disclosure_level", if_exists: true, algorithm: :concurrently
-    end
+    remove_index :articles, :ai_disclosure_level, algorithm: :concurrently if index_exists?(:articles, :ai_disclosure_level)
+    remove_index :comments, :ai_disclosure_level, algorithm: :concurrently if index_exists?(:comments, :ai_disclosure_level)
   end
 end


### PR DESCRIPTION
## Summary
Resolves the statement timeout during the Heroku release phase for `AddIndexToArticlesAndCommentsAiDisclosureLevel`.

### Issue
Calling `remove_index if_exists: true, algorithm: :concurrently` issues `DROP INDEX CONCURRENTLY IF EXISTS`. In PostgreSQL, dropping an index concurrently on an active table like `articles` waits for all active transactions referencing the table to complete. Since the index was not yet present (or if already dropped), this unnecessary wait caused the release task to hit the statement timeout before `add_index` could be reached.

### Solution
1. Only attempt to drop an index if an **invalid** index is explicitly present in `pg_index` (e.g. from an aborted previous run).
2. Set `SET statement_timeout = 0;` directly on the active connection before index creation.
3. Use `add_index ..., algorithm: :concurrently unless index_exists?(...)` so that the migration runs without superfluous drop operations.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789591162&installation_model_id=424141&pr_number=23746&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23746&signature=67b4c5f45f276ea5e6b1495a1ae41ee546c904e81feb68d89fb2b764e5906ce1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->