### PR TITLE
feat: emit the moderator newsletter consents to MLH Core

### DIFF
--- a/app/controllers/concerns/api/admin/users_controller.rb
+++ b/app/controllers/concerns/api/admin/users_controller.rb
@@ -14,8 +14,9 @@ module Api
       # Email notification columns writable through this endpoint. These are
       # the user-consent settings an external system of record may push back
       # onto the account. Mobile and in-app columns are excluded, as are the
-      # moderator newsletters, which are driven by role changes rather than by
-      # the user's own choice.
+      # moderator newsletters (Users::NotificationSetting::ROLE_DRIVEN_NEWSLETTER_SETTINGS),
+      # which are driven by role changes rather than by the user's own choice —
+      # Core still receives their state via EMAIL_CONSENT_EVENTS, one-way.
       ALLOWED_NOTIFICATION_SETTINGS = Users::NotificationSetting::CORE_SYNCED_EMAIL_SETTINGS
 
       def index

--- a/app/models/users/notification_setting.rb
+++ b/app/models/users/notification_setting.rb
@@ -5,8 +5,9 @@ module Users
   class NotificationSetting < ApplicationRecord
     self.table_name_prefix = "users_"
 
-    # Every email consent MLH Core mirrors onto a Customer.io subscription
-    # topic, mapped to the base name of the events Core matches on the wire.
+    # Every email consent MLH Core mirrors (onto a Customer.io subscription
+    # topic or a Core newsletter key), mapped to the base name of the events
+    # Core matches on the wire.
     #
     # The two original entries produce "user_newsletter_*" and "user_digest_*" —
     # NOT the column names. Core matches these strings exactly, so renaming one
@@ -18,9 +19,19 @@ module Users
       email_follower_notifications: "follower_notifications",
       email_mention_notifications: "mention_notifications",
       email_unread_notifications: "unread_notifications",
-      email_badge_notifications: "badge_notifications"
+      email_badge_notifications: "badge_notifications",
+      # Moderator newsletters land on Core's newsletter_subscriptions
+      # dev_tag_mod / dev_community_mod keys (which Customer.io sends from).
+      email_tag_mod_newsletter: "tag_mod_newsletter",
+      email_community_mod_newsletter: "community_mod_newsletter"
     }.freeze
-    CORE_SYNCED_EMAIL_SETTINGS = EMAIL_CONSENT_EVENTS.keys.freeze
+    # Emitted to Core but never written back by it: these follow the tag /
+    # subforem moderator role (TagModerators::Add, SubforemModerators::Add,
+    # Moderator::ManageActivityAndRoles), so DEV owns them one-way.
+    ROLE_DRIVEN_NEWSLETTER_SETTINGS = %i[email_tag_mod_newsletter email_community_mod_newsletter].freeze
+    # The user's own choices — the settings Core may push back through the
+    # admin API (Api::Admin::UsersController#update_notification_settings).
+    CORE_SYNCED_EMAIL_SETTINGS = (EMAIL_CONSENT_EVENTS.keys - ROLE_DRIVEN_NEWSLETTER_SETTINGS).freeze
 
     belongs_to :user, touch: true
 

--- a/spec/models/users/notification_setting_spec.rb
+++ b/spec/models/users/notification_setting_spec.rb
@@ -147,6 +147,34 @@ RSpec.describe Users::NotificationSetting do
       end
     end
 
+    # Role-driven newsletters: DEV grants/removes them with the moderator role
+    # and the user can switch them off; Core mirrors them onto its own
+    # newsletter keys so Customer.io can send them, but never writes them back.
+    {
+      email_tag_mod_newsletter: "user_tag_mod_newsletter",
+      email_community_mod_newsletter: "user_community_mod_newsletter"
+    }.each do |column, event_prefix|
+      it "emits #{event_prefix}_subscribed when #{column} flips on (role granted)" do
+        notification_setting.update!(column => true)
+
+        expect(Trackable::DispatchWorker).to have_received(:perform_async)
+          .with(anything, "#{event_prefix}_subscribed", [user.id], anything, anything)
+      end
+
+      it "emits #{event_prefix}_unsubscribed when #{column} flips off (role removed or user opts out)" do
+        notification_setting.update!(column => true)
+        notification_setting.update!(column => false)
+
+        expect(Trackable::DispatchWorker).to have_received(:perform_async)
+          .with(anything, "#{event_prefix}_unsubscribed", [user.id], anything, anything)
+      end
+
+      it "keeps #{column} out of the admin-API writable set" do
+        expect(described_class::CORE_SYNCED_EMAIL_SETTINGS).not_to include(column)
+        expect(described_class::ROLE_DRIVEN_NEWSLETTER_SETTINGS).to include(column)
+      end
+    end
+
     it "emits one event per flipped consent when a single save changes several" do
       notification_setting.update!(email_newsletter: true, email_comment_notifications: false,
                                    email_badge_notifications: false)


### PR DESCRIPTION
## Summary

`email_tag_mod_newsletter` and `email_community_mod_newsletter` never fired a CDP consent event. MLH Core now holds them as `newsletter_subscriptions.dev_tag_mod` / `dev_community_mod` (Customer.io sends the moderator newsletters from those keys), but Core only ever learned them from a one-off backfill and drifts every time a tag/subforem moderator is added or removed.

This adds the two columns to `Users::NotificationSetting::EMAIL_CONSENT_EVENTS`, so every flip — `TagModerators::Add/Remove`, `SubforemModerators::Add/Remove`, `Moderator::ManageActivityAndRoles`, the user's own settings page — emits `user_tag_mod_newsletter_{subscribed,unsubscribed}` / `user_community_mod_newsletter_{subscribed,unsubscribed}` through the existing `track_email_consent_changes` path.

They stay **out** of the admin-API writable set: `CORE_SYNCED_EMAIL_SETTINGS` is now `EMAIL_CONSENT_EVENTS.keys - ROLE_DRIVEN_NEWSLETTER_SETTINGS`, so `Api::Admin::UsersController::ALLOWED_NOTIFICATION_SETTINGS` is unchanged and DEV keeps owning them one-way (they follow the moderator role, not the user's own consent).

Companion Core PR: MLH-Engineering/core#3011 (routes the four events onto the two keys).

## Testing

`spec/models/users/notification_setting_spec.rb` — new examples per column: emits `_subscribed` on flip-on, `_unsubscribed` on flip-off, and the column is excluded from `CORE_SYNCED_EMAIL_SETTINGS`. 36 examples, 0 failures. `spec/requests/api/v1/admin/users_spec.rb` unchanged (the allowlist-equality example still passes; the one failure there, `POST /api/admin/users … invitation email`, is pre-existing on unmodified main). RuboCop clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789653348&installation_model_id=424141&pr_number=23752&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23752&signature=969adb3927f39a3aec5e4b6f49bc48d8df275b51ac32f4445809b7a984f1aa5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->