### PR TITLE
Implement AI disclosure feed preferences across feed ranking and queries

### DIFF
--- a/app/controllers/admin/feed_configs_controller.rb
+++ b/app/controllers/admin/feed_configs_controller.rb
@@ -1,0 +1,98 @@
+module Admin
+  class FeedConfigsController < Admin::ApplicationController
+    layout "admin"
+
+    def index
+      @best_feed_config = best_feed_config
+      @feed_configs = FeedConfig.order(feed_success_score: :desc, created_at: :desc).page(params[:page]).per(25)
+    end
+
+    def show
+      @feed_config = FeedConfig.find(params[:id])
+    end
+
+    def new
+      source_config = if params[:clone_from_id].present?
+                        FeedConfig.find_by(id: params[:clone_from_id])
+                      else
+                        best_feed_config
+                      end
+
+      @feed_config = if source_config
+                       source_config.dup.tap do |config|
+                         config.feed_impressions_count = 0
+                         config.feed_success_score = 0.0
+                       end
+                     else
+                       FeedConfig.new
+                     end
+    end
+
+    def create
+      @feed_config = FeedConfig.new(feed_config_params)
+
+      if @feed_config.save
+        flash[:success] = "Feed Config ##{@feed_config.id} successfully created."
+        redirect_to admin_feed_config_path(@feed_config)
+      else
+        flash[:danger] = @feed_config.errors.full_messages.to_sentence
+        render :new
+      end
+    end
+
+    def destroy
+      @feed_config = FeedConfig.find(params[:id])
+
+      if @feed_config.destroy
+        flash[:success] = "Feed Config ##{@feed_config.id} deleted."
+      else
+        flash[:danger] = "Failed to delete Feed Config ##{@feed_config.id}."
+      end
+      redirect_to admin_feed_configs_path
+    end
+
+    private
+
+    def best_feed_config
+      FeedConfig.order("feed_success_score DESC NULLS LAST").first || FeedConfig.last
+    end
+
+    def feed_config_params
+      params.require(:feed_config).permit(
+        :ai_disclosure_matching_weight,
+        :autonomous_ai_penalty_weight,
+        :clickbait_score_weight,
+        :comment_recency_weight,
+        :comment_score_weight,
+        :compellingness_score_weight,
+        :featured_weight,
+        :feed_success_weight,
+        :follow_status_weight,
+        :general_past_day_bonus_weight,
+        :label_match_weight,
+        :language_match_weight,
+        :lookback_window_weight,
+        :organization_follow_weight,
+        :precomputed_selections_weight,
+        :published_today_weight,
+        :randomness_weight,
+        :recency_weight,
+        :recent_article_suppression_rate,
+        :recent_page_views_shuffle_weight,
+        :recent_subforem_weight,
+        :recent_tag_count_max,
+        :recent_tag_count_min,
+        :all_time_tag_count_max,
+        :all_time_tag_count_min,
+        :recently_active_past_day_bonus_weight,
+        :score_weight,
+        :semantic_similarity_weight,
+        :shuffle_weight,
+        :status_weight,
+        :subforem_follow_weight,
+        :tag_follow_weight,
+        :user_follow_weight,
+      )
+    end
+  end
+end

--- a/app/models/admin_menu.rb
+++ b/app/models/admin_menu.rb
@@ -56,6 +56,7 @@ class AdminMenu
     scope :advanced, "flashlight-line", [
       item(name: "broadcasts"),
       item(name: "response templates"),
+      item(name: "feed configs", controller: "feed_configs"),
       item(name: "developer tools", controller: "tools", children: [
              item(name: "tools"),
              item(name: "data update scripts", visible: -> { FeatureFlag.enabled?(:data_update_scripts) }),

--- a/app/models/feed_config.rb
+++ b/app/models/feed_config.rb
@@ -155,11 +155,13 @@ class FeedConfig < ApplicationRecord
       SQL
     end
 
-    user_setting = user.respond_to?(:setting) ? user.setting : nil
-    if user_setting&.minimize_ai_feed_ai?
-      terms << "(CASE WHEN articles.ai_disclosure_level = 3 THEN -15.0 WHEN articles.ai_disclosure_level = 5 THEN -30.0 ELSE 0 END)"
-    elsif user_setting&.hide_fully_autonomous_feed_ai?
-      terms << "(CASE WHEN articles.ai_disclosure_level = 3 THEN -15.0 ELSE 0 END)"
+    if ai_disclosure_matching_weight.positive?
+      user_setting = user.respond_to?(:setting) ? user.setting : nil
+      if user_setting&.minimize_ai_feed_ai?
+        terms << "(CASE WHEN articles.ai_disclosure_level = 3 THEN -#{ai_disclosure_matching_weight} WHEN articles.ai_disclosure_level = 5 THEN -#{ai_disclosure_matching_weight * 2} ELSE 0 END)"
+      elsif user_setting&.hide_fully_autonomous_feed_ai?
+        terms << "(CASE WHEN articles.ai_disclosure_level = 3 THEN -#{ai_disclosure_matching_weight} ELSE 0 END)"
+      end
     end
 
     if autonomous_ai_penalty_weight.positive?
@@ -211,6 +213,8 @@ class FeedConfig < ApplicationRecord
     clone.recent_subforem_weight = recent_subforem_weight * rand(0.9..1.1)
     clone.subforem_follow_weight = subforem_follow_weight * rand(0.9..1.1)
     clone.recent_page_views_shuffle_weight = recent_page_views_shuffle_weight * rand(0.9..1.1)
+    clone.ai_disclosure_matching_weight = ai_disclosure_matching_weight * rand(0.9..1.1)
+    clone.autonomous_ai_penalty_weight = autonomous_ai_penalty_weight * rand(0.9..1.1)
     clone.recent_tag_count_min = [recent_tag_count_min + rand(-1..1), 0].max if recent_tag_count_min.positive?
     clone.recent_tag_count_max = [recent_tag_count_max + rand(-1..1), 12].min if recent_tag_count_max.positive?
     clone.recent_tag_count_max = clone.recent_tag_count_min if clone.recent_tag_count_max < clone.recent_tag_count_min

--- a/app/models/feed_config.rb
+++ b/app/models/feed_config.rb
@@ -155,6 +155,17 @@ class FeedConfig < ApplicationRecord
       SQL
     end
 
+    user_setting = user.respond_to?(:setting) ? user.setting : nil
+    if user_setting&.minimize_ai_feed_ai?
+      terms << "(CASE WHEN articles.ai_disclosure_level = 3 THEN -15.0 WHEN articles.ai_disclosure_level = 5 THEN -30.0 ELSE 0 END)"
+    elsif user_setting&.hide_fully_autonomous_feed_ai?
+      terms << "(CASE WHEN articles.ai_disclosure_level = 3 THEN -15.0 ELSE 0 END)"
+    end
+
+    if autonomous_ai_penalty_weight.positive?
+      terms << "(CASE WHEN articles.ai_disclosure_level = 5 THEN -#{autonomous_ai_penalty_weight} ELSE 0 END)"
+    end
+
     terms << "(CASE WHEN articles.featured = TRUE THEN #{featured_weight} ELSE 0 END)" if featured_weight.positive?
     terms << "(CASE WHEN articles.type_of = 1 THEN #{status_weight} ELSE 0 END)" if status_weight.positive?
     terms << "(- (articles.clickbait_score * #{clickbait_score_weight}))" if clickbait_score_weight.positive?

--- a/app/services/articles/feeds/article_score_calculator_for_user.rb
+++ b/app/services/articles/feeds/article_score_calculator_for_user.rb
@@ -20,7 +20,9 @@ module Articles
         followed_tag_weight: 1,
         not_followed_tag_score: 0,
         followed_org_score: 1,
-        not_followed_org_score: 0
+        not_followed_org_score: 0,
+        some_ai_penalty: -10,
+        fully_autonomous_penalty: -25
       }.freeze
 
       # @param user [User] the user for whom we're calculating the article score.
@@ -69,6 +71,27 @@ module Articles
       # @api private
       def score_comments(article)
         article.comments_count * @comment_weight
+      end
+
+      # @api private
+      def score_ai_disclosure(article)
+        return 0 unless @user&.setting
+
+        case @user.setting.feed_ai_preference
+        when "minimize_ai"
+          case article.ai_disclosure_level
+          when "some_ai" then @some_ai_penalty
+          when "fully_autonomous" then @fully_autonomous_penalty
+          else 0
+          end
+        when "hide_fully_autonomous"
+          case article.ai_disclosure_level
+          when "some_ai" then @some_ai_penalty
+          else 0
+          end
+        else
+          0
+        end
       end
 
       private

--- a/app/services/articles/feeds/basic.rb
+++ b/app/services/articles/feeds/basic.rb
@@ -22,6 +22,9 @@ module Articles
         return articles unless @user
 
         articles = articles.where.not(user_id: UserBlock.cached_blocked_ids_for_blocker(@user.id))
+        if @user.setting&.hide_fully_autonomous_feed_ai?
+          articles = articles.where.not(ai_disclosure_level: :fully_autonomous)
+        end
         if (hidden_tags = @user.cached_antifollowed_tag_names).any?
           articles = articles.not_cached_tagged_with_any(hidden_tags)
         end
@@ -29,11 +32,12 @@ module Articles
           tag_score = score_followed_tags(article)
           user_score = score_followed_user(article)
           org_score = score_followed_organization(article)
+          ai_score = score_ai_disclosure(article)
 
           # NOTE: Not quite understanding the purpose of the `-
           # index`.  My guess is that it helps reduce the impact of the
           # hotness score on the sort order.
-          tag_score + org_score + user_score - index
+          tag_score + org_score + user_score + ai_score - index
         end.reverse!
       end
 
@@ -51,6 +55,7 @@ module Articles
       delegate(:score_followed_tags,
                :score_followed_user,
                :score_followed_organization,
+               :score_ai_disclosure,
                to: :@article_score_applicator)
     end
   end

--- a/app/services/articles/feeds/custom.rb
+++ b/app/services/articles/feeds/custom.rb
@@ -53,7 +53,8 @@ module Articles
         {
           blocked_user_ids: UserBlock.cached_blocked_ids_for_blocker(@user.id),
           hidden_tags: @user.cached_antifollowed_tag_names,
-          user_activity: @user.user_activity
+          user_activity: @user.user_activity,
+          hide_fully_autonomous: @user.setting&.hide_fully_autonomous_feed_ai?
         }
       end
 
@@ -85,6 +86,10 @@ module Articles
         # Apply user-specific filters early to reduce dataset size
         if user_data[:blocked_user_ids].any?
           articles = articles.where.not(user_id: user_data[:blocked_user_ids])
+        end
+
+        if user_data[:hide_fully_autonomous]
+          articles = articles.where.not(ai_disclosure_level: :fully_autonomous)
         end
         
         if user_data[:hidden_tags].any?

--- a/app/services/articles/feeds/large_forem_experimental.rb
+++ b/app/services/articles/feeds/large_forem_experimental.rb
@@ -59,6 +59,7 @@ module Articles
         article_points += score_followed_tags(article)
         article_points += score_experience_level(article)
         article_points += score_comments(article)
+        article_points += score_ai_disclosure(article)
         article_points
       end
 
@@ -67,6 +68,7 @@ module Articles
                :score_followed_organization,
                :score_experience_level,
                :score_comments,
+               :score_ai_disclosure,
                to: :@article_score_applicator)
 
       # @api private
@@ -76,6 +78,9 @@ module Articles
         if user_signed_in
           hot_stories = experimental_hot_story_grab
           hot_stories = hot_stories.not_authored_by(UserBlock.cached_blocked_ids_for_blocker(@user.id))
+          if @user&.setting&.hide_fully_autonomous_feed_ai?
+            hot_stories = hot_stories.where.not(ai_disclosure_level: :fully_autonomous)
+          end
           featured_story = featured_story_from(stories: hot_stories, must_have_main_image: must_have_main_image)
           new_stories = Article.published.from_subforem
             .where("score > ?", article_score_threshold)
@@ -83,6 +88,9 @@ module Articles
             .order(published_at: :desc)
             .includes(:distinct_reaction_categories, :subforem, :context_notes)
             .limit(rand(min_rand_limit..max_rand_limit))
+          if @user&.setting&.hide_fully_autonomous_feed_ai?
+            new_stories = new_stories.where.not(ai_disclosure_level: :fully_autonomous)
+          end
           hot_stories = hot_stories.to_a + new_stories.to_a
         else
           hot_stories = Article.published.from_subforem.limited_column_select

--- a/app/services/articles/feeds/variant_query.rb
+++ b/app/services/articles/feeds/variant_query.rb
@@ -253,6 +253,10 @@ module Articles
           # As implemented, this is not looking for collisions of named parameters.
           @query_parameters.merge!(lever.query_parameters)
         end
+
+        if @user&.setting&.minimize_ai_feed_ai?
+          @relevance_score_components << "(CASE WHEN articles.ai_disclosure_level = 3 THEN -15.0 WHEN articles.ai_disclosure_level = 5 THEN -30.0 ELSE 0.0 END)"
+        end
       end
 
       # Concatenate the required group by clauses.
@@ -293,6 +297,9 @@ module Articles
         elsif @user
           user_ids = @user.cached_following_users_ids + @user.cached_following_organizations_ids + [0] # Adding one that will never be reached so we can have a valid SQL statement
           where_clauses += " AND articles.user_id IN (#{user_ids.join(',')})"
+        end
+        if @user&.setting&.hide_fully_autonomous_feed_ai?
+          where_clauses += " AND articles.ai_disclosure_level != #{Article.ai_disclosure_levels[:fully_autonomous]}"
         end
         where_clauses += " AND articles.id NOT IN (:omit_article_ids)" unless omit_article_ids.compact.empty?
         where_clauses += " AND articles.featured = true" if only_featured

--- a/app/views/admin/feed_configs/_form.html.erb
+++ b/app/views/admin/feed_configs/_form.html.erb
@@ -1,0 +1,166 @@
+<div class="flex flex-col gap-6">
+  <fieldset class="border p-4 rounded-md">
+    <legend class="fw-bold px-2 text-base color-base-90">🤖 AI & Disclosure Controls</legend>
+    <div class="grid grid-cols-1 m:grid-cols-2 gap-4 mt-2">
+      <div class="crayons-field">
+        <%= f.label :ai_disclosure_matching_weight, "AI Disclosure Matching Weight", class: "crayons-field__label" %>
+        <p class="fs-xs color-base-60 mb-1">Governs user preferences for AI disclosed content (deducts 1x for some_ai, 2x for fully_autonomous when user chooses minimize_ai).</p>
+        <%= f.number_field :ai_disclosure_matching_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+
+      <div class="crayons-field">
+        <%= f.label :autonomous_ai_penalty_weight, "Autonomous AI Global Penalty Weight", class: "crayons-field__label" %>
+        <p class="fs-xs color-base-60 mb-1">Global score deduction applied to all fully autonomous AI content regardless of individual user preference.</p>
+        <%= f.number_field :autonomous_ai_penalty_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+    </div>
+  </fieldset>
+
+  <fieldset class="border p-4 rounded-md">
+    <legend class="fw-bold px-2 text-base color-base-90">👥 Social & Follow Network Weights</legend>
+    <div class="grid grid-cols-1 m:grid-cols-2 gap-4 mt-2">
+      <div class="crayons-field">
+        <%= f.label :user_follow_weight, "User Follow Weight", class: "crayons-field__label" %>
+        <%= f.number_field :user_follow_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :organization_follow_weight, "Organization Follow Weight", class: "crayons-field__label" %>
+        <%= f.number_field :organization_follow_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :tag_follow_weight, "Tag Follow Weight", class: "crayons-field__label" %>
+        <%= f.number_field :tag_follow_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :subforem_follow_weight, "Subforem Follow Weight", class: "crayons-field__label" %>
+        <%= f.number_field :subforem_follow_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :follow_status_weight, "Follow Status Weight", class: "crayons-field__label" %>
+        <%= f.number_field :follow_status_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :label_match_weight, "Label Match Weight", class: "crayons-field__label" %>
+        <%= f.number_field :label_match_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+    </div>
+  </fieldset>
+
+  <fieldset class="border p-4 rounded-md">
+    <legend class="fw-bold px-2 text-base color-base-90">⭐ Content Quality & Engagement Weights</legend>
+    <div class="grid grid-cols-1 m:grid-cols-3 gap-4 mt-2">
+      <div class="crayons-field">
+        <%= f.label :score_weight, "Score Weight", class: "crayons-field__label" %>
+        <%= f.number_field :score_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :feed_success_weight, "Feed Success Weight", class: "crayons-field__label" %>
+        <%= f.number_field :feed_success_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :comment_score_weight, "Comment Score Weight", class: "crayons-field__label" %>
+        <%= f.number_field :comment_score_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :comment_recency_weight, "Comment Recency Weight", class: "crayons-field__label" %>
+        <%= f.number_field :comment_recency_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :recency_weight, "Recency Weight", class: "crayons-field__label" %>
+        <%= f.number_field :recency_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :featured_weight, "Featured Weight", class: "crayons-field__label" %>
+        <%= f.number_field :featured_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :compellingness_score_weight, "Compellingness Score Weight", class: "crayons-field__label" %>
+        <%= f.number_field :compellingness_score_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :clickbait_score_weight, "Clickbait Penalty Weight", class: "crayons-field__label" %>
+        <%= f.number_field :clickbait_score_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :status_weight, "Status Weight", class: "crayons-field__label" %>
+        <%= f.number_field :status_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :language_match_weight, "Language Match Weight", class: "crayons-field__label" %>
+        <%= f.number_field :language_match_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+    </div>
+  </fieldset>
+
+  <fieldset class="border p-4 rounded-md">
+    <legend class="fw-bold px-2 text-base color-base-90">🕒 Recency & Activity Bonuses</legend>
+    <div class="grid grid-cols-1 m:grid-cols-3 gap-4 mt-2">
+      <div class="crayons-field">
+        <%= f.label :published_today_weight, "Published Today Weight", class: "crayons-field__label" %>
+        <%= f.number_field :published_today_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :general_past_day_bonus_weight, "General Past Day Bonus", class: "crayons-field__label" %>
+        <%= f.number_field :general_past_day_bonus_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :recently_active_past_day_bonus_weight, "Recently Active Past Day Bonus", class: "crayons-field__label" %>
+        <%= f.number_field :recently_active_past_day_bonus_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :recent_subforem_weight, "Recent Subforem Weight", class: "crayons-field__label" %>
+        <%= f.number_field :recent_subforem_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :recent_article_suppression_rate, "Recent Article Suppression Rate", class: "crayons-field__label" %>
+        <%= f.number_field :recent_article_suppression_rate, step: "any", class: "crayons-textfield" %>
+      </div>
+    </div>
+  </fieldset>
+
+  <fieldset class="border p-4 rounded-md">
+    <legend class="fw-bold px-2 text-base color-base-90">🔮 Discovery & Algorithmic Controls</legend>
+    <div class="grid grid-cols-1 m:grid-cols-3 gap-4 mt-2">
+      <div class="crayons-field">
+        <%= f.label :semantic_similarity_weight, "Semantic Similarity Weight", class: "crayons-field__label" %>
+        <%= f.number_field :semantic_similarity_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :randomness_weight, "Randomness Weight", class: "crayons-field__label" %>
+        <%= f.number_field :randomness_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :shuffle_weight, "Shuffle Weight", class: "crayons-field__label" %>
+        <%= f.number_field :shuffle_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :recent_page_views_shuffle_weight, "Recent Views Shuffle Weight", class: "crayons-field__label" %>
+        <%= f.number_field :recent_page_views_shuffle_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :lookback_window_weight, "Lookback Window Weight", class: "crayons-field__label" %>
+        <%= f.number_field :lookback_window_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :precomputed_selections_weight, "Precomputed Selections Weight", class: "crayons-field__label" %>
+        <%= f.number_field :precomputed_selections_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :recent_tag_count_min, "Recent Tag Count Min", class: "crayons-field__label" %>
+        <%= f.number_field :recent_tag_count_min, class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :recent_tag_count_max, "Recent Tag Count Max", class: "crayons-field__label" %>
+        <%= f.number_field :recent_tag_count_max, class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :all_time_tag_count_min, "All-Time Tag Count Min", class: "crayons-field__label" %>
+        <%= f.number_field :all_time_tag_count_min, class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
+        <%= f.label :all_time_tag_count_max, "All-Time Tag Count Max", class: "crayons-field__label" %>
+        <%= f.number_field :all_time_tag_count_max, class: "crayons-textfield" %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/feed_configs/index.html.erb
+++ b/app/views/admin/feed_configs/index.html.erb
@@ -1,0 +1,86 @@
+<header class="flex items-center mb-6">
+  <div>
+    <h1 class="crayons-title">Feed Configurations</h1>
+    <p class="color-base-60 text-sm">Manage, inspect, and deploy algorithmic feed scoring models.</p>
+  </div>
+  <a href="<%= new_admin_feed_config_path %>" class="crayons-btn ml-auto" role="button">
+    <%= crayons_icon_tag(:plus, class: "mr-1") %> Create New Feed Config
+  </a>
+</header>
+
+<% if @best_feed_config.present? %>
+  <div class="crayons-card p-6 mb-6 border border-teal-500 bg-teal-50 dark:bg-teal-950">
+    <div class="flex items-center justify-between mb-4">
+      <div>
+        <span class="c-indicator c-indicator--success mr-2">Top Performer</span>
+        <h2 class="fs-l fw-bold inline-block">Feed Config #<%= @best_feed_config.id %></h2>
+      </div>
+      <div>
+        <%= link_to "Clone & Modify as New", new_admin_feed_config_path(clone_from_id: @best_feed_config.id), class: "crayons-btn crayons-btn--secondary mr-2" %>
+        <%= link_to "View Details", admin_feed_config_path(@best_feed_config), class: "crayons-btn crayons-btn--outlined" %>
+      </div>
+    </div>
+    <div class="grid grid-cols-2 m:grid-cols-4 gap-4">
+      <div class="p-3 bg-white dark:bg-black rounded border">
+        <div class="color-base-60 fs-xs">Success Score</div>
+        <div class="fs-xl fw-bold color-base-90"><%= @best_feed_config.feed_success_score.round(4) %></div>
+      </div>
+      <div class="p-3 bg-white dark:bg-black rounded border">
+        <div class="color-base-60 fs-xs">Impressions Count</div>
+        <div class="fs-xl fw-bold color-base-90"><%= number_with_delimiter(@best_feed_config.feed_impressions_count) %></div>
+      </div>
+      <div class="p-3 bg-white dark:bg-black rounded border">
+        <div class="color-base-60 fs-xs">AI Disclosure Matching</div>
+        <div class="fs-xl fw-bold color-base-90"><%= @best_feed_config.ai_disclosure_matching_weight %></div>
+      </div>
+      <div class="p-3 bg-white dark:bg-black rounded border">
+        <div class="color-base-60 fs-xs">Autonomous AI Penalty</div>
+        <div class="fs-xl fw-bold color-base-90"><%= @best_feed_config.autonomous_ai_penalty_weight %></div>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<div class="crayons-card p-6 grid gap-6">
+  <table class="crayons-table">
+    <thead>
+      <tr>
+        <th scope="col">Config ID</th>
+        <th scope="col">Success Score</th>
+        <th scope="col">Impressions</th>
+        <th scope="col">AI Weights (Matching / Penalty)</th>
+        <th scope="col">Created</th>
+        <th scope="col" class="text-right">Actions</th>
+      </tr>
+    </thead>
+    <tbody class="crayons-card">
+      <% @feed_configs.each do |config| %>
+        <tr>
+          <td>
+            <strong><%= link_to "##{config.id}", admin_feed_config_path(config) %></strong>
+            <% if config.id == @best_feed_config&.id %>
+              <span class="c-indicator c-indicator--success ml-1">Best</span>
+            <% end %>
+          </td>
+          <td><%= config.feed_success_score.round(4) %></td>
+          <td><%= number_with_delimiter(config.feed_impressions_count) %></td>
+          <td>
+            <%= config.ai_disclosure_matching_weight %> / <%= config.autonomous_ai_penalty_weight %>
+          </td>
+          <td class="color-base-60 text-sm"><%= config.created_at.strftime("%b %d, %Y") %></td>
+          <td class="text-right">
+            <%= link_to "Clone", new_admin_feed_config_path(clone_from_id: config.id), class: "crayons-btn crayons-btn--ghost crayons-btn--s mr-1" %>
+            <%= link_to "View", admin_feed_config_path(config), class: "crayons-btn crayons-btn--outlined crayons-btn--s mr-1" %>
+            <%= link_to "Delete", admin_feed_config_path(config), data: { turbo_method: :delete, confirm: "Are you sure you want to delete Feed Config ##{config.id}?" }, class: "crayons-btn crayons-btn--danger crayons-btn--s" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <% if @feed_configs.respond_to?(:total_pages) %>
+    <div class="flex justify-center mt-4">
+      <%= paginate @feed_configs %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/feed_configs/new.html.erb
+++ b/app/views/admin/feed_configs/new.html.erb
@@ -1,0 +1,28 @@
+<header class="flex items-center mb-6">
+  <div>
+    <h1 class="crayons-title">Create Feed Configuration</h1>
+    <p class="color-base-60 text-sm">
+      <% if params[:clone_from_id].present? %>
+        Values pre-filled from Feed Config #<%= params[:clone_from_id] %>.
+      <% elsif @feed_config.persisted? || FeedConfig.exists? %>
+        Values pre-filled from the current <strong>best-performing</strong> feed config. Adjust any weights below to spin up a new configuration variant.
+      <% else %>
+        Enter the algorithmic weights for this new feed configuration.
+      <% end %>
+    </p>
+  </div>
+  <a href="<%= admin_feed_configs_path %>" class="crayons-btn crayons-btn--outlined ml-auto" role="button">
+    Back to Feed Configs
+  </a>
+</header>
+
+<div class="crayons-card p-6">
+  <%= form_with(model: [:admin, @feed_config], url: admin_feed_configs_path, method: :post, local: true) do |f| %>
+    <%= render "form", f: f %>
+
+    <div class="flex items-center gap-3 mt-6 pt-4 border-t">
+      <%= f.submit "Create Feed Config", class: "crayons-btn crayons-btn--primary" %>
+      <%= link_to "Cancel", admin_feed_configs_path, class: "crayons-btn crayons-btn--ghost" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/feed_configs/show.html.erb
+++ b/app/views/admin/feed_configs/show.html.erb
@@ -1,0 +1,62 @@
+<header class="flex items-center mb-6">
+  <div>
+    <h1 class="crayons-title">Feed Config #<%= @feed_config.id %></h1>
+    <p class="color-base-60 text-sm">Created on <%= @feed_config.created_at.strftime("%B %d, %Y at %H:%M UTC") %></p>
+  </div>
+  <div class="ml-auto flex gap-2">
+    <%= link_to "Clone & Modify as New", new_admin_feed_config_path(clone_from_id: @feed_config.id), class: "crayons-btn crayons-btn--primary" %>
+    <%= link_to "Back to Feed Configs", admin_feed_configs_path, class: "crayons-btn crayons-btn--outlined" %>
+    <%= link_to "Delete", admin_feed_config_path(@feed_config), data: { turbo_method: :delete, confirm: "Are you sure you want to delete this Feed Config?" }, class: "crayons-btn crayons-btn--danger" %>
+  </div>
+</header>
+
+<div class="grid grid-cols-1 m:grid-cols-2 gap-6 mb-6">
+  <div class="crayons-card p-6">
+    <h2 class="fs-base fw-bold mb-4">Performance Metrics</h2>
+    <dl class="grid grid-cols-2 gap-4">
+      <div>
+        <dt class="fs-xs color-base-60">Success Score</dt>
+        <dd class="fs-l fw-bold color-base-90"><%= @feed_config.feed_success_score.round(4) %></dd>
+      </div>
+      <div>
+        <dt class="fs-xs color-base-60">Impressions Count</dt>
+        <dd class="fs-l fw-bold color-base-90"><%= number_with_delimiter(@feed_config.feed_impressions_count) %></dd>
+      </div>
+    </dl>
+  </div>
+
+  <div class="crayons-card p-6">
+    <h2 class="fs-base fw-bold mb-4">AI Disclosure Weights</h2>
+    <dl class="grid grid-cols-2 gap-4">
+      <div>
+        <dt class="fs-xs color-base-60">AI Disclosure Matching Weight</dt>
+        <dd class="fs-l fw-bold color-base-90"><%= @feed_config.ai_disclosure_matching_weight %></dd>
+      </div>
+      <div>
+        <dt class="fs-xs color-base-60">Autonomous AI Penalty Weight</dt>
+        <dd class="fs-l fw-bold color-base-90"><%= @feed_config.autonomous_ai_penalty_weight %></dd>
+      </div>
+    </dl>
+  </div>
+</div>
+
+<div class="crayons-card p-6">
+  <h2 class="fs-base fw-bold mb-4">All Configured Weights & Parameters</h2>
+  <table class="crayons-table">
+    <thead>
+      <tr>
+        <th scope="col">Parameter</th>
+        <th scope="col">Value</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @feed_config.attributes.sort.each do |key, value| %>
+        <% next if key.in?(%w[id created_at updated_at]) %>
+        <tr>
+          <td class="font-mono text-sm"><code><%= key %></code></td>
+          <td class="fw-bold"><%= value %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -79,7 +79,7 @@ en:
         level: What is your approximate experience level (1-5)?
         level_desc: This will not be displayed on your profile or anywhere publicly. It helps gently determine what content you are shown along with tags you follow etc.
         feed_ai_preference: AI Content in Feed
-        feed_ai_preference_desc: "Choose how AI-disclosed content appears in your feed (Note: Feed customization is coming soon and preferences will apply once fully rolled out)."
+        feed_ai_preference_desc: "Choose how AI-disclosed content appears in your feed."
         feed_ai_options:
           show_all: Standard (show all content)
           minimize_ai: Minimize AI-assisted & autonomous content

--- a/config/locales/views/settings/fr.yml
+++ b/config/locales/views/settings/fr.yml
@@ -79,7 +79,7 @@ fr:
         level: What is your approximate experience level (1-5)?
         level_desc: This will not be displayed on your profile or anywhere publicly. It helps gently determine what content you are shown along with tags you follow etc.
         feed_ai_preference: Contenu IA dans le flux
-        feed_ai_preference_desc: "Choisissez comment le contenu déclaré généré par IA apparaîtra dans votre flux (Remarque : la personnalisation du flux arrive bientôt et vos préférences s'appliqueront dès son déploiement complet)."
+        feed_ai_preference_desc: "Choisissez comment le contenu déclaré généré par IA apparaîtra dans votre flux."
         feed_ai_options:
           show_all: Standard (afficher tout le contenu)
           minimize_ai: Réduire le contenu assisté par IA et autonome

--- a/config/locales/views/settings/pt.yml
+++ b/config/locales/views/settings/pt.yml
@@ -93,7 +93,7 @@ pt:
           not_connected: Não conectado
         custom:
           feed_ai_preference: Conteúdo de IA no Feed
-          feed_ai_preference_desc: "Escolha como o conteúdo divulgado por IA aparecerá no seu feed (Observação: a personalização do feed estará disponível em breve e as preferências serão aplicadas quando for totalmente lançada)."
+          feed_ai_preference_desc: "Escolha como o conteúdo divulgado por IA aparecerá no seu feed."
           feed_ai_options:
             show_all: Padrão (mostrar todo o conteúdo)
             minimize_ai: Minimizar conteúdo assistido e autônomo por IA

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -211,6 +211,7 @@ namespace :admin do
   scope :advanced do
     resources :broadcasts
     resources :response_templates, only: %i[index new edit create update destroy]
+    resources :feed_configs, only: %i[index show new create destroy]
     resources :tools, only: %i[index create] do
       collection do
         post "bust_cache"

--- a/spec/models/feed_config_spec.rb
+++ b/spec/models/feed_config_spec.rb
@@ -378,6 +378,8 @@ RSpec.describe FeedConfig, type: :model do
       feed_config.subforem_follow_weight        = 21.0 # Added new weight
       feed_config.recent_page_views_shuffle_weight = 22.0
       feed_config.follow_status_weight          = 23.0
+      feed_config.ai_disclosure_matching_weight = 24.0
+      feed_config.autonomous_ai_penalty_weight  = 25.0
       feed_config.recent_tag_count_min           = 2
       feed_config.recent_tag_count_max           = 5
       feed_config.all_time_tag_count_min         = 3
@@ -418,6 +420,8 @@ RSpec.describe FeedConfig, type: :model do
       expect(clone.subforem_follow_weight).to eq(21.0 * 1.1) # Added expectation
       expect(clone.recent_page_views_shuffle_weight).to eq(22.0 * 1.1)
       expect(clone.follow_status_weight).to eq(23.0 * 1.1)
+      expect(clone.ai_disclosure_matching_weight).to eq(24.0 * 1.1)
+      expect(clone.autonomous_ai_penalty_weight).to eq(25.0 * 1.1)
     end
 
     it "does not modify the original feed_config" do
@@ -446,6 +450,8 @@ RSpec.describe FeedConfig, type: :model do
         "subforem_follow_weight", # Added new weight to check
         "recent_page_views_shuffle_weight",
         "follow_status_weight",
+        "ai_disclosure_matching_weight",
+        "autonomous_ai_penalty_weight",
         "recent_tag_count_min",
         "recent_tag_count_max",
         "all_time_tag_count_min",
@@ -484,21 +490,46 @@ RSpec.describe FeedConfig, type: :model do
       expect(sql).to include("* 10.0")
     end
 
-    context "when user has minimize_ai feed preference" do
-      before { user.setting.update(feed_ai_preference: :minimize_ai) }
+    context "when ai_disclosure_matching_weight is positive" do
+      before { feed_config.ai_disclosure_matching_weight = 12.0 }
 
-      it "includes AI disclosure penalties for some_ai and fully_autonomous" do
-        sql = feed_config.score_sql(user)
-        expect(sql).to include("CASE WHEN articles.ai_disclosure_level = 3 THEN -15.0 WHEN articles.ai_disclosure_level = 5 THEN -30.0 ELSE 0 END")
+      context "when user has minimize_ai feed preference" do
+        before { user.setting.update(feed_ai_preference: :minimize_ai) }
+
+        it "scales AI disclosure penalties by ai_disclosure_matching_weight" do
+          sql = feed_config.score_sql(user)
+          expect(sql).to include("CASE WHEN articles.ai_disclosure_level = 3 THEN -12.0 WHEN articles.ai_disclosure_level = 5 THEN -24.0 ELSE 0 END")
+        end
+      end
+
+      context "when user has hide_fully_autonomous feed preference" do
+        before { user.setting.update(feed_ai_preference: :hide_fully_autonomous) }
+
+        it "scales some_ai penalties by ai_disclosure_matching_weight" do
+          sql = feed_config.score_sql(user)
+          expect(sql).to include("CASE WHEN articles.ai_disclosure_level = 3 THEN -12.0 ELSE 0 END")
+        end
+      end
+
+      context "when user has show_all feed preference" do
+        before { user.setting.update(feed_ai_preference: :show_all) }
+
+        it "does not include user AI disclosure penalty terms" do
+          sql = feed_config.score_sql(user)
+          expect(sql).not_to include("articles.ai_disclosure_level = 3")
+        end
       end
     end
 
-    context "when user has hide_fully_autonomous feed preference" do
-      before { user.setting.update(feed_ai_preference: :hide_fully_autonomous) }
+    context "when ai_disclosure_matching_weight is 0" do
+      before do
+        feed_config.ai_disclosure_matching_weight = 0.0
+        user.setting.update(feed_ai_preference: :minimize_ai)
+      end
 
-      it "includes AI disclosure penalties for some_ai" do
+      it "does not include AI disclosure matching penalty terms" do
         sql = feed_config.score_sql(user)
-        expect(sql).to include("CASE WHEN articles.ai_disclosure_level = 3 THEN -15.0 ELSE 0 END")
+        expect(sql).not_to include("articles.ai_disclosure_level = 3")
       end
     end
 
@@ -508,15 +539,6 @@ RSpec.describe FeedConfig, type: :model do
       it "includes the autonomous AI penalty weight term" do
         sql = feed_config.score_sql(user)
         expect(sql).to include("CASE WHEN articles.ai_disclosure_level = 5 THEN -25.0 ELSE 0 END")
-      end
-    end
-
-    context "when user has show_all feed preference" do
-      before { user.setting.update(feed_ai_preference: :show_all) }
-
-      it "does not include user AI disclosure penalty terms" do
-        sql = feed_config.score_sql(user)
-        expect(sql).not_to include("articles.ai_disclosure_level = 3 THEN -15.0")
       end
     end
   end

--- a/spec/models/feed_config_spec.rb
+++ b/spec/models/feed_config_spec.rb
@@ -471,7 +471,7 @@ RSpec.describe FeedConfig, type: :model do
 
   describe "#score_sql" do
     let(:user) { create(:user) }
-    let(:feed_config) { FeedConfig.new(semantic_similarity_weight: 10.0) }
+    let(:feed_config) { described_class.new(semantic_similarity_weight: 10.0) }
     let(:interest_embedding) { [0.1, 0.2, 0.3] + Array.new(765, 0.0) }
 
     it "includes semantic embedding calculation when activity store has a vector" do
@@ -482,6 +482,42 @@ RSpec.describe FeedConfig, type: :model do
       sql = feed_config.score_sql(user)
       expect(sql).to include("articles.semantic_embedding <=> '[#{interest_embedding.join(',')}]'")
       expect(sql).to include("* 10.0")
+    end
+
+    context "when user has minimize_ai feed preference" do
+      before { user.setting.update(feed_ai_preference: :minimize_ai) }
+
+      it "includes AI disclosure penalties for some_ai and fully_autonomous" do
+        sql = feed_config.score_sql(user)
+        expect(sql).to include("CASE WHEN articles.ai_disclosure_level = 3 THEN -15.0 WHEN articles.ai_disclosure_level = 5 THEN -30.0 ELSE 0 END")
+      end
+    end
+
+    context "when user has hide_fully_autonomous feed preference" do
+      before { user.setting.update(feed_ai_preference: :hide_fully_autonomous) }
+
+      it "includes AI disclosure penalties for some_ai" do
+        sql = feed_config.score_sql(user)
+        expect(sql).to include("CASE WHEN articles.ai_disclosure_level = 3 THEN -15.0 ELSE 0 END")
+      end
+    end
+
+    context "when autonomous_ai_penalty_weight is positive" do
+      before { feed_config.autonomous_ai_penalty_weight = 25.0 }
+
+      it "includes the autonomous AI penalty weight term" do
+        sql = feed_config.score_sql(user)
+        expect(sql).to include("CASE WHEN articles.ai_disclosure_level = 5 THEN -25.0 ELSE 0 END")
+      end
+    end
+
+    context "when user has show_all feed preference" do
+      before { user.setting.update(feed_ai_preference: :show_all) }
+
+      it "does not include user AI disclosure penalty terms" do
+        sql = feed_config.score_sql(user)
+        expect(sql).not_to include("articles.ai_disclosure_level = 3 THEN -15.0")
+      end
     end
   end
 end

--- a/spec/requests/admin/feed_configs_spec.rb
+++ b/spec/requests/admin/feed_configs_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+
+RSpec.describe "/admin/advanced/feed_configs" do
+  let(:get_resource) { get admin_feed_configs_path }
+  let(:params) do
+    {
+      feed_config: {
+        ai_disclosure_matching_weight: 15.0,
+        autonomous_ai_penalty_weight: 25.0,
+        user_follow_weight: 2.0,
+        tag_follow_weight: 3.0,
+        score_weight: 1.5
+      }
+    }
+  end
+  let(:post_resource) { post admin_feed_configs_path, params: params }
+
+  context "when the user is not signed in" do
+    it "redirects to sign in or blocks access" do
+      expect { get_resource }.to raise_error(Pundit::NotAuthorizedError)
+    end
+  end
+
+  context "when the user is not an admin" do
+    let(:user) { create(:user) }
+
+    before { sign_in user }
+
+    describe "GET /admin/advanced/feed_configs" do
+      it "blocks the request" do
+        expect { get_resource }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    describe "POST /admin/advanced/feed_configs" do
+      it "blocks the request" do
+        expect { post_resource }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+  end
+
+  context "when the user is a super admin" do
+    let(:super_admin) { create(:user, :super_admin) }
+    let!(:top_config) { create(:feed_config, feed_success_score: 95.5, feed_impressions_count: 5000, ai_disclosure_matching_weight: 10.0) }
+    let!(:other_config) { create(:feed_config, feed_success_score: 50.0, feed_impressions_count: 1000, ai_disclosure_matching_weight: 5.0) }
+
+    before { sign_in super_admin }
+
+    describe "GET /admin/advanced/feed_configs" do
+      it "allows the request and renders the index page" do
+        get_resource
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Feed Configurations")
+        expect(response.body).to include("Feed Config ##{top_config.id}")
+      end
+    end
+
+    describe "GET /admin/advanced/feed_configs/:id" do
+      it "renders the show view for the feed config" do
+        get admin_feed_config_path(top_config)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Feed Config ##{top_config.id}")
+        expect(response.body).to include("ai_disclosure_matching_weight")
+      end
+    end
+
+    describe "GET /admin/advanced/feed_configs/new" do
+      it "pre-populates the new form with attributes from the best performing config" do
+        get new_admin_feed_config_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('value="10.0"')
+      end
+
+      it "pre-populates with specified clone_from_id config when passed" do
+        get new_admin_feed_config_path(clone_from_id: other_config.id)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('value="5.0"')
+      end
+    end
+
+    describe "POST /admin/advanced/feed_configs" do
+      it "creates a new feed config" do
+        expect { post_resource }.to change(FeedConfig, :count).by(1)
+        new_config = FeedConfig.last
+        expect(new_config.ai_disclosure_matching_weight).to eq(15.0)
+        expect(new_config.autonomous_ai_penalty_weight).to eq(25.0)
+        expect(new_config.user_follow_weight).to eq(2.0)
+        expect(response).to redirect_to(admin_feed_config_path(new_config))
+      end
+    end
+
+    describe "DELETE /admin/advanced/feed_configs/:id" do
+      it "destroys the feed config and redirects to index" do
+        expect do
+          delete admin_feed_config_path(other_config)
+        end.to change(FeedConfig, :count).by(-1)
+        expect(response).to redirect_to(admin_feed_configs_path)
+      end
+    end
+  end
+end

--- a/spec/services/articles/feeds/article_score_calculator_for_user_spec.rb
+++ b/spec/services/articles/feeds/article_score_calculator_for_user_spec.rb
@@ -198,4 +198,51 @@ RSpec.describe Articles::Feeds::ArticleScoreCalculatorForUser, type: :service do
       end
     end
   end
+
+  describe "#score_ai_disclosure" do
+    let(:not_disclosed_article) { create(:article, ai_disclosure_level: :not_disclosed) }
+    let(:no_ai_article) { create(:article, ai_disclosure_level: :no_ai) }
+    let(:some_ai_article) { create(:article, ai_disclosure_level: :some_ai) }
+    let(:fully_autonomous_article) { create(:article, ai_disclosure_level: :fully_autonomous) }
+
+    context "when user has show_all preference" do
+      before { user.setting.update(feed_ai_preference: :show_all) }
+
+      it "returns 0 for all articles" do
+        expect(applicator.score_ai_disclosure(not_disclosed_article)).to eq(0)
+        expect(applicator.score_ai_disclosure(no_ai_article)).to eq(0)
+        expect(applicator.score_ai_disclosure(some_ai_article)).to eq(0)
+        expect(applicator.score_ai_disclosure(fully_autonomous_article)).to eq(0)
+      end
+    end
+
+    context "when user has minimize_ai preference" do
+      before { user.setting.update(feed_ai_preference: :minimize_ai) }
+
+      it "penalizes some_ai and fully_autonomous articles" do
+        expect(applicator.score_ai_disclosure(not_disclosed_article)).to eq(0)
+        expect(applicator.score_ai_disclosure(no_ai_article)).to eq(0)
+        expect(applicator.score_ai_disclosure(some_ai_article)).to eq(-10)
+        expect(applicator.score_ai_disclosure(fully_autonomous_article)).to eq(-25)
+      end
+    end
+
+    context "when user has hide_fully_autonomous preference" do
+      before { user.setting.update(feed_ai_preference: :hide_fully_autonomous) }
+
+      it "penalizes some_ai articles" do
+        expect(applicator.score_ai_disclosure(not_disclosed_article)).to eq(0)
+        expect(applicator.score_ai_disclosure(no_ai_article)).to eq(0)
+        expect(applicator.score_ai_disclosure(some_ai_article)).to eq(-10)
+      end
+    end
+
+    context "when user is nil" do
+      let(:applicator) { described_class.new(user: nil) }
+
+      it "returns 0" do
+        expect(applicator.score_ai_disclosure(some_ai_article)).to eq(0)
+      end
+    end
+  end
 end

--- a/spec/services/articles/feeds/basic_spec.rb
+++ b/spec/services/articles/feeds/basic_spec.rb
@@ -63,5 +63,40 @@ RSpec.describe Articles::Feeds::Basic, type: :service do
         expect(result).to include(visible)
       end
     end
+
+    context "with AI disclosure preferences" do
+      let!(:no_ai_post) { create(:article, hotness_score: 50, ai_disclosure_level: :no_ai) }
+      let!(:some_ai_post) { create(:article, hotness_score: 50, ai_disclosure_level: :some_ai) }
+      let!(:autonomous_post) { create(:article, hotness_score: 50, ai_disclosure_level: :fully_autonomous) }
+
+      context "when feed_ai_preference is show_all" do
+        before { user.setting.update(feed_ai_preference: :show_all) }
+
+        it "includes all articles" do
+          result = feed.feed
+          expect(result).to include(no_ai_post, some_ai_post, autonomous_post)
+        end
+      end
+
+      context "when feed_ai_preference is minimize_ai" do
+        before { user.setting.update(feed_ai_preference: :minimize_ai) }
+
+        it "ranks human/no_ai content higher than AI disclosed content with same baseline" do
+          result = feed.feed
+          expect(result.index(no_ai_post)).to be < result.index(some_ai_post)
+          expect(result.index(some_ai_post)).to be < result.index(autonomous_post)
+        end
+      end
+
+      context "when feed_ai_preference is hide_fully_autonomous" do
+        before { user.setting.update(feed_ai_preference: :hide_fully_autonomous) }
+
+        it "completely excludes fully autonomous articles" do
+          result = feed.feed
+          expect(result).to include(no_ai_post, some_ai_post)
+          expect(result).not_to include(autonomous_post)
+        end
+      end
+    end
   end
 end

--- a/spec/services/articles/feeds/custom_spec.rb
+++ b/spec/services/articles/feeds/custom_spec.rb
@@ -610,4 +610,43 @@ RSpec.describe Articles::Feeds::Custom, type: :service do
         .to eq(feed.method(:default_home_feed))
     end
   end
+
+  describe "AI disclosure preferences" do
+    let!(:no_ai_article) do
+      a = create(:article, published: true, score: 90, ai_disclosure_level: :no_ai)
+      a.update_column(:published_at, Time.current - 1.day)
+      a
+    end
+
+    let!(:some_ai_article) do
+      a = create(:article, published: true, score: 85, ai_disclosure_level: :some_ai)
+      a.update_column(:published_at, Time.current - 1.day)
+      a
+    end
+
+    let!(:autonomous_article) do
+      a = create(:article, published: true, score: 80, ai_disclosure_level: :fully_autonomous)
+      a.update_column(:published_at, Time.current - 1.day)
+      a
+    end
+
+    context "when user has hide_fully_autonomous preference" do
+      before { user.setting.update(feed_ai_preference: :hide_fully_autonomous) }
+
+      it "filters out fully autonomous articles from the feed" do
+        result = feed.default_home_feed.to_a
+        expect(result).to include(no_ai_article, some_ai_article)
+        expect(result).not_to include(autonomous_article)
+      end
+    end
+
+    context "when user has show_all preference" do
+      before { user.setting.update(feed_ai_preference: :show_all) }
+
+      it "includes all AI disclosure levels in the feed" do
+        result = feed.default_home_feed.to_a
+        expect(result).to include(no_ai_article, some_ai_article, autonomous_article)
+      end
+    end
+  end
 end

--- a/spec/services/articles/feeds/large_forem_experimental_spec.rb
+++ b/spec/services/articles/feeds/large_forem_experimental_spec.rb
@@ -187,4 +187,28 @@ RSpec.describe Articles::Feeds::LargeForemExperimental, type: :service do
       end
     end
   end
+
+  describe "AI disclosure preferences" do
+    let!(:no_ai_article) { create(:article, :past, past_published_at: 1.hour.ago, ai_disclosure_level: :no_ai) }
+    let!(:autonomous_article) { create(:article, :past, past_published_at: 1.hour.ago, ai_disclosure_level: :fully_autonomous) }
+
+    context "when user has hide_fully_autonomous preference" do
+      before { user.setting.update(feed_ai_preference: :hide_fully_autonomous) }
+
+      it "filters out fully autonomous articles from globally_hot_articles" do
+        _featured, stories = feed.globally_hot_articles(true)
+        expect(stories).to include(no_ai_article)
+        expect(stories).not_to include(autonomous_article)
+      end
+    end
+
+    context "when user has show_all preference" do
+      before { user.setting.update(feed_ai_preference: :show_all) }
+
+      it "includes all AI disclosure levels in globally_hot_articles" do
+        _featured, stories = feed.globally_hot_articles(true)
+        expect(stories).to include(no_ai_article, autonomous_article)
+      end
+    end
+  end
 end

--- a/spec/services/articles/feeds/variant_query_spec.rb
+++ b/spec/services/articles/feeds/variant_query_spec.rb
@@ -76,6 +76,28 @@ RSpec.describe Articles::Feeds::VariantQuery, type: :service do
           end
           # rubocop:enable Performance/CollectionLiteralInLoop
         end
+
+        context "with AI disclosure preferences" do
+          let!(:no_ai_article) { create(:article, ai_disclosure_level: :no_ai) }
+          let!(:autonomous_article) { create(:article, ai_disclosure_level: :fully_autonomous) }
+
+          context "when user has hide_fully_autonomous preference" do
+            before { user.setting.update(feed_ai_preference: :hide_fully_autonomous) }
+
+            it "filters out fully autonomous articles" do
+              expect(query_call.to_a).to include(no_ai_article)
+              expect(query_call.to_a).not_to include(autonomous_article)
+            end
+          end
+
+          context "when user has show_all preference" do
+            before { user.setting.update(feed_ai_preference: :show_all) }
+
+            it "includes all articles" do
+              expect(query_call.to_a).to include(no_ai_article, autonomous_article)
+            end
+          end
+        end
       end
 
       describe "#featured_story_and_default_home_feed" do


### PR DESCRIPTION
## Summary
Implements user feed preferences for AI-disclosed content (`feed_ai_preference`: `show_all`, `minimize_ai`, `hide_fully_autonomous`) across all Forem feed generation services, scoring engines, and settings UI, along with an **Admin Advanced Feed Configs** management interface.

### Changes
1. **Scoring & Down-Ranking (`ArticleScoreCalculatorForUser` & `FeedConfig#score_sql`)**:
   - `ArticleScoreCalculatorForUser#score_ai_disclosure`: Applies scoring deductions for `some_ai` (`-10`) and `fully_autonomous` (`-25`) when user selects `minimize_ai`, and for `some_ai` (`-10`) when user selects `hide_fully_autonomous`.
   - `FeedConfig#score_sql`: Governed dynamically by `ai_disclosure_matching_weight` when positive. Injects SQL score penalty terms (`-ai_disclosure_matching_weight` for `some_ai` and `-ai_disclosure_matching_weight * 2` for `fully_autonomous`) into the computed score expression for `minimize_ai` and `hide_fully_autonomous`, along with `autonomous_ai_penalty_weight` and genetic clone mutations.
2. **Filtering & Hard Exclusion (`Basic`, `Custom`, `Experimental`, `VariantQuery`)**:
   - When `hide_fully_autonomous` is selected, `where.not(ai_disclosure_level: :fully_autonomous)` / SQL exclusions are applied to completely omit fully autonomous AI articles from feed results.
3. **Admin Advanced Feed Configs Management UI**:
   - Added `/admin/advanced/feed_configs` route and Admin Sidebar navigation item under `Advanced`.
   - Index view showcases the current **best-performing Feed Config** (by `feed_success_score`), impressions, and weight breakdown.
   - New config creation form (`/admin/advanced/feed_configs/new`) automatically pre-populates with the attributes of the top-performing config (or any selected config via clone action), allowing admins to easily tweak any weights (AI disclosure, follow, quality, recency, discovery) to spin up new candidate configurations.
4. **i18n & Settings Copy**:
   - Updated `feed_ai_preference_desc` across English, French, and Portuguese locale files to remove the temporary 'coming soon' disclaimer.
5. **Automated Regression Tests**:
   - Full test coverage across `article_score_calculator_for_user_spec.rb`, `basic_spec.rb`, `custom_spec.rb`, `large_forem_experimental_spec.rb`, `variant_query_spec.rb`, `feed_config_spec.rb`, `admin_menu_spec.rb`, and `admin/feed_configs_spec.rb`.