### PR TITLE
Execute concurrent index creation with Migration 7.0 and raw SQL to bypass connection checkout timeout

### DIFF
--- a/db/migrate/20260814130100_add_index_to_articles_and_comments_ai_disclosure_level.rb
+++ b/db/migrate/20260814130100_add_index_to_articles_and_comments_ai_disclosure_level.rb
@@ -1,27 +1,32 @@
-class AddIndexToArticlesAndCommentsAiDisclosureLevel < ActiveRecord::Migration[8.0]
+class AddIndexToArticlesAndCommentsAiDisclosureLevel < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
 
   def up
-    # Drop leftover invalid indexes if a previous attempt was interrupted
-    if connection.select_value("SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid WHERE c.relname = 'index_articles_on_ai_disclosure_level' AND NOT i.indisvalid")
-      connection.execute "SET statement_timeout = 0;"
-      connection.execute "DROP INDEX CONCURRENTLY IF EXISTS index_articles_on_ai_disclosure_level;"
+    safety_assured do
+      # Drop leftover invalid indexes if a previous attempt was interrupted
+      if select_value("SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid WHERE c.relname = 'index_articles_on_ai_disclosure_level' AND NOT i.indisvalid")
+        execute "SET statement_timeout = 0;"
+        execute "DROP INDEX CONCURRENTLY IF EXISTS index_articles_on_ai_disclosure_level;"
+      end
+
+      if select_value("SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid WHERE c.relname = 'index_comments_on_ai_disclosure_level' AND NOT i.indisvalid")
+        execute "SET statement_timeout = 0;"
+        execute "DROP INDEX CONCURRENTLY IF EXISTS index_comments_on_ai_disclosure_level;"
+      end
+
+      execute "SET statement_timeout = 0;"
+      execute "CREATE INDEX CONCURRENTLY IF NOT EXISTS index_articles_on_ai_disclosure_level ON articles (ai_disclosure_level);"
+
+      execute "SET statement_timeout = 0;"
+      execute "CREATE INDEX CONCURRENTLY IF NOT EXISTS index_comments_on_ai_disclosure_level ON comments (ai_disclosure_level);"
     end
-
-    if connection.select_value("SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid WHERE c.relname = 'index_comments_on_ai_disclosure_level' AND NOT i.indisvalid")
-      connection.execute "SET statement_timeout = 0;"
-      connection.execute "DROP INDEX CONCURRENTLY IF EXISTS index_comments_on_ai_disclosure_level;"
-    end
-
-    connection.execute "SET statement_timeout = 0;"
-    add_index :articles, :ai_disclosure_level, algorithm: :concurrently unless index_exists?(:articles, :ai_disclosure_level)
-
-    connection.execute "SET statement_timeout = 0;"
-    add_index :comments, :ai_disclosure_level, algorithm: :concurrently unless index_exists?(:comments, :ai_disclosure_level)
   end
 
   def down
-    remove_index :articles, :ai_disclosure_level, algorithm: :concurrently if index_exists?(:articles, :ai_disclosure_level)
-    remove_index :comments, :ai_disclosure_level, algorithm: :concurrently if index_exists?(:comments, :ai_disclosure_level)
+    safety_assured do
+      execute "SET statement_timeout = 0;"
+      execute "DROP INDEX CONCURRENTLY IF EXISTS index_articles_on_ai_disclosure_level;"
+      execute "DROP INDEX CONCURRENTLY IF EXISTS index_comments_on_ai_disclosure_level;"
+    end
   end
 end


### PR DESCRIPTION
## Summary
Fixes the statement timeout on large production tables during the Heroku release phase for `AddIndexToArticlesAndCommentsAiDisclosureLevel`.

### Why it failed previously
1. In Rails 8 (`ActiveRecord::Migration[8.0]`), calling `add_index` triggers connection pool checkouts wrapped in `with_connection`. Each checkout runs default connection variables from `database.yml` (`statement_timeout: 10_000`), overriding any session-level `SET statement_timeout = 0;` that was previously issued.
2. Building an index on large tables like `articles` (5M+ rows) takes more than 10-20 seconds on production, triggering `PG::QueryCanceled: ERROR: canceling statement due to statement timeout` during `add_index`.

### Solution
- Use `ActiveRecord::Migration[7.0]` (matching all other large production index migrations in the codebase like `20250821230000_add_moderation_indexes_to_articles.rb` and `20260430190000_add_index_on_reactions_reactable_and_created_at.rb`).
- Execute `SET statement_timeout = 0;` and direct `CREATE INDEX CONCURRENTLY IF NOT EXISTS` on the same connection context inside `safety_assured`.
- Keep the check to drop any invalid/partial index from previous interrupted attempts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789592761&installation_model_id=424141&pr_number=23747&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23747&signature=66f5b8f2ab561ef31d541a6f007970ec3f14f7c235e8d7b2bca68c4d1b2d552f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->