### PR TITLE
Add 30 req/min rate limit for API GET requests

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -46,7 +46,21 @@ module Rack
       end
     end
 
+    throttle("api_throttle_per_minute", limit: 30, period: 1.minute) do |request|
+      api_endpoint = request.path.starts_with?("/api/")
+      if api_endpoint && request.get? && !admin_api_key?(request)
+        request.track_and_return_ip
+      end
+    end
+
     throttle("api_key_throttle", limit: 3, period: 1) do |request|
+      api_endpoint = request.path.starts_with?("/api/")
+      if api_endpoint && request.get? && !admin_api_key?(request)
+        request.env["HTTP_API_KEY"] if request.env["HTTP_API_KEY"].present?
+      end
+    end
+
+    throttle("api_key_throttle_per_minute", limit: 30, period: 1.minute) do |request|
       api_endpoint = request.path.starts_with?("/api/")
       if api_endpoint && request.get? && !admin_api_key?(request)
         request.env["HTTP_API_KEY"] if request.env["HTTP_API_KEY"].present?

--- a/spec/initializers/rack_attack_spec.rb
+++ b/spec/initializers/rack_attack_spec.rb
@@ -157,6 +157,62 @@ describe Rack, ".attack", throttle: true, type: :request do
     end
   end
 
+  describe "api_throttle_per_minute" do
+    it "throttles api get endpoints after 30 requests per minute based on IP" do
+      Timecop.freeze do
+        start_time = Time.current.beginning_of_minute
+        valid_responses = (1..30).map do |i|
+          Timecop.travel(start_time + (i * 1.5).seconds)
+          get api_articles_path, headers: { "HTTP_FASTLY_CLIENT_IP" => "5.6.7.8" }
+        end
+        Timecop.travel(start_time + 46.seconds)
+        throttled_response = get api_articles_path, headers: { "HTTP_FASTLY_CLIENT_IP" => "5.6.7.8" }
+        new_ip_response = get api_articles_path, headers: { "HTTP_FASTLY_CLIENT_IP" => "1.1.1.1" }
+
+        valid_responses.each { |r| expect(r).not_to eq(429) }
+        expect(throttled_response).to eq(429)
+        expect(new_ip_response).not_to eq(429)
+      end
+    end
+
+    it "doesn't throttle when API key provided belongs to admin" do
+      admin_api_key = create(:api_secret, user: create(:user, :admin))
+
+      Timecop.freeze do
+        start_time = Time.current.beginning_of_minute
+        headers = { "HTTP_FASTLY_CLIENT_IP" => "5.6.7.8", "api-key" => admin_api_key.secret }
+        valid_responses = (1..35).map do |i|
+          Timecop.travel(start_time + (i * 1.5).seconds)
+          get api_articles_path, headers: headers
+        end
+
+        valid_responses.each { |r| expect(r).not_to eq(429) }
+      end
+    end
+  end
+
+  describe "api_key_throttle_per_minute" do
+    it "throttles api get endpoints after 30 requests per minute based on API key across different IPs" do
+      api_secret = create(:api_secret)
+      another_api_secret = create(:api_secret)
+
+      Timecop.freeze do
+        start_time = Time.current.beginning_of_minute
+        valid_responses = (1..30).map do |i|
+          Timecop.travel(start_time + (i * 1.5).seconds)
+          get api_articles_path, headers: { "HTTP_FASTLY_CLIENT_IP" => "10.0.0.#{i}", "api-key" => api_secret.secret }
+        end
+        Timecop.travel(start_time + 46.seconds)
+        throttled_response = get api_articles_path, headers: { "HTTP_FASTLY_CLIENT_IP" => "10.0.0.99", "api-key" => api_secret.secret }
+        new_key_response = get api_articles_path, headers: { "HTTP_FASTLY_CLIENT_IP" => "10.0.0.100", "api-key" => another_api_secret.secret }
+
+        valid_responses.each { |r| expect(r).not_to eq(429) }
+        expect(throttled_response).to eq(429)
+        expect(new_key_response).not_to eq(429)
+      end
+    end
+  end
+
   describe "api_write_throttle" do
     let(:api_secret) { create(:api_secret) }
     let(:another_api_secret) { create(:api_secret) }


### PR DESCRIPTION
## Summary
Adds a sustained rate limit of 30 requests per minute for public API GET endpoints in `Rack::Attack` (in addition to the existing 3 requests/second burst limit).

- **`api_throttle_per_minute`**: Throttles `/api/*` GET requests exceeding 30 req/min per IP.
- **`api_key_throttle_per_minute`**: Throttles `/api/*` GET requests exceeding 30 req/min per API key.
- **Admin Exemption**: Requests authenticated with an admin API key continue to bypass throttling.

## Motivation
Scrapers crawling `/api/articles` (and other heavy API index endpoints) at sustained 1–2 req/sec rates were not tripping the 3 req/sec burst limit, causing heavy recurring database load. Adding a per-minute rate limit prevents sustained scraping while keeping headroom for normal usage and burst traffic.

## Testing
- Added regression tests in `spec/initializers/rack_attack_spec.rb` covering IP-based per-minute rate limiting, API key per-minute rate limiting, and admin API key exemptions.
- All 18 test examples in `spec/initializers/rack_attack_spec.rb` pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789742224&installation_model_id=424141&pr_number=23756&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23756&signature=a4493069728c50a2a97b687e067c4af6e215d411bfba65a5454d72d2ed315d50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->