### PR TITLE
feat: sync the five remaining email consents to MLH Core

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -904,10 +904,20 @@ class User < ApplicationRecord
       "id" => id, "username" => username, "email" => email, "name" => name,
       "registered_at" => registered_at&.iso8601,
       "confirmed_at" => confirmed_at&.iso8601,
-      "email_newsletter" => notification_setting&.email_newsletter,
-      "email_digest_periodic" => notification_setting&.email_digest_periodic,
       "mlh_user_id" => identities.where(provider: "mlh").pick(:uid)
-    }.merge(Users::EmailFooterPayload.call(self))
+    }.merge(trackable_email_consents).merge(Users::EmailFooterPayload.call(self))
+  end
+
+  # Current state of every email consent Core mirrors onto a Customer.io
+  # subscription topic. The per-consent events on Users::NotificationSetting
+  # only fire when someone toggles a setting, so seeding the state here is what
+  # lets Core learn it for accounts that never touch their notification
+  # settings. Keyed off the same map the events use so the two cannot drift.
+  def trackable_email_consents
+    setting = notification_setting
+    Users::NotificationSetting::EMAIL_CONSENT_EVENTS.keys.to_h do |column|
+      [column.to_s, setting&.public_send(column)]
+    end
   end
 
   # Invited accounts (registered: false) have not consented to anything yet,

--- a/app/models/users/notification_setting.rb
+++ b/app/models/users/notification_setting.rb
@@ -5,6 +5,22 @@ module Users
   class NotificationSetting < ApplicationRecord
     self.table_name_prefix = "users_"
 
+    # Every email consent MLH Core mirrors onto a Customer.io subscription
+    # topic, mapped to the base name of the events Core matches on the wire.
+    #
+    # The two original entries produce "user_newsletter_*" and "user_digest_*" —
+    # NOT the column names. Core matches these strings exactly, so renaming one
+    # silently breaks live consent sync; add entries, never rewrite these two.
+    EMAIL_CONSENT_EVENTS = {
+      email_newsletter: "newsletter",
+      email_digest_periodic: "digest",
+      email_comment_notifications: "comment_notifications",
+      email_follower_notifications: "follower_notifications",
+      email_mention_notifications: "mention_notifications",
+      email_unread_notifications: "unread_notifications",
+      email_badge_notifications: "badge_notifications"
+    }.freeze
+
     belongs_to :user, touch: true
 
     validates :email_digest_periodic, inclusion: { in: [true, false] }
@@ -33,26 +49,20 @@ module Users
     # toggle path: settings page, one-click unsubscribe links, onboarding, and
     # the Mailchimp unsubscribe webhook.
     #
-    # The newsletter and the periodic digest are SEPARATE consents — EmailDigest
-    # selects on email_digest_periodic alone and never reads email_newsletter —
-    # so each needs its own signal. A save that flips both emits both events.
+    # Each entry in EMAIL_CONSENT_EVENTS is a SEPARATE consent — the digest, for
+    # instance, is not the newsletter: EmailDigest selects on
+    # email_digest_periodic alone and never reads email_newsletter — so each
+    # needs its own signal. A save that flips several emits one event per flip.
     def track_email_consent_changes
-      track_newsletter_change
-      track_digest_change
-    end
+      consenting_user = user
+      return if consenting_user.nil?
 
-    def track_newsletter_change
-      return unless saved_change_to_email_newsletter?
+      EMAIL_CONSENT_EVENTS.each do |column, name|
+        next unless saved_change_to_attribute?(column)
 
-      event = email_newsletter? ? "user_newsletter_subscribed" : "user_newsletter_unsubscribed"
-      user&.track!(event)
-    end
-
-    def track_digest_change
-      return unless saved_change_to_email_digest_periodic?
-
-      event = email_digest_periodic? ? "user_digest_subscribed" : "user_digest_unsubscribed"
-      user&.track!(event)
+        state = public_send(column) ? "subscribed" : "unsubscribed"
+        consenting_user.track!("user_#{name}_#{state}")
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -71,8 +71,32 @@ RSpec.describe User do
       user = create(:user)
       expect(user.trackable_payload.keys).to contain_exactly(
         "id", "username", "email", "name", "registered_at", "confirmed_at", "email_newsletter",
-        "email_digest_periodic", "mlh_user_id",
+        "email_digest_periodic", "email_comment_notifications", "email_follower_notifications",
+        "email_mention_notifications", "email_unread_notifications", "email_badge_notifications",
+        "mlh_user_id",
         "signed_up_with_html", "unsubscribe_url", "notification_settings_url"
+      )
+    end
+
+    # Core maps each of these onto its own Customer.io subscription topic, and
+    # can only learn the state of an account that never toggles anything from
+    # this payload, so all seven consents have to ride along.
+    it "seeds every email consent Core mirrors, not just the newsletter and digest" do
+      user = create(:user)
+      user.notification_setting.update!(email_comment_notifications: false,
+                                        email_follower_notifications: false,
+                                        email_mention_notifications: true,
+                                        email_unread_notifications: false,
+                                        email_badge_notifications: true)
+
+      payload = user.reload.trackable_payload
+
+      expect(payload).to include(
+        "email_comment_notifications" => false,
+        "email_follower_notifications" => false,
+        "email_mention_notifications" => true,
+        "email_unread_notifications" => false,
+        "email_badge_notifications" => true,
       )
     end
 

--- a/spec/models/users/notification_setting_spec.rb
+++ b/spec/models/users/notification_setting_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Users::NotificationSetting do
     end
   end
 
-  describe "newsletter events for the DEV → Core sync" do
+  describe "email consent events for the DEV → Core sync" do
     before do
       allow(Trackable::Registry).to receive(:active_names).and_return([:any])
       allow(Trackable::DispatchWorker).to receive(:perform_async)
@@ -66,10 +66,9 @@ RSpec.describe Users::NotificationSetting do
         .with(anything, "user_newsletter_unsubscribed", [user.id], anything, anything)
     end
 
-    it "does not emit for other notification setting changes" do
-      notification_setting.update!(email_badge_notifications: !notification_setting.email_badge_notifications)
+    it "does not emit for a setting outside the email consents Core mirrors" do
+      notification_setting.update!(reaction_notifications: !notification_setting.reaction_notifications)
       expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
-        .with(anything, /user_newsletter/, anything, anything, anything)
     end
 
     # The digest is a separate consent from the newsletter: EmailDigest selects
@@ -100,6 +99,64 @@ RSpec.describe Users::NotificationSetting do
         .with(anything, "user_newsletter_subscribed", [user.id], anything, anything)
       expect(Trackable::DispatchWorker).to have_received(:perform_async)
         .with(anything, "user_digest_subscribed", [user.id], anything, anything)
+    end
+
+    # Core matches these two names exactly on the wire. Deriving them from the
+    # column name instead (user_email_newsletter_*, user_email_digest_periodic_*)
+    # would silently break live consent sync for every existing subscriber.
+    it "keeps the two pre-existing event names byte-identical to the column-agnostic originals" do
+      notification_setting.update!(email_newsletter: true, email_digest_periodic: true)
+
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_newsletter_subscribed", [user.id], anything, anything)
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_digest_subscribed", [user.id], anything, anything)
+      expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+        .with(anything, a_string_matching(/\Auser_email_/), anything, anything, anything)
+    end
+
+    # The five settings below have Customer.io subscription topics on the Core
+    # side but emitted no signal at all, so Core could never learn their state.
+    {
+      email_comment_notifications: "user_comment_notifications",
+      email_follower_notifications: "user_follower_notifications",
+      email_mention_notifications: "user_mention_notifications",
+      email_unread_notifications: "user_unread_notifications",
+      email_badge_notifications: "user_badge_notifications"
+    }.each do |column, event_prefix|
+      it "emits #{event_prefix}_unsubscribed when #{column} flips off" do
+        notification_setting.update!(column => false)
+
+        expect(Trackable::DispatchWorker).to have_received(:perform_async)
+          .with(anything, "#{event_prefix}_unsubscribed", [user.id], anything, anything)
+      end
+
+      it "emits #{event_prefix}_subscribed when #{column} flips back on" do
+        notification_setting.update!(column => false)
+        notification_setting.update!(column => true)
+
+        expect(Trackable::DispatchWorker).to have_received(:perform_async)
+          .with(anything, "#{event_prefix}_subscribed", [user.id], anything, anything)
+      end
+
+      it "does not emit #{event_prefix} events when an unrelated consent changes" do
+        notification_setting.update!(email_newsletter: true)
+
+        expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+          .with(anything, a_string_starting_with(event_prefix), anything, anything, anything)
+      end
+    end
+
+    it "emits one event per flipped consent when a single save changes several" do
+      notification_setting.update!(email_newsletter: true, email_comment_notifications: false,
+                                   email_badge_notifications: false)
+
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_newsletter_subscribed", [user.id], anything, anything)
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_comment_notifications_unsubscribed", [user.id], anything, anything)
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_badge_notifications_unsubscribed", [user.id], anything, anything)
     end
 
     it "does not emit when the sync gates are off" do

--- a/spec/requests/api/v1/admin/users_spec.rb
+++ b/spec/requests/api/v1/admin/users_spec.rb
@@ -427,6 +427,26 @@ RSpec.describe "/api/admin/users" do
       FeatureFlag.remove(:dev_core_user_sync)
     end
 
+    # Same suppression again, for the five per-notification consents. These now
+    # emit their own DEV → Core events, so an admin-API write of them must stay
+    # silent too or Core would consume its own push straight back.
+    it "does not emit CDP events for the per-notification consents on admin-API writes" do
+      allow(Trackable::Registry).to receive(:active_names).and_return([:any])
+      allow(Trackable::DispatchWorker).to receive(:perform_async)
+      Settings::General.customerio_cdp_enabled = true
+      FeatureFlag.enable(:dev_core_user_sync, FeatureFlag::Actor[target])
+
+      with_trackable_events do
+        put_settings({ notification_setting: { email_comment_notifications: false,
+                                               email_badge_notifications: false } })
+      end
+
+      expect(target.notification_setting.reload.email_comment_notifications).to be(false)
+      expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+    ensure
+      FeatureFlag.remove(:dev_core_user_sync)
+    end
+
     it "rejects a body missing the notification_setting wrapper with the admin error_code" do
       put_settings({ email_newsletter: false })
 


### PR DESCRIPTION
## The gap

MLH Core is the source of truth for email consent. DEV pushes consent changes to Core over the Customer.io CDP, and Core maps each one onto a Customer.io subscription topic.

Today only **two** of the seven email consents on `Users::NotificationSetting` emit a signal:

| column | events |
| --- | --- |
| `email_newsletter` | `user_newsletter_subscribed` / `user_newsletter_unsubscribed` |
| `email_digest_periodic` | `user_digest_subscribed` / `user_digest_unsubscribed` |

Core has since added subscription topics **24–28** for five more Forem notification settings, but DEV emits nothing for them and `User#trackable_payload` doesn't carry them either — so Core has no way at all to learn their state. Whatever a DEV user does on `/settings/notifications` for those five, Core never sees it.

The reverse direction already works: `Api::Admin::UsersController::ALLOWED_NOTIFICATION_SETTINGS` permits all seven keys (added in #23585). This PR closes the outbound half.

## The approach

Mirrors the existing newsletter/digest pattern exactly, rather than inventing a new mechanism.

**`app/models/users/notification_setting.rb`**

Seven near-identical `track_*_change` methods would have been poor style, so the two hand-rolled ones are replaced by a frozen map iterated in a single pass inside the same `after_commit ... on: :update` callback:

```ruby
EMAIL_CONSENT_EVENTS = {
  email_newsletter: "newsletter",
  email_digest_periodic: "digest",
  email_comment_notifications: "comment_notifications",
  email_follower_notifications: "follower_notifications",
  email_mention_notifications: "mention_notifications",
  email_unread_notifications: "unread_notifications",
  email_badge_notifications: "badge_notifications"
}.freeze
```

New events emitted:

- `user_comment_notifications_subscribed` / `_unsubscribed`
- `user_follower_notifications_subscribed` / `_unsubscribed`
- `user_mention_notifications_subscribed` / `_unsubscribed`
- `user_unread_notifications_subscribed` / `_unsubscribed`
- `user_badge_notifications_subscribed` / `_unsubscribed`

**The two existing event names are byte-identical — this is the point of the map storing a base name rather than the column name.** Core matches `user_newsletter_*` and `user_digest_*` exactly on the wire; deriving the event from the column would have produced `user_email_newsletter_*` and `user_email_digest_periodic_*` and silently broken live consent sync for millions of existing subscribers. A regression spec pins this, including a negative assertion that nothing matching `/\Auser_email_/` is ever emitted.

A save that flips several columns emits one event per flipped column, unchanged from today's behaviour.

**`app/models/user.rb`**

`trackable_payload` now seeds all seven consents (keyed off the same map, so the payload and the events cannot drift), letting Core establish state for accounts that never toggle a setting and therefore never emit a per-consent event. It stays a curated payload — the whole `users_notification_settings` row is not shipped — and keys remain strings for `Sidekiq.strict_args!`.

## Notes

- **No echo loop.** The admin API write path already wraps the update in `User.skip_trackable_events`, so Core pushing its own consent state back through `PUT /api/admin/users/:id/notification_settings` stays silent for the new events too. Covered by a new request spec.
- **`User::SYNC_TRIGGER_KEYS` needs no change.** It gates `user_updated` on `previous_changes` of the `users` table; these settings live on `users_notification_settings` and emit their own events. The association's `touch: true` only advances `users.updated_at`, which is not a trigger key, so no spurious `user_updated` results.
- **No migration and no schema change** — all seven columns already exist on `users_notification_settings`.
- **No i18n changes** — the only strings added are event names on the wire; nothing user-facing.

## Testing

```
$ bundle exec rspec spec/models/users/notification_setting_spec.rb
30 examples, 0 failures

$ bundle exec rspec spec/models/user_spec.rb -e "Trackable adoption for DEV → Core sync"
41 examples, 0 failures

$ bundle exec rspec spec/requests/api/v1/admin/users_spec.rb
58 examples, 1 failure
```

The single `users_spec.rb` failure ("enqueues an invitation email to be sent with custom options") reproduces unchanged on `main` and is unrelated to this branch.

RuboCop on all five touched files reports 20 offenses, identical in count and location to `main` — this diff introduces none.

## Related

- #23585 — added the Core → DEV direction (`ALLOWED_NOTIFICATION_SETTINGS`), untouched here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789607845&installation_model_id=424141&pr_number=23748&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23748&signature=1e7c68a4a245e4f7c15c32871c5ff6e878d1fccf765a0e08417d10d255c5aab2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->