### PR TITLE
refactor: share Core email consent allowlist

### DIFF
--- a/app/controllers/concerns/api/admin/users_controller.rb
+++ b/app/controllers/concerns/api/admin/users_controller.rb
@@ -16,15 +16,7 @@ module Api
       # onto the account. Mobile and in-app columns are excluded, as are the
       # moderator newsletters, which are driven by role changes rather than by
       # the user's own choice.
-      ALLOWED_NOTIFICATION_SETTINGS = %i[
-        email_newsletter
-        email_digest_periodic
-        email_comment_notifications
-        email_follower_notifications
-        email_mention_notifications
-        email_unread_notifications
-        email_badge_notifications
-      ].freeze
+      ALLOWED_NOTIFICATION_SETTINGS = Users::NotificationSetting::CORE_SYNCED_EMAIL_SETTINGS
 
       def index
         users = filtered_users
@@ -115,12 +107,9 @@ module Api
         render json: { id: @user_record.id, status: status }
       end
 
-      # Lets an external system of record push consent changes (its
-      # dev-newsletter opt-outs) back onto the DEV account's local
-      # notification settings, which DEV's own senders (digest, newsletter)
-      # key off. Writes through the model so the normal callbacks fire
-      # (Mailchimp sync, and the CDP newsletter events once enabled) - the
-      # resulting echo event is value-idempotent on that system's side.
+      # Lets Core push all seven DEV email consents back onto the account's
+      # local notification settings, which DEV's own senders key off. Writes
+      # through the model so callbacks other than CDP event emission still run.
       def update_notification_settings
         @user_record = User.find(params[:id])
         # Handle the missing wrapper here rather than via params.require, so
@@ -135,13 +124,10 @@ module Api
         end
 
         setting = @user_record.notification_setting
-        # This endpoint carries an external system of record's OWN consent
-        # state (its dev newsletter opt-outs/opt-ins). Emitting the CDP
-        # newsletter events here would make that system consume its own push
-        # as a user consent change — destroying the layered
-        # global-unsubscribe vs list-preference distinction. Model callbacks
-        # that aren't CDP emission (Mailchimp sync, base_email_eligible)
-        # still run.
+        # This endpoint carries Core's own consent state. Emitting the CDP
+        # consent events here would make Core consume its own push as a user
+        # change. Model callbacks that aren't CDP emission (Mailchimp sync,
+        # base_email_eligible) still run.
         User.skip_trackable_events { setting.update!(updates) }
 
         audit!(slug: "update_notification_settings",

--- a/app/models/users/notification_setting.rb
+++ b/app/models/users/notification_setting.rb
@@ -20,6 +20,7 @@ module Users
       email_unread_notifications: "unread_notifications",
       email_badge_notifications: "badge_notifications"
     }.freeze
+    CORE_SYNCED_EMAIL_SETTINGS = EMAIL_CONSENT_EVENTS.keys.freeze
 
     belongs_to :user, touch: true
 

--- a/spec/requests/api/v1/admin/users_spec.rb
+++ b/spec/requests/api/v1/admin/users_spec.rb
@@ -348,6 +348,11 @@ RSpec.describe "/api/admin/users" do
 
     let!(:target) { create(:user) }
 
+    it "uses the same Core-synced consent allowlist as the event emitter" do
+      expect(Api::Admin::UsersController::ALLOWED_NOTIFICATION_SETTINGS)
+        .to equal(Users::NotificationSetting::CORE_SYNCED_EMAIL_SETTINGS)
+    end
+
     def put_settings(body, id: target.id)
       put "/api/admin/users/#{id}/notification_settings",
           params: body.to_json,


### PR DESCRIPTION
## Summary

- make the admin notification-settings endpoint reuse the exact seven-setting Core sync contract used by DEV's consent event emitter
- remove the duplicated controller allowlist so future topic additions cannot emit outbound without also being writable by Core
- clarify that Core-originated API writes suppress CDP echo events while retaining other model callbacks

This is the Forem follow-up for live bidirectional consent sync; historical reconciliation/backfill remains out of scope.

Companion Core PR: https://github.com/MLH-Engineering/core/pull/3009

## Verification

- 40 focused notification-setting and admin API examples: passing
- RuboCop on all changed files: passing

No design/spec document is included in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789612583&installation_model_id=424141&pr_number=23749&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23749&signature=e7c02e5c07ae87ff48198f68e8c42d8e27cdd573b1b9e23f27a54c741000c89d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->