### PR TITLE
Add event cover images, social cropping, and landing page visual enrichment

### DIFF
--- a/app/assets/stylesheets/views/events.scss
+++ b/app/assets/stylesheets/views/events.scss
@@ -236,3 +236,139 @@
   50% { opacity: 0.7; }
   100% { opacity: 1; }
 }
+
+.events-landing {
+  padding-bottom: var(--su-8);
+
+  .events-year-header {
+    font-size: var(--fs-2xl);
+    font-weight: 800;
+    color: var(--base-90);
+    margin-bottom: var(--su-4);
+  }
+
+  .events-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--su-4);
+
+    @media screen and (min-width: 640px) {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    @media screen and (min-width: 1024px) {
+      grid-template-columns: repeat(4, 1fr);
+    }
+  }
+
+  .event-card {
+    background: var(--card-bg, var(--base-0));
+    border: 1px solid var(--card-border, var(--base-20));
+    border-radius: var(--radius);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    text-decoration: none;
+    color: inherit;
+
+    &:hover {
+      box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.08));
+      border-color: var(--base-30);
+    }
+
+    .event-card-banner {
+      width: 100%;
+      height: 160px;
+      position: relative;
+      overflow: hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+      }
+    }
+
+    .event-card-body {
+      padding: var(--su-4);
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      gap: var(--su-3);
+    }
+
+    .event-card-title {
+      font-size: var(--fs-l);
+      font-weight: 700;
+      line-height: var(--lh-tight);
+      color: var(--base-100);
+      margin: 0;
+    }
+
+    .event-card-meta {
+      display: flex;
+      flex-direction: column;
+      gap: var(--su-2);
+      font-size: var(--fs-s);
+      color: var(--base-70);
+
+      .meta-item {
+        display: flex;
+        align-items: center;
+        gap: var(--su-2);
+
+        svg {
+          flex-shrink: 0;
+          color: var(--base-60);
+        }
+      }
+    }
+
+    .event-card-footer {
+      margin-top: auto;
+      padding-top: var(--su-2);
+    }
+
+    .event-pill {
+      display: inline-block;
+      font-size: var(--fs-xs);
+      font-weight: 700;
+      letter-spacing: 0.5px;
+      padding: 3px 8px;
+      border-radius: 4px;
+      text-transform: uppercase;
+
+      &--digital {
+        background: #eef2ff;
+        color: #4338ca;
+      }
+
+      &--in-person {
+        background: #ecfdf5;
+        color: #047857;
+      }
+
+      &--challenge {
+        background: #fef3c7;
+        color: #b45309;
+      }
+
+      &--takeover {
+        background: #f3e8ff;
+        color: #6b21a8;
+      }
+
+      &--default {
+        background: var(--base-10);
+        color: var(--base-80);
+      }
+    }
+  }
+}

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -88,6 +88,7 @@ module Admin
         :delegate_to_page,
         :cover_image,
         :remove_cover_image,
+        :bg_color_hex,
         data: {},
       )
     end

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -3,7 +3,7 @@ module Admin
     before_action :set_event, only: %i[show edit update destroy]
 
     def index
-      @events = Event.all.order(created_at: :desc)
+      @events = Event.order(created_at: :desc)
     end
 
     def show
@@ -25,6 +25,8 @@ module Admin
       redirect_to new_admin_event_path(fork_from_id: params[:id])
     end
 
+    def edit; end
+
     def create
       @event = Event.new(event_params)
       if @event.save
@@ -33,8 +35,6 @@ module Admin
         render :new, status: :unprocessable_entity
       end
     end
-
-    def edit; end
 
     def update
       if @event.update(event_params)
@@ -51,10 +51,11 @@ module Admin
 
     def end_broadcast
       @event = Event.find(params[:id])
-      
+
       if @event.update(broadcast_ended_at: Time.current)
         Events::ManageBroadcastBillboardsWorker.perform_async
-        redirect_to admin_event_path(@event), notice: "Broadcast manually ended. Billboards are being deactivated locally."
+        redirect_to admin_event_path(@event),
+                    notice: "Broadcast manually ended. Billboards are being deactivated locally."
       else
         redirect_to admin_event_path(@event), alert: "Failed to end broadcast."
       end
@@ -68,24 +69,26 @@ module Admin
 
     def event_params
       params.require(:event).permit(
-        :title, 
+        :title,
         :event_name_slug,
         :event_variation_slug,
-        :description, 
-        :primary_stream_url, 
-        :published, 
+        :description,
+        :primary_stream_url,
+        :published,
         :elevated,
-        :start_time, 
-        :end_time, 
+        :start_time,
+        :end_time,
         :type_of,
         :broadcast_config,
         :manual_broadcast_end,
-        :user_id, 
-        :organization_id, 
+        :user_id,
+        :organization_id,
         :tag_list,
         :page_id,
         :delegate_to_page,
-        data: {}
+        :cover_image,
+        :remove_cover_image,
+        data: {},
       )
     end
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -26,7 +26,11 @@ class Event < ApplicationRecord
   validates :primary_stream_url,
             format: { with: %r{\Ahttps://(www\.)?(youtube\.com|youtu\.be|twitch\.tv|player\.twitch\.tv|streamyard\.com)/.*\z}, message: "must be a valid HTTPS YouTube, Twitch, or Streamyard URL" }, allow_blank: true
   validates :page, presence: true, if: :delegate_to_page?
+  validates :bg_color_hex,
+            format: { with: /\A#[0-9a-fA-F]{6}\z/, message: "must be a valid 6-digit hex color (e.g. #3B49DF)" },
+            allow_blank: true
 
+  before_validation :set_default_bg_color_hex
   before_save :format_stream_urls
   after_commit :ensure_broadcast_billboards_and_workers, on: %i[create update]
   after_commit :bust_upcoming_events_cache, on: %i[create update destroy]
@@ -47,9 +51,15 @@ class Event < ApplicationRecord
 
   mount_uploader :cover_image, EventCoverImageUploader
 
-  def background_hex_color
+  def set_default_bg_color_hex
+    return if bg_color_hex.present?
+
     first_supported = tags.detect { |t| t.supported? && t.bg_color_hex.present? }
-    return first_supported.bg_color_hex if first_supported.present?
+    self.bg_color_hex = first_supported.bg_color_hex if first_supported.present?
+  end
+
+  def background_hex_color
+    return bg_color_hex if bg_color_hex.present?
 
     color_index = (id || title.to_s.bytes.sum) % DEFAULT_HEX_COLORS.size
     DEFAULT_HEX_COLORS[color_index]
@@ -87,8 +97,8 @@ class Event < ApplicationRecord
   def formatted_date_range
     return "" if start_time.blank?
 
-    start_date = start_time.utc.to_date
-    end_date = end_time&.utc&.to_date || start_date
+    start_date = start_time.to_date
+    end_date = (end_time || start_time).to_date
 
     if start_date == end_date
       start_date.strftime("%b %-d").upcase

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,7 +7,7 @@ class Event < ApplicationRecord
   belongs_to :organization, optional: true
   belongs_to :page, optional: true
 
-  has_many :billboards, foreign_key: :event_id, dependent: :destroy
+  has_many :billboards, dependent: :destroy
   has_many :event_signups, dependent: :destroy
   has_many :signed_up_users, through: :event_signups, source: :user
   has_many :emails, dependent: :nullify
@@ -18,26 +18,104 @@ class Event < ApplicationRecord
   validates :title, presence: true
   validates :start_time, presence: true
   validates :end_time, presence: true
-  validates :event_name_slug, presence: true, format: { with: /\A[a-z0-9-]+\z/, message: "can only contain lowercase letters, numbers, and dashes" }
-  validates :event_variation_slug, presence: true, format: { with: /\A[a-z0-9-]+\z/, message: "can only contain lowercase letters, numbers, and dashes" }, uniqueness: { scope: :event_name_slug, case_sensitive: false }
+  validates :event_name_slug, presence: true,
+                              format: { with: /\A[a-z0-9-]+\z/, message: "can only contain lowercase letters, numbers, and dashes" }
+  validates :event_variation_slug, presence: true,
+                                   format: { with: /\A[a-z0-9-]+\z/, message: "can only contain lowercase letters, numbers, and dashes" }, uniqueness: { scope: :event_name_slug, case_sensitive: false }
   validate :end_time_after_start_time
-  validates :primary_stream_url, format: { with: /\Ahttps:\/\/(www\.)?(youtube\.com|youtu\.be|twitch\.tv|player\.twitch\.tv|streamyard\.com)\/.*\z/, message: "must be a valid HTTPS YouTube, Twitch, or Streamyard URL" }, allow_blank: true
+  validates :primary_stream_url,
+            format: { with: %r{\Ahttps://(www\.)?(youtube\.com|youtu\.be|twitch\.tv|player\.twitch\.tv|streamyard\.com)/.*\z}, message: "must be a valid HTTPS YouTube, Twitch, or Streamyard URL" }, allow_blank: true
   validates :page, presence: true, if: :delegate_to_page?
 
   before_save :format_stream_urls
-  after_commit :ensure_broadcast_billboards_and_workers, on: [:create, :update]
-  after_commit :bust_upcoming_events_cache, on: [:create, :update, :destroy]
+  after_commit :ensure_broadcast_billboards_and_workers, on: %i[create update]
+  after_commit :bust_upcoming_events_cache, on: %i[create update destroy]
 
   scope :published, -> { where(published: true) }
   scope :elevated, -> { where(elevated: true) }
 
+  DEFAULT_HEX_COLORS = ["#3B49DF", "#0D9488", "#7C3AED", "#DB2777", "#D97706"].freeze
   def self.active_broadcast_events
     Rails.cache.fetch("active_broadcast_events", expires_in: 30.seconds) do
       published
         .where.not(broadcast_config: "no_broadcast")
-        .where("start_time <= ? AND end_time >= ?", Time.current + 15.minutes, Time.current - 5.minutes)
+        .where("start_time <= ? AND end_time >= ?", 15.minutes.from_now, 5.minutes.ago)
         .select(:id, :broadcast_config, :start_time, :end_time, :tags_array)
         .to_a
+    end
+  end
+
+  mount_uploader :cover_image, EventCoverImageUploader
+
+  def background_hex_color
+    first_supported = tags.detect { |t| t.supported? && t.bg_color_hex.present? }
+    return first_supported.bg_color_hex if first_supported.present?
+
+    color_index = (id || title.to_s.bytes.sum) % DEFAULT_HEX_COLORS.size
+    DEFAULT_HEX_COLORS[color_index]
+  end
+
+  def gradient_background_css
+    base_hex = background_hex_color
+    dark_hex = adjust_hex_brightness(base_hex, 0.65)
+    "linear-gradient(135deg, #{base_hex} 0%, #{dark_hex} 100%)"
+  end
+
+  def adjust_hex_brightness(hex, factor)
+    clean_hex = hex.to_s.delete("#")
+    return "#18181A" unless clean_hex.match?(/\A[0-9a-fA-F]{6}\z/)
+
+    r = (clean_hex[0..1].to_i(16) * factor).round.clamp(0, 255)
+    g = (clean_hex[2..3].to_i(16) * factor).round.clamp(0, 255)
+    b = (clean_hex[4..5].to_i(16) * factor).round.clamp(0, 255)
+
+    format("#%<r>02x%<g>02x%<b>02x", r: r, g: g, b: b)
+  end
+
+  def social_image_url
+    if cover_image.present?
+      if cover_image.respond_to?(:social) && cover_image.social.present? && cover_image.social.url.present?
+        cover_image.social.url
+      else
+        cover_image.url
+      end
+    else
+      Settings::General.main_social_image.to_s
+    end
+  end
+
+  def formatted_date_range
+    return "" if start_time.blank?
+
+    start_date = start_time.utc.to_date
+    end_date = end_time&.utc&.to_date || start_date
+
+    if start_date == end_date
+      start_date.strftime("%b %-d").upcase
+    elsif start_date.month == end_date.month && start_date.year == end_date.year
+      "#{start_date.strftime('%b %-d').upcase} - #{end_date.strftime('%-d')}"
+    else
+      "#{start_date.strftime('%b %-d').upcase} - #{end_date.strftime('%b %-d').upcase}"
+    end
+  end
+
+  def location_display
+    data&.dig("location") || data&.dig(:location) || "Everywhere, Worldwide"
+  end
+
+  def format_pill_label
+    custom_format = data&.dig("format") || data&.dig(:format)
+    return custom_format.to_s.upcase if custom_format.present?
+
+    case type_of
+    when "live_stream"
+      "DIGITAL"
+    when "challenge"
+      "CHALLENGE"
+    when "takeover"
+      "TAKEOVER"
+    else
+      "EVENT"
     end
   end
 
@@ -62,9 +140,9 @@ class Event < ApplicationRecord
   def end_time_after_start_time
     return if end_time.blank? || start_time.blank?
 
-    if end_time < start_time
-      errors.add(:end_time, "must be after the start time")
-    end
+    return unless end_time < start_time
+
+    errors.add(:end_time, "must be after the start time")
   end
 
   def format_stream_urls
@@ -74,31 +152,30 @@ class Event < ApplicationRecord
     self.data ||= {}
 
     youtube_match = primary_stream_url.match(%r{(?:youtu\.be/|youtube\.com/(?:watch\?v=|embed/|live/|v/|shorts/))([a-zA-Z0-9_-]{11})}i) ||
-                    primary_stream_url.match(%r{[?&]v=([a-zA-Z0-9_-]{11})}i) ||
-                    primary_stream_url.match(/\A([a-zA-Z0-9_-]{11})\z/)
+      primary_stream_url.match(/[?&]v=([a-zA-Z0-9_-]{11})/i) ||
+      primary_stream_url.match(/\A([a-zA-Z0-9_-]{11})\z/)
 
     if youtube_match
       video_id = youtube_match[1]
       self.primary_stream_url = "https://www.youtube.com/embed/#{video_id}?autoplay=1"
       self.data["chat_url"] = "https://www.youtube.com/live_chat?v=#{video_id}&embed_domain=#{app_domain}"
-    elsif primary_stream_url.match?(%r{twitch\.tv}i)
+    elsif primary_stream_url.match?(/twitch\.tv/i)
       channel_name = nil
-      if primary_stream_url.include?("channel=")
-        match = primary_stream_url.match(/channel=([a-zA-Z0-9_]+)/i)
-        channel_name = match[1] if match
-      else
-        match = primary_stream_url.match(%r{twitch\.tv/([a-zA-Z0-9_]+)}i)
-        channel_name = match[1] if match
-      end
+      match = if primary_stream_url.include?("channel=")
+                primary_stream_url.match(/channel=([a-zA-Z0-9_]+)/i)
+              else
+                primary_stream_url.match(%r{twitch\.tv/([a-zA-Z0-9_]+)}i)
+              end
+      channel_name = match[1] if match
 
-      if channel_name && !%w[videos clip clips directory].include?(channel_name.downcase)
+      if channel_name && %w[videos clip clips directory].exclude?(channel_name.downcase)
         self.primary_stream_url = "https://player.twitch.tv/?channel=#{channel_name}&parent=#{app_domain}"
         self.data["chat_url"] = "https://www.twitch.tv/embed/#{channel_name}/chat?parent=#{app_domain}"
       end
-    elsif primary_stream_url.match?(%r{streamyard\.com}i)
+    elsif primary_stream_url.match?(/streamyard\.com/i)
       begin
         uri = URI.parse(primary_stream_url)
-        path_segments = uri.path.split('/').reject(&:blank?)
+        path_segments = uri.path.split("/").compact_blank
         if path_segments.any?
           streamyard_id = path_segments.last
           self.primary_stream_url = "https://streamyard.com/e/#{streamyard_id}"
@@ -123,8 +200,8 @@ class Event < ApplicationRecord
 
     prefix = takeover? ? "takeover" : "live_now"
     stream_hour = start_time.strftime("%H")
-    base_name = "#{prefix}_#{Time.now.strftime('%B').downcase}_#{Time.now.strftime('%d')}_#{stream_hour}_#{Time.now.strftime('%Y')}"
-    
+    base_name = "#{prefix}_#{Time.zone.now.strftime('%B').downcase}_#{Time.zone.now.strftime('%d')}_#{stream_hour}_#{Time.zone.now.strftime('%Y')}"
+
     custom_display_label = takeover? ? "#{Settings::Community.community_name} Takeovers" : "#{Settings::Community.community_name} Live Events"
 
     # Only process if it has a published state linking (though we generate them regardless)
@@ -141,7 +218,7 @@ class Event < ApplicationRecord
       render_mode: "raw",
       template: "authorship_box",
       approved: home_feed_bb.new_record? ? false : home_feed_bb.approved,
-      published: true
+      published: true,
     )
 
     post_bottom_bb = billboards.find_or_initialize_by(placement_area: "post_fixed_bottom")

--- a/app/uploaders/event_cover_image_uploader.rb
+++ b/app/uploaders/event_cover_image_uploader.rb
@@ -1,0 +1,26 @@
+class EventCoverImageUploader < BaseUploader
+  MAX_FILE_SIZE = 25.megabytes
+
+  def filename
+    "#{secure_token}.#{file.extension}" if file.present?
+  end
+
+  def size_range
+    1..MAX_FILE_SIZE
+  end
+
+  def store_dir
+    "uploads/events/cover_image/#{model.id}"
+  end
+
+  version :social do
+    process resize_to_fill: [1200, 630]
+  end
+
+  protected
+
+  def secure_token
+    var = :"@#{mounted_as}_secure_token"
+    model.instance_variable_get(var) || model.instance_variable_set(var, SecureRandom.uuid)
+  end
+end

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -39,6 +39,23 @@
       <%= form.text_area :description, class: "crayons-textfield", rows: 3 %>
     </div>
 
+    <div class="crayons-field">
+      <%= form.label :cover_image, "Cover Image", class: "crayons-field__label" do %>
+        Cover Image
+        <p class="crayons-field__description">Upload a cover image for this event. It will be used for social preview cards (og:image) and the events landing page.</p>
+      <% end %>
+      <% if event.cover_image.present? %>
+        <div class="mb-3">
+          <img src="<%= event.cover_image.url %>" alt="Cover Image Preview" style="max-width: 360px; height: auto; border-radius: var(--radius); display: block; margin-bottom: 8px; border: 1px solid var(--card-border);" />
+          <label class="crayons-field crayons-field--checkbox flex items-center gap-2">
+            <%= form.check_box :remove_cover_image, class: "crayons-checkbox" %>
+            <span class="fs-s">Remove cover image</span>
+          </label>
+        </div>
+      <% end %>
+      <%= form.file_field :cover_image, accept: "image/*", class: "crayons-file-field" %>
+    </div>
+
     <div class="grid grid-cols-2 gap-4">
       <div class="crayons-field">
         <%= form.label :type_of, "Event Type", class: "crayons-field__label" %>
@@ -80,6 +97,28 @@
         <% end %>
         <input type="text" name="event[data][auto_follow_tag_names]" id="event_data_auto_follow_tag_names" class="crayons-textfield" value="<%= event.data&.dig('auto_follow_tag_names') %>" placeholder="e.g., devchallenge, writeathon">
       <% end %>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4">
+      <div class="crayons-field">
+        <%= form.fields_for :data, event.data || {} do |data_form| %>
+          <%= data_form.label :location, "Location Display", class: "crayons-field__label" do %>
+            Location Display
+            <p class="crayons-field__description">e.g. 'Everywhere, Worldwide, US' or 'Chennai, Tamilnadu, IN'</p>
+          <% end %>
+          <input type="text" name="event[data][location]" id="event_data_location" class="crayons-textfield" value="<%= event.data&.dig('location') || event.data&.dig(:location) %>" placeholder="Everywhere, Worldwide, US">
+        <% end %>
+      </div>
+
+      <div class="crayons-field">
+        <%= form.fields_for :data, event.data || {} do |data_form| %>
+          <%= data_form.label :format, "Event Format Badge", class: "crayons-field__label" do %>
+            Event Format Badge
+            <p class="crayons-field__description">e.g. 'DIGITAL', 'IN-PERSON', 'HYBRID' (defaults to type)</p>
+          <% end %>
+          <input type="text" name="event[data][format]" id="event_data_format" class="crayons-textfield" value="<%= event.data&.dig('format') || event.data&.dig(:format) %>" placeholder="DIGITAL">
+        <% end %>
+      </div>
     </div>
 
     <div class="crayons-field">

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -129,6 +129,19 @@
       <%= form.text_field :tag_list, value: event.tag_list.join(", "), class: "crayons-textfield", placeholder: "aws, ai, streaming" %>
     </div>
 
+    <div class="crayons-field">
+      <%= form.label :bg_color_hex, "Background Hex Color", class: "crayons-field__label" do %>
+        Background Hex Color
+        <p class="crayons-field__description">Optional 6-digit hex color (e.g., '#3B49DF'). If left blank, automatically derived from the first supported tag or default palette fallback.</p>
+      <% end %>
+      <div class="flex items-center gap-2">
+        <%= form.text_field :bg_color_hex, class: "crayons-textfield", placeholder: "#3B49DF", style: "max-width: 240px;" %>
+        <% if event.bg_color_hex.present? %>
+          <span style="display:inline-block; width: 28px; height: 28px; border-radius: 4px; background: <%= event.bg_color_hex %>; border: 1px solid var(--card-border);"></span>
+        <% end %>
+      </div>
+    </div>
+
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div class="crayons-field">
         <%= form.label :start_time, class: "crayons-field__label" do %>

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -15,9 +15,17 @@
         <li><strong>Title:</strong> <%= @event.title %></li>
         <li><strong>Event Name Slug:</strong> <%= @event.event_name_slug %></li>
         <li><strong>Event Variation Slug:</strong> <%= @event.event_variation_slug %></li>
-        <li><strong>Description:</strong> <%= @event.description %></li>
         <li><strong>Tags:</strong> <%= @event.tag_list.join(", ") %></li>
-        <li><strong>Background Color:</strong> <span style="display:inline-block; width:16px; height:16px; background-color:<%= @event.background_hex_color %>; vertical-align:middle; border-radius:3px; margin-right:4px;"></span> <%= @event.background_hex_color %></li>
+        <li>
+          <strong>Background Color:</strong>
+          <span style="display:inline-block; width:16px; height:16px; background-color:<%= @event.background_hex_color %>; vertical-align:middle; border-radius:3px; margin-right:4px; border: 1px solid var(--card-border);"></span>
+          <%= @event.background_hex_color %>
+          <% if @event.bg_color_hex.present? %>
+            <span class="text-xs opacity-75">(stored)</span>
+          <% else %>
+            <span class="text-xs opacity-75">(dynamic fallback)</span>
+          <% end %>
+        </li>
         <% if @event.cover_image.present? %>
           <li>
             <strong>Cover Image:</strong>

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -17,6 +17,15 @@
         <li><strong>Event Variation Slug:</strong> <%= @event.event_variation_slug %></li>
         <li><strong>Description:</strong> <%= @event.description %></li>
         <li><strong>Tags:</strong> <%= @event.tag_list.join(", ") %></li>
+        <li><strong>Background Color:</strong> <span style="display:inline-block; width:16px; height:16px; background-color:<%= @event.background_hex_color %>; vertical-align:middle; border-radius:3px; margin-right:4px;"></span> <%= @event.background_hex_color %></li>
+        <% if @event.cover_image.present? %>
+          <li>
+            <strong>Cover Image:</strong>
+            <div class="mt-2">
+              <img src="<%= @event.cover_image.url %>" alt="Cover Image" style="max-width: 320px; border-radius: var(--radius); border: 1px solid var(--card-border);" />
+            </div>
+          </li>
+        <% end %>
       </ul>
     </div>
     

--- a/app/views/events/challenge.html.erb
+++ b/app/views/events/challenge.html.erb
@@ -1,6 +1,18 @@
+<% content_for :title, @event.title %>
+<%= content_for :page_meta do %>
+  <link rel="canonical" href="<%= app_url(event_path(@event.event_name_slug, @event.event_variation_slug)) %>" />
+  <meta name="description" content="<%= @event.description %>">
+  <meta property="og:title" content="<%= @event.title %>" />
+  <meta property="og:description" content="<%= @event.description %>" />
+  <meta property="og:url" content="<%= app_url(event_path(@event.event_name_slug, @event.event_variation_slug)) %>" />
+  <meta property="og:type" content="event" />
+  <meta property="og:image" content="<%= @event.social_image_url %>" />
+  <meta name="twitter:image:src" content="<%= @event.social_image_url %>">
+  <meta name="twitter:card" content="summary_large_image">
+<% end %>
 <div class="crayons-layout event-show-layout container">
   <!-- Banner Image -->
-  <% banner_image = @event.data&.dig('banner_image_url') %>
+  <% banner_image = @event.cover_image.presence&.url || @event.data&.dig('banner_image_url') %>
   <% if banner_image.present? %>
     <div class="crayons-card mb-6 overflow-hidden">
       <img src="<%= banner_image %>" alt="<%= @event.title %>" class="w-100" style="max-height: 400px; object-fit: cover; display: block;">

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,34 +1,94 @@
-<main id="main-content" class="crayons-layout crayons-layout--header-inside">
-  <header class="crayons-page-header">
-    <h1 class="crayons-title">Upcoming Events</h1>
+<% content_for :title, t("views.events.meta.title") %>
+<%= content_for :page_meta do %>
+  <link rel="canonical" href="<%= app_url(events_path) %>" />
+  <meta name="description" content="<%= t("views.events.meta.description") %>">
+  <meta property="og:title" content="<%= t("views.events.meta.title") %>" />
+  <meta property="og:description" content="<%= t("views.events.meta.description") %>" />
+  <meta property="og:url" content="<%= app_url(events_path) %>" />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="<%= Settings::General.main_social_image %>" />
+  <meta name="twitter:image:src" content="<%= Settings::General.main_social_image %>">
+  <meta name="twitter:card" content="summary_large_image">
+<% end %>
+
+<main id="main-content" class="crayons-layout crayons-layout--header-inside events-landing">
+  <header class="crayons-page-header flex items-center justify-between flex-wrap gap-3 mb-6">
+    <h1 class="events-year-header m-0"><%= Time.current.year %></h1>
+
+    <div class="flex items-center gap-2">
+      <%= link_to calendar_path, class: "crayons-btn crayons-btn--secondary flex items-center gap-2" do %>
+        <svg class="c-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+          <line x1="16" y1="2" x2="16" y2="6"></line>
+          <line x1="8" y1="2" x2="8" y2="6"></line>
+          <line x1="3" y1="10" x2="21" y2="10"></line>
+        </svg>
+        <span><%= t("views.events.view_on_calendar") %></span>
+      <% end %>
+    </div>
   </header>
   
   <% if @events.any? %>
-    <div class="grid gap-3 m:gap-4 l:gap-4 m:grid-cols-2 l:grid-cols-3 px-3 m:px-0 pb-7">
+    <div class="events-grid">
       <% @events.each do |event| %>
-        <div class="crayons-card p-4 flex flex-col justify-between">
-          <div>
-            <div class="flex items-center justify-between mb-2">
-              <span class="fs-s fw-bold color-base-50"><%= event.type_of.to_s.titleize %></span>
-              <% if event.start_time <= Time.current && event.end_time >= Time.current %>
-                <span class="c-indicator c-indicator--error fw-bold">LIVE</span>
-              <% else %>
-                <span class="fs-s color-base-50"><%= event.start_time.to_fs(:short) %></span>
-              <% end %>
-            </div>
-            <h2 class="crayons-subtitle-2 mb-2">
-              <% link_target = (event.delegate_to_page? && event.page.present?) ? event.page.path : event_path(event.event_name_slug, event.event_variation_slug) %>
-              <%= link_to event.title, link_target, class: "crayons-link" %>
-            </h2>
-            <p class="fs-s color-base-70 mb-4"><%= event.description %></p>
+        <% link_target = (event.delegate_to_page? && event.page.present?) ? event.page.path : event_path(event.event_name_slug, event.event_variation_slug) %>
+        <a href="<%= link_target %>" class="event-card">
+          <div class="event-card-banner" <% unless event.cover_image.present? %>style="background: <%= event.gradient_background_css %>;"<% end %>>
+            <% if event.cover_image.present? %>
+              <img src="<%= event.cover_image.url %>" alt="<%= event.title %> Cover" loading="lazy" />
+            <% end %>
           </div>
-          <%= link_to "View Event", link_target, class: "c-btn w-100 text-center" %>
-        </div>
+
+          <div class="event-card-body">
+            <div>
+              <h2 class="event-card-title mb-3">
+                <%= event.title %>
+              </h2>
+
+              <div class="event-card-meta">
+                <div class="meta-item">
+                  <svg class="c-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+                    <line x1="16" y1="2" x2="16" y2="6"></line>
+                    <line x1="8" y1="2" x2="8" y2="6"></line>
+                    <line x1="3" y1="10" x2="21" y2="10"></line>
+                  </svg>
+                  <span><%= event.formatted_date_range %></span>
+                </div>
+
+                <div class="meta-item">
+                  <svg class="c-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"></path>
+                    <circle cx="12" cy="10" r="3"></circle>
+                  </svg>
+                  <span><%= event.location_display %></span>
+                </div>
+              </div>
+            </div>
+
+            <div class="event-card-footer">
+              <% pill_label = event.format_pill_label %>
+              <% pill_class = case pill_label.downcase
+                              when "digital", "live stream"
+                                "event-pill--digital"
+                              when "in-person", "in person"
+                                "event-pill--in-person"
+                              when "challenge"
+                                "event-pill--challenge"
+                              when "takeover"
+                                "event-pill--takeover"
+                              else
+                                "event-pill--default"
+                              end %>
+              <span class="event-pill <%= pill_class %>"><%= pill_label %></span>
+            </div>
+          </div>
+        </a>
       <% end %>
     </div>
   <% else %>
     <div class="p-9 align-center crayons-card">
-      <p class="text-center color-base-60 py-8">No upcoming events scheduled right now. Check back soon!</p>
+      <p class="text-center color-base-60 py-8"><%= t("views.events.no_events") %></p>
     </div>
   <% end %>
 </main>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,5 +1,16 @@
 <!-- Forem Event Show Page -->
 <% content_for :title, @event.title %>
+<%= content_for :page_meta do %>
+  <link rel="canonical" href="<%= app_url(event_path(@event.event_name_slug, @event.event_variation_slug)) %>" />
+  <meta name="description" content="<%= @event.description %>">
+  <meta property="og:title" content="<%= @event.title %>" />
+  <meta property="og:description" content="<%= @event.description %>" />
+  <meta property="og:url" content="<%= app_url(event_path(@event.event_name_slug, @event.event_variation_slug)) %>" />
+  <meta property="og:type" content="event" />
+  <meta property="og:image" content="<%= @event.social_image_url %>" />
+  <meta name="twitter:image:src" content="<%= @event.social_image_url %>">
+  <meta name="twitter:card" content="summary_large_image">
+<% end %>
 <div class="container crayons-layout event-show-layout">
     <% if !@event.published? %>
       <div class="crayons-notice crayons-notice--warning mb-8 p-4 text-center">

--- a/config/locales/views/events/en.yml
+++ b/config/locales/views/events/en.yml
@@ -1,0 +1,9 @@
+---
+en:
+  views:
+    events:
+      meta:
+        title: Upcoming Events
+        description: Discover upcoming virtual events, challenges, streams, and hackathons.
+      view_on_calendar: View on Calendar
+      no_events: No upcoming events scheduled right now. Check back soon!

--- a/config/locales/views/events/fr.yml
+++ b/config/locales/views/events/fr.yml
@@ -1,0 +1,9 @@
+---
+fr:
+  views:
+    events:
+      meta:
+        title: Événements à venir
+        description: Découvrez les événements virtuels, défis, streams et hackathons à venir.
+      view_on_calendar: Voir sur le calendrier
+      no_events: Aucun événement à venir n'est programmé pour le moment. Revenez bientôt !

--- a/config/locales/views/events/pt.yml
+++ b/config/locales/views/events/pt.yml
@@ -1,0 +1,9 @@
+---
+pt:
+  views:
+    events:
+      meta:
+        title: Próximos Eventos
+        description: Descubra os próximos eventos virtuais, desafios, transmissões e hackathons.
+      view_on_calendar: Ver no calendário
+      no_events: Nenhum evento agendado no momento. Volte em breve!

--- a/db/migrate/20260819150645_add_cover_image_to_events.rb
+++ b/db/migrate/20260819150645_add_cover_image_to_events.rb
@@ -1,0 +1,5 @@
+class AddCoverImageToEvents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :events, :cover_image, :string
+  end
+end

--- a/db/migrate/20260819181500_add_bg_color_hex_to_events.rb
+++ b/db/migrate/20260819181500_add_bg_color_hex_to_events.rb
@@ -1,0 +1,5 @@
+class AddBgColorHexToEvents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :events, :bg_color_hex, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_14_130200) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_19_150645) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -774,6 +774,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_14_130200) do
     t.integer "broadcast_config", default: 0
     t.datetime "broadcast_ended_at"
     t.string "cached_tag_list"
+    t.string "cover_image"
     t.datetime "created_at", null: false
     t.jsonb "data", default: {}
     t.boolean "delegate_to_page", default: false, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_19_150645) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_19_181500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -771,6 +771,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_19_150645) do
   end
 
   create_table "events", force: :cascade do |t|
+    t.string "bg_color_hex"
     t.integer "broadcast_config", default: 0
     t.datetime "broadcast_ended_at"
     t.string "cached_tag_list"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1174,14 +1174,121 @@ PinnedArticle.set(first_article) if first_article.present?
 
 seeder.create_if_none(Event) do
   user_ids = User.pluck(:id)
+  app_host = Settings::General.app_domain.split(":").first
   
-  aws_event = Event.create!(
+  sample_events = []
+
+  # 1. Events with uploaded cover images
+  sample_events << Event.create!(
+    title: "Midnight Virtual Hackathon",
+    event_name_slug: "midnight-hackathon",
+    event_variation_slug: "aug-2026",
+    description: "36 hours of virtual hacking, community building, and shipping innovative apps.",
+    cover_image: Rails.root.join("app/assets/images/1.png").open,
+    primary_stream_url: "https://player.twitch.tv/?channel=ThePracticalDev&parent=#{app_host}",
+    data: { "location" => "Everywhere, Worldwide, US", "format" => "DIGITAL" },
+    published: true,
+    start_time: Time.zone.parse("2026-08-28 12:00:00"),
+    end_time: Time.zone.parse("2026-08-30 23:59:59"),
+    type_of: :live_stream,
+    user_id: user_ids.sample,
+    tag_list: "hackathon, javascript"
+  )
+
+  sample_events << Event.create!(
+    title: "Global Hack Week: Data",
+    event_name_slug: "ghw-data",
+    event_variation_slug: "sept-2026",
+    description: "A week-long celebration of data science, machine learning, and analytics.",
+    cover_image: Rails.root.join("app/assets/images/2.png").open,
+    primary_stream_url: "https://player.twitch.tv/?channel=ThePracticalDev&parent=#{app_host}",
+    data: { "location" => "Everywhere, Worldwide", "format" => "DIGITAL" },
+    published: true,
+    start_time: Time.zone.parse("2026-09-11 09:00:00"),
+    end_time: Time.zone.parse("2026-09-17 18:00:00"),
+    type_of: :live_stream,
+    user_id: user_ids.sample,
+    tag_list: "data, python"
+  )
+
+  # 2. Events with supported tag background colors (e.g. ruby, ai)
+  ruby_tag = Tag.find_or_create_by!(name: "ruby") do |t|
+    t.supported = true
+    t.bg_color_hex = "#CC342D"
+    t.text_color_hex = "#FFFFFF"
+  end
+  ruby_tag.update_columns(supported: true, bg_color_hex: "#CC342D")
+
+  sample_events << Event.create!(
+    title: "Ruby & Rails World Conference 2026",
+    event_name_slug: "ruby-rails-world-conf",
+    event_variation_slug: "2026",
+    description: "Deep dive into modern Rails 8, performance tuning, and full-stack Ruby architecture.",
+    data: { "location" => "Tokyo, Japan", "format" => "IN-PERSON" },
+    published: true,
+    start_time: Time.zone.parse("2026-08-29 08:00:00"),
+    end_time: Time.zone.parse("2026-08-30 19:00:00"),
+    type_of: :other,
+    user_id: user_ids.sample,
+    tag_list: "ruby"
+  )
+
+  ai_tag = Tag.find_or_create_by!(name: "ai") do |t|
+    t.supported = true
+    t.bg_color_hex = "#0D9488"
+    t.text_color_hex = "#FFFFFF"
+  end
+  ai_tag.update_columns(supported: true, bg_color_hex: "#0D9488")
+
+  sample_events << Event.create!(
+    title: "AI Developers & Agents Summit",
+    event_name_slug: "ai-developers-summit",
+    event_variation_slug: "fall-2026",
+    description: "Exploring the next generation of autonomous coding agents and LLM tooling.",
+    data: { "location" => "San Francisco, CA, US", "format" => "HYBRID" },
+    published: true,
+    start_time: Time.zone.parse("2026-09-05 10:00:00"),
+    end_time: Time.zone.parse("2026-09-07 17:00:00"),
+    type_of: :other,
+    user_id: user_ids.sample,
+    tag_list: "ai"
+  )
+
+  # 3. Events without images or tags (testing default 5-hex gradient palette)
+  sample_events << Event.create!(
+    title: "PEC HACKS 4.0",
+    event_name_slug: "pec-hacks",
+    event_variation_slug: "v4",
+    description: "Premier collegiate hackathon bringing student developers together for 36 hours.",
+    data: { "location" => "Chennai, Tamilnadu, IN", "format" => "IN-PERSON" },
+    published: true,
+    start_time: Time.zone.parse("2026-08-29 09:00:00"),
+    end_time: Time.zone.parse("2026-08-30 18:00:00"),
+    type_of: :other,
+    user_id: user_ids.sample
+  )
+
+  sample_events << Event.create!(
+    title: "HackRice XIII",
+    event_name_slug: "hackrice",
+    event_variation_slug: "13",
+    description: "Rice University's annual hackathon empowering creators to build the future.",
+    data: { "location" => "Houston, Texas, US", "format" => "IN-PERSON" },
+    published: true,
+    start_time: Time.zone.parse("2026-09-11 10:00:00"),
+    end_time: Time.zone.parse("2026-09-13 16:00:00"),
+    type_of: :other,
+    user_id: user_ids.sample
+  )
+
+  # 4. Standard live streams and challenges
+  sample_events << Event.create!(
     title: "AWS Industries LIVE!",
     event_name_slug: "aws-industries-live",
     event_variation_slug: "v1",
-    description: "AWS Industries LIVE! features AWS Partners discussing various topics related to their industry, their solutions, and how they can help customers.",
-    primary_stream_url: "https://player.twitch.tv/?channel=aws&parent=#{Settings::General.app_domain.split(':').first}",
-    data: { chat_url: "https://www.twitch.tv/embed/aws/chat?parent=#{Settings::General.app_domain.split(':').first}" },
+    description: "AWS Partners discussing various topics related to their industry and cloud solutions.",
+    primary_stream_url: "https://player.twitch.tv/?channel=aws&parent=#{app_host}",
+    data: { "chat_url" => "https://www.twitch.tv/embed/aws/chat?parent=#{app_host}", "location" => "Everywhere, Worldwide", "format" => "DIGITAL" },
     published: true,
     start_time: 1.day.ago,
     end_time: 1.week.from_now,
@@ -1189,24 +1296,8 @@ seeder.create_if_none(Event) do
     user_id: user_ids.sample,
     tag_list: "aws"
   )
-  
-  forem_event = Event.create!(
-    title: "Forem Walkthrough with Ben Halpern",
-    event_name_slug: "forem-walkthrough-with-ben-halpern",
-    event_variation_slug: "v1",
-    description: "Join us for a walkthrough of the newest Forem features.",
-    primary_stream_url: "https://player.twitch.tv/?channel=ThePracticalDev&parent=#{Settings::General.app_domain.split(':').first}",
-    data: {},
-    published: true,
-    start_time: 2.days.from_now,
-    end_time: 2.days.from_now + 2.hours,
-    type_of: :live_stream,
-    user_id: user_ids.sample,
-    tag_list: "forem, updates"
-  )
 
-  # Automatically approve the billboards generated by the callbacks for these events
-  [aws_event, forem_event].each do |event|
+  sample_events.each do |event|
     event.billboards.update_all(approved: true)
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1254,12 +1254,13 @@ seeder.create_if_none(Event) do
     tag_list: "ai"
   )
 
-  # 3. Events without images or tags (testing default 5-hex gradient palette)
+  # 3. Events testing explicit bg_color_hex and default 5-hex gradient palette
   sample_events << Event.create!(
     title: "PEC HACKS 4.0",
     event_name_slug: "pec-hacks",
     event_variation_slug: "v4",
     description: "Premier collegiate hackathon bringing student developers together for 36 hours.",
+    bg_color_hex: "#7C3AED",
     data: { "location" => "Chennai, Tamilnadu, IN", "format" => "IN-PERSON" },
     published: true,
     start_time: Time.zone.parse("2026-08-29 09:00:00"),
@@ -1273,6 +1274,7 @@ seeder.create_if_none(Event) do
     event_name_slug: "hackrice",
     event_variation_slug: "13",
     description: "Rice University's annual hackathon empowering creators to build the future.",
+    bg_color_hex: nil,
     data: { "location" => "Houston, Texas, US", "format" => "IN-PERSON" },
     published: true,
     start_time: Time.zone.parse("2026-09-11 10:00:00"),

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -228,24 +228,55 @@ RSpec.describe Event do
     end
   end
 
-  describe "#background_hex_color" do
-    let(:event) { create(:event, id: 1, title: "Special Community Event") }
+  describe "bg_color_hex validation" do
+    it "validates format of bg_color_hex when present" do
+      valid_event = build(:event, bg_color_hex: "#3B49DF")
+      invalid_event = build(:event, bg_color_hex: "invalid-hex")
+      short_event = build(:event, bg_color_hex: "#123")
 
-    it "returns the hex color of the first supported tag with bg_color_hex" do
+      expect(valid_event).to be_valid
+      expect(invalid_event).not_to be_valid
+      expect(short_event).not_to be_valid
+    end
+  end
+
+  describe "#set_default_bg_color_hex" do
+    it "preserves explicitly assigned bg_color_hex" do
       supported_tag = create(:tag, name: "ruby", supported: true, bg_color_hex: "#CC342D")
+      event = create(:event, bg_color_hex: "#7C3AED")
       event.tags << supported_tag
+      event.save!
 
-      expect(event.background_hex_color).to eq("#CC342D")
+      expect(event.reload.bg_color_hex).to eq("#7C3AED")
     end
 
-    it "ignores unsupported tags and picks from DEFAULT_HEX_COLORS" do
+    it "auto-populates bg_color_hex from the first supported tag on save when blank" do
+      supported_tag = create(:tag, name: "ruby", supported: true, bg_color_hex: "#CC342D")
+      event = build(:event, bg_color_hex: nil)
+      event.tags << supported_tag
+      event.save!
+
+      expect(event.reload.bg_color_hex).to eq("#CC342D")
+    end
+
+    it "leaves bg_color_hex nil when tags are unsupported or without color" do
       unsupported_tag = create(:tag, name: "customtag", supported: false, bg_color_hex: "#112233")
+      event = build(:event, bg_color_hex: nil)
       event.tags << unsupported_tag
+      event.save!
 
-      expect(Event::DEFAULT_HEX_COLORS).to include(event.background_hex_color)
+      expect(event.reload.bg_color_hex).to be_nil
+    end
+  end
+
+  describe "#background_hex_color" do
+    it "returns the stored bg_color_hex if present" do
+      event = build(:event, bg_color_hex: "#DB2777")
+      expect(event.background_hex_color).to eq("#DB2777")
     end
 
-    it "deterministically chooses from DEFAULT_HEX_COLORS when no tags exist" do
+    it "deterministically chooses from DEFAULT_HEX_COLORS when bg_color_hex is nil" do
+      event = build(:event, id: 1, bg_color_hex: nil)
       expected_color = Event::DEFAULT_HEX_COLORS[1 % Event::DEFAULT_HEX_COLORS.size]
       expect(event.background_hex_color).to eq(expected_color)
     end
@@ -253,10 +284,10 @@ RSpec.describe Event do
 
   describe "#gradient_background_css" do
     it "returns a linear gradient string with shaded tones" do
-      event = build(:event, id: 2)
+      event = build(:event, id: 2, bg_color_hex: "#0D9488")
       css = event.gradient_background_css
       expect(css).to start_with("linear-gradient(135deg,")
-      expect(css).to include(event.background_hex_color)
+      expect(css).to include("#0D9488")
     end
   end
 
@@ -278,17 +309,29 @@ RSpec.describe Event do
 
   describe "#formatted_date_range" do
     it "formats same-month date ranges as 'MMM D - D'" do
-      event = build(:event, start_time: Time.utc(2026, 8, 28, 10, 0), end_time: Time.utc(2026, 8, 30, 18, 0))
+      event = build(
+        :event,
+        start_time: Time.zone.local(2026, 8, 28, 10, 0),
+        end_time: Time.zone.local(2026, 8, 30, 18, 0),
+      )
       expect(event.formatted_date_range).to eq("AUG 28 - 30")
     end
 
     it "formats cross-month date ranges as 'MMM D - MMM D'" do
-      event = build(:event, start_time: Time.utc(2026, 8, 30, 10, 0), end_time: Time.utc(2026, 9, 2, 18, 0))
+      event = build(
+        :event,
+        start_time: Time.zone.local(2026, 8, 30, 10, 0),
+        end_time: Time.zone.local(2026, 9, 2, 18, 0),
+      )
       expect(event.formatted_date_range).to eq("AUG 30 - SEP 2")
     end
 
     it "formats single-day events as 'MMM D'" do
-      event = build(:event, start_time: Time.utc(2026, 8, 28, 10, 0), end_time: Time.utc(2026, 8, 28, 18, 0))
+      event = build(
+        :event,
+        start_time: Time.zone.local(2026, 8, 28, 10, 0),
+        end_time: Time.zone.local(2026, 8, 28, 18, 0),
+      )
       expect(event.formatted_date_range).to eq("AUG 28")
     end
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,10 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Event, type: :model do
-  describe "validations" do
-    # Validations tests have been moved into their dedicated block extending boundaries.
-  end
-
+RSpec.describe Event do
   describe "associations" do
     it { is_expected.to belong_to(:user).optional }
     it { is_expected.to belong_to(:organization).optional }
@@ -14,18 +10,19 @@ RSpec.describe Event, type: :model do
 
   describe "enums" do
     it do
-      is_expected.to define_enum_for(:type_of).with_values(
+      expect(subject).to define_enum_for(:type_of).with_values(
         live_stream: 0,
         takeover: 1,
         other: 2,
-        challenge: 3
+        challenge: 3,
       )
     end
+
     it do
-      is_expected.to define_enum_for(:broadcast_config).with_values(
+      expect(subject).to define_enum_for(:broadcast_config).with_values(
         no_broadcast: 0,
         tagged_broadcast: 1,
-        global_broadcast: 2
+        global_broadcast: 2,
       )
     end
   end
@@ -38,7 +35,7 @@ RSpec.describe Event, type: :model do
     it { is_expected.to validate_presence_of(:end_time) }
     it { is_expected.to validate_presence_of(:event_name_slug) }
     it { is_expected.to validate_presence_of(:event_variation_slug) }
-    
+
     it "requires uniqueness of event_variation_slug scoped to event_name_slug" do
       create(:event, event_name_slug: "test-event", event_variation_slug: "v1")
       duplicate = build(:event, event_name_slug: "test-event", event_variation_slug: "v1")
@@ -114,7 +111,7 @@ RSpec.describe Event, type: :model do
 
       event2 = create(:event, primary_stream_url: "https://streamyard.com/e/12345")
       expect(event2.primary_stream_url).to eq("https://streamyard.com/e/12345")
-      
+
       event3 = create(:event, primary_stream_url: "https://streamyard.com/12345")
       expect(event3.primary_stream_url).to eq("https://streamyard.com/e/12345")
     end
@@ -128,40 +125,40 @@ RSpec.describe Event, type: :model do
 
     it "generates fully formulated HTML billboards containing dynamic parameters for a takeover" do
       user = create(:user)
-      event = create(:event, 
-                     broadcast_config: "global_broadcast", 
+      event = create(:event,
+                     broadcast_config: "global_broadcast",
                      type_of: "takeover",
-                     title: "Test HTML Event", 
+                     title: "Test HTML Event",
                      description: "A very exciting summary",
-                     event_name_slug: "test-html-event", 
+                     event_name_slug: "test-html-event",
                      event_variation_slug: "v1",
                      data: { "image_url" => "https://dummyimage.com/img.jpg" },
                      user: user)
 
       # 2 billboards (feed_first, post_fixed_bottom)
       expect(event.billboards.count).to eq(2)
-      
+
       feed_bb = event.billboards.find_by(placement_area: "feed_first")
       post_bb = event.billboards.find_by(placement_area: "post_fixed_bottom")
 
       expect(feed_bb.published).to be(true)
       expect(feed_bb.approved).to be(false) # Needs worker to approve
-      
+
       expect(feed_bb.render_mode).to eq("raw")
       expect(feed_bb.template).to eq("authorship_box")
       expect(post_bb.template).to eq("authorship_box")
       expect(feed_bb.custom_display_label).to eq("#{Settings::Community.community_name} Takeovers")
-      
+
       expect(feed_bb.name).to start_with("takeover_")
       expect(feed_bb.dismissal_sku).to start_with("takeover_")
       expect(feed_bb.name).to include("_feed")
-      
+
       expect(post_bb.render_mode).to eq("raw")
       expect(post_bb.template).to eq("authorship_box")
       expect(post_bb.dismissal_sku).to eq(feed_bb.dismissal_sku)
       expect(post_bb.name).to include("_post")
-      expect(post_bb.name).to_not eq(feed_bb.name)
-      
+      expect(post_bb.name).not_to eq(feed_bb.name)
+
       # Assert the HTML was injected cleanly inside body_markdown using user fallback
       expect(feed_bb.body_markdown).to include("id=\"event-takeover-image-feed\"")
       expect(feed_bb.body_markdown).to include("Tune in to the full event")
@@ -175,22 +172,22 @@ RSpec.describe Event, type: :model do
 
     it "generates persistent on-post billboard with minimized HTML for a live_stream event" do
       user = create(:user)
-      event = create(:event, 
-                     broadcast_config: "global_broadcast", 
+      event = create(:event,
+                     broadcast_config: "global_broadcast",
                      type_of: "live_stream",
-                     title: "Test Live Stream Event", 
+                     title: "Test Live Stream Event",
                      description: "A live broadcast summary",
-                     event_name_slug: "test-live-stream", 
+                     event_name_slug: "test-live-stream",
                      event_variation_slug: "v1",
                      user: user)
 
       expect(event.billboards.count).to eq(2)
-      
+
       feed_bb = event.billboards.find_by(placement_area: "feed_first")
       post_bb = event.billboards.find_by(placement_area: "post_fixed_bottom")
 
       expect(feed_bb.custom_display_label).to eq("#{Settings::Community.community_name} Live Events")
-      
+
       expect(post_bb.special_behavior).to eq("persistent")
       expect(post_bb.minimized_body_markdown).to include("live-stream-minimized")
       expect(post_bb.minimized_body_markdown).to include("Test Live Stream Event")
@@ -204,7 +201,7 @@ RSpec.describe Event, type: :model do
 
   describe "Callbacks" do
     it "registers #bust_upcoming_events_cache as an after_commit callback" do
-      callback_names = Event._commit_callbacks.select { |cb| cb.kind == :after }.map(&:filter)
+      callback_names = described_class._commit_callbacks.select { |cb| cb.kind == :after }.map(&:filter)
       expect(callback_names).to include(:bust_upcoming_events_cache)
     end
   end
@@ -230,5 +227,86 @@ RSpec.describe Event, type: :model do
       expect(Rails.cache.read("upcoming_elevated_events")).to be_nil
     end
   end
-end
 
+  describe "#background_hex_color" do
+    let(:event) { create(:event, id: 1, title: "Special Community Event") }
+
+    it "returns the hex color of the first supported tag with bg_color_hex" do
+      supported_tag = create(:tag, name: "ruby", supported: true, bg_color_hex: "#CC342D")
+      event.tags << supported_tag
+
+      expect(event.background_hex_color).to eq("#CC342D")
+    end
+
+    it "ignores unsupported tags and picks from DEFAULT_HEX_COLORS" do
+      unsupported_tag = create(:tag, name: "customtag", supported: false, bg_color_hex: "#112233")
+      event.tags << unsupported_tag
+
+      expect(Event::DEFAULT_HEX_COLORS).to include(event.background_hex_color)
+    end
+
+    it "deterministically chooses from DEFAULT_HEX_COLORS when no tags exist" do
+      expected_color = Event::DEFAULT_HEX_COLORS[1 % Event::DEFAULT_HEX_COLORS.size]
+      expect(event.background_hex_color).to eq(expected_color)
+    end
+  end
+
+  describe "#gradient_background_css" do
+    it "returns a linear gradient string with shaded tones" do
+      event = build(:event, id: 2)
+      css = event.gradient_background_css
+      expect(css).to start_with("linear-gradient(135deg,")
+      expect(css).to include(event.background_hex_color)
+    end
+  end
+
+  describe "#social_image_url" do
+    it "returns the fallback main social image when cover_image is blank" do
+      event = build(:event, cover_image: nil)
+      expect(event.social_image_url).to eq(Settings::General.main_social_image.to_s)
+    end
+
+    it "returns the cover image url when cover_image is present" do
+      event = create(:event, cover_image: Rack::Test::UploadedFile.new(
+        Rails.root.join("spec/fixtures/files/800x600.png"),
+        "image/png",
+      ))
+      expect(event.social_image_url).to be_present
+      expect(event.social_image_url).to include("800x600.png").or include("uploads/events/cover_image")
+    end
+  end
+
+  describe "#formatted_date_range" do
+    it "formats same-month date ranges as 'MMM D - D'" do
+      event = build(:event, start_time: Time.utc(2026, 8, 28, 10, 0), end_time: Time.utc(2026, 8, 30, 18, 0))
+      expect(event.formatted_date_range).to eq("AUG 28 - 30")
+    end
+
+    it "formats cross-month date ranges as 'MMM D - MMM D'" do
+      event = build(:event, start_time: Time.utc(2026, 8, 30, 10, 0), end_time: Time.utc(2026, 9, 2, 18, 0))
+      expect(event.formatted_date_range).to eq("AUG 30 - SEP 2")
+    end
+
+    it "formats single-day events as 'MMM D'" do
+      event = build(:event, start_time: Time.utc(2026, 8, 28, 10, 0), end_time: Time.utc(2026, 8, 28, 18, 0))
+      expect(event.formatted_date_range).to eq("AUG 28")
+    end
+  end
+
+  describe "#format_pill_label" do
+    it "returns custom format when present in data" do
+      event = build(:event, data: { "format" => "in-person" })
+      expect(event.format_pill_label).to eq("IN-PERSON")
+    end
+
+    it "defaults to DIGITAL for live_stream" do
+      event = build(:event, type_of: :live_stream)
+      expect(event.format_pill_label).to eq("DIGITAL")
+    end
+
+    it "defaults to CHALLENGE for challenge" do
+      event = build(:event, type_of: :challenge)
+      expect(event.format_pill_label).to eq("CHALLENGE")
+    end
+  end
+end

--- a/spec/requests/admin/events_spec.rb
+++ b/spec/requests/admin/events_spec.rb
@@ -164,6 +164,15 @@ RSpec.describe "Admin::Events" do
         expect(Event.last.cover_image).to be_present
       end
     end
+
+    context "with bg_color_hex" do
+      let(:attributes_with_hex) { valid_attributes.merge(bg_color_hex: "#7C3AED") }
+
+      it "permits and sets the bg_color_hex" do
+        post admin_events_path, params: { event: attributes_with_hex }
+        expect(Event.last.bg_color_hex).to eq("#7C3AED")
+      end
+    end
   end
 
   describe "PATCH /admin/content_manager/events/:id" do
@@ -172,13 +181,16 @@ RSpec.describe "Admin::Events" do
     context "when logged in as an admin" do
       before { login_as(super_admin) }
 
-      it "updates the event title and cover image" do
+      it "updates the event title, cover image, and bg_color_hex" do
         image_file = fixture_file_upload(Rails.root.join("spec/fixtures/files/800x600.png"), "image/png")
-        patch admin_event_path(event), params: { event: { title: "Updated Event Title", cover_image: image_file } }
+        patch admin_event_path(event), params: {
+          event: { title: "Updated Event Title", cover_image: image_file, bg_color_hex: "#0D9488" }
+        }
 
         expect(response).to redirect_to(admin_events_path)
         expect(event.reload.title).to eq("Updated Event Title")
         expect(event.cover_image).to be_present
+        expect(event.bg_color_hex).to eq("#0D9488")
       end
 
       it "removes the cover image when remove_cover_image is submitted" do

--- a/spec/requests/admin/events_spec.rb
+++ b/spec/requests/admin/events_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
-RSpec.describe "Admin::Events", type: :request do
+RSpec.describe "Admin::Events" do
   let(:super_admin) { create(:user, :super_admin) }
   let(:regular_user) { create(:user) }
-  
+
   describe "GET /admin/content_manager/events" do
     context "when logged in as an admin" do
       before { login_as(super_admin) }
@@ -19,14 +19,15 @@ RSpec.describe "Admin::Events", type: :request do
       before { login_as(regular_user) }
 
       it "denies access" do
-        expect {
+        expect do
           get admin_events_path
-        }.to raise_error(Pundit::NotAuthorizedError)
+        end.to raise_error(Pundit::NotAuthorizedError)
       end
     end
 
     context "when logged in as a resource admin for Event" do
       let(:event_admin) { create(:user) }
+
       before do
         event_admin.add_role(:single_resource_admin, Event)
         login_as(event_admin)
@@ -41,15 +42,16 @@ RSpec.describe "Admin::Events", type: :request do
 
     context "when logged in as a resource admin for a different resource" do
       let(:other_admin) { create(:user) }
+
       before do
         other_admin.add_role(:single_resource_admin, Article)
         login_as(other_admin)
       end
 
       it "denies access" do
-        expect {
+        expect do
           get admin_events_path
-        }.to raise_error(Pundit::NotAuthorizedError)
+        end.to raise_error(Pundit::NotAuthorizedError)
       end
     end
   end
@@ -91,9 +93,9 @@ RSpec.describe "Admin::Events", type: :request do
       before { login_as(regular_user) }
 
       it "denies access" do
-        expect {
+        expect do
           get admin_event_path(event)
-        }.to raise_error(Pundit::NotAuthorizedError)
+        end.to raise_error(Pundit::NotAuthorizedError)
       end
     end
   end
@@ -114,10 +116,10 @@ RSpec.describe "Admin::Events", type: :request do
     end
 
     it "creates a new Event" do
-      expect {
+      expect do
         post admin_events_path, params: { event: valid_attributes }
-      }.to change(Event, :count).by(1)
-      
+      end.to change(Event, :count).by(1)
+
       expect(response).to redirect_to(admin_events_path)
       expect(Event.last.event_name_slug).to eq("test-admin")
     end
@@ -126,9 +128,9 @@ RSpec.describe "Admin::Events", type: :request do
       let(:invalid_attributes) { valid_attributes.merge(title: "") }
 
       it "does not create a new event and returns unprocessable_entity with an error message" do
-        expect {
+        expect do
           post admin_events_path, params: { event: invalid_attributes }
-        }.not_to change(Event, :count)
+        end.not_to change(Event, :count)
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.body).to include("prohibited this event from being saved")
@@ -137,17 +139,57 @@ RSpec.describe "Admin::Events", type: :request do
 
     context "with manual_broadcast_end config" do
       let(:attributes_with_manual) { valid_attributes.merge(manual_broadcast_end: true) }
+
       it "permits and sets the manual_broadcast_end flag" do
         post admin_events_path, params: { event: attributes_with_manual }
-        expect(Event.last.manual_broadcast_end).to eq(true)
+        expect(Event.last.manual_broadcast_end).to be(true)
       end
     end
 
     context "with elevated config" do
       let(:attributes_with_elevated) { valid_attributes.merge(elevated: true) }
+
       it "permits and sets the elevated flag" do
         post admin_events_path, params: { event: attributes_with_elevated }
-        expect(Event.last.elevated).to eq(true)
+        expect(Event.last.elevated).to be(true)
+      end
+    end
+
+    context "with cover_image" do
+      let(:image_file) { fixture_file_upload(Rails.root.join("spec/fixtures/files/800x600.png"), "image/png") }
+      let(:attributes_with_cover) { valid_attributes.merge(cover_image: image_file) }
+
+      it "permits and uploads the cover image" do
+        post admin_events_path, params: { event: attributes_with_cover }
+        expect(Event.last.cover_image).to be_present
+      end
+    end
+  end
+
+  describe "PATCH /admin/content_manager/events/:id" do
+    let(:event) { create(:event) }
+
+    context "when logged in as an admin" do
+      before { login_as(super_admin) }
+
+      it "updates the event title and cover image" do
+        image_file = fixture_file_upload(Rails.root.join("spec/fixtures/files/800x600.png"), "image/png")
+        patch admin_event_path(event), params: { event: { title: "Updated Event Title", cover_image: image_file } }
+
+        expect(response).to redirect_to(admin_events_path)
+        expect(event.reload.title).to eq("Updated Event Title")
+        expect(event.cover_image).to be_present
+      end
+
+      it "removes the cover image when remove_cover_image is submitted" do
+        image_file = fixture_file_upload(Rails.root.join("spec/fixtures/files/800x600.png"), "image/png")
+        event.update!(cover_image: image_file)
+        expect(event.reload.cover_image).to be_present
+
+        patch admin_event_path(event), params: { event: { remove_cover_image: "1" } }
+
+        expect(response).to redirect_to(admin_events_path)
+        expect(event.reload.cover_image.file).to be_nil
       end
     end
   end
@@ -160,9 +202,9 @@ RSpec.describe "Admin::Events", type: :request do
 
       it "updates broadcast_ended_at and enqueues the worker" do
         allow(Events::ManageBroadcastBillboardsWorker).to receive(:perform_async)
-        
+
         patch end_broadcast_admin_event_path(event)
-        
+
         expect(response).to redirect_to(admin_event_path(event))
         expect(flash[:notice]).to include("Broadcast manually ended")
         expect(event.reload.broadcast_ended_at).to be_within(1.second).of(Time.current)
@@ -181,7 +223,8 @@ RSpec.describe "Admin::Events", type: :request do
       end
 
       it "pre-fills the form with attributes from the original event when fork_from_id is passed" do
-        original_event = create(:event, title: "Original Event Title", description: "Original Description", tag_list: ["ruby", "rails"])
+        original_event = create(:event, title: "Original Event Title", description: "Original Description",
+                                        tag_list: %w[ruby rails])
 
         get new_admin_event_path(fork_from_id: original_event.id)
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1,33 +1,52 @@
 require "rails_helper"
 
-RSpec.describe "Events", type: :request do
+RSpec.describe "Events" do
   let!(:published_event) { create(:event, title: "Super Cool Launch Event", published: true) }
   let!(:draft_event)     { create(:event, title: "Secret Internal Test", published: false) }
 
   describe "GET /events" do
     it "renders the index successfully, displaying only published events" do
       get events_path
-      
+
       expect(response).to have_http_status(:success)
       expect(response.body).to include(published_event.title)
       expect(response.body).not_to include(draft_event.title)
+      expect(response.body).to include("Upcoming Events")
+      expect(response.body).to include("View on Calendar")
+      expect(response.body).to include(calendar_path)
+    end
+
+    it "renders gradient background for events without cover image" do
+      get events_path
+      expect(response.body).to include("linear-gradient(135deg,")
+    end
+
+    it "renders cover image when an event has one attached" do
+      image_file = fixture_file_upload(Rails.root.join("spec/fixtures/files/800x600.png"), "image/png")
+      published_event.update!(cover_image: image_file)
+
+      get events_path
+      expect(response.body).to include(published_event.cover_image.url)
     end
   end
 
   describe "GET /events/:id" do
     context "when requesting a published event" do
-      it "renders the show view successfully" do
+      it "renders the show view successfully with og:image meta tags" do
         # `event_path` natively uses the overloaded `to_param` (slug) we built!
         get event_path(published_event.event_name_slug, published_event.event_variation_slug)
-        
+
         expect(response).to have_http_status(:success)
         expect(response.body).to include(published_event.title)
+        expect(response.body).to include("property=\"og:image\"")
+        expect(response.body).to include("name=\"twitter:image:src\"")
       end
 
       context "when forced_live state is passed" do
         it "renders the show view indicating that forced live mode is enabled" do
-          get event_path(published_event.event_name_slug, published_event.event_variation_slug), params: { state: "forced_live" }
-          
+          get event_path(published_event.event_name_slug, published_event.event_variation_slug),
+              params: { state: "forced_live" }
+
           expect(response).to have_http_status(:success)
           expect(response.body).to include("IS_FORCED_LIVE = true;")
         end
@@ -44,7 +63,7 @@ RSpec.describe "Events", type: :request do
 
         it "renders the articles with their tags successfully without throwing NoMethodError" do
           get event_path(published_event.event_name_slug, published_event.event_variation_slug)
-          
+
           expect(response).to have_http_status(:success)
           expect(response.body).to include("A Custom Event Article")
           expect(response.body).to include(article.path)
@@ -52,6 +71,7 @@ RSpec.describe "Events", type: :request do
         end
       end
     end
+
     context "when requesting an event that delegates to a page" do
       let(:delegated_page) { create(:page, slug: "delegated-page") }
       let!(:delegated_event) { create(:event, published: true, delegate_to_page: true, page: delegated_page) }
@@ -77,54 +97,56 @@ RSpec.describe "Events", type: :request do
     context "when requesting a draft event" do
       context "as a logged out user" do
         it "raises a 404 RoutingError as if it does not exist" do
-          expect {
+          expect do
             get event_path(draft_event.event_name_slug, draft_event.event_variation_slug)
-          }.to raise_error(ActionController::RoutingError, "Not Found")
+          end.to raise_error(ActionController::RoutingError, "Not Found")
         end
       end
 
       context "as a regular logged in user" do
         let(:regular_user) { create(:user) }
-        
+
         before { login_as(regular_user) }
 
         it "raises a 404 RoutingError to maintain draft secrecy" do
-          expect {
+          expect do
             get event_path(draft_event.event_name_slug, draft_event.event_variation_slug)
-          }.to raise_error(ActionController::RoutingError, "Not Found")
+          end.to raise_error(ActionController::RoutingError, "Not Found")
         end
       end
 
       context "as an admin" do
         let(:admin) { create(:user, :super_admin) }
-        
+
         before { login_as(admin) }
 
         it "renders the show view with an unpublished warning banner" do
           get event_path(draft_event.event_name_slug, draft_event.event_variation_slug)
-          
+
           expect(response).to have_http_status(:success)
           expect(response.body).to include("This event is not published!")
           expect(response.body).to include("Edit Event")
         end
       end
     end
-    
+
     context "when an event does not exist" do
       context "and a matching page does not exist" do
         it "raises an ActiveRecord::RecordNotFound implicitly handled as a 404" do
-          expect {
+          expect do
             get "/events/does-not-exist/version"
-          }.to raise_error(ActiveRecord::RecordNotFound)
+          end.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 
       context "and a matching page exists" do
-        let!(:fallback_page) { create(:page, slug: "events/midnight/april-2-2026", body_markdown: "This is the fallback midnight event page") }
-        
+        let!(:fallback_page) do
+          create(:page, slug: "events/midnight/april-2-2026", body_markdown: "This is the fallback midnight event page")
+        end
+
         it "renders the page instead of raising a 404" do
           get "/events/midnight/april-2-2026"
-          
+
           expect(response).to have_http_status(:success)
           expect(response.body).to include("This is the fallback midnight event page")
         end


### PR DESCRIPTION
## Summary

This PR adds cover images to Events with automatic social cropping, supports tag-aware and default fallback gradient backgrounds, wires OpenGraph / Twitter meta tags, overhauls the events landing page with responsive cards, adds a 'View on Calendar' action, and enriches seed data.

### Key Changes
- **Database & Model**:
  - Added  column to  table via migration.
  - Created `EventCoverImageUploader` (CarrierWave) with a `:social` version auto-resized to `1200x630`.
  - Added `Event#background_hex_color` mapping to the event's first supported tag, with a fallback to 5 curated default hex codes.
  - Added `Event#gradient_background_css` for shaded linear gradient banners when no image is uploaded.
  - Added helpers for date ranges (`Event#formatted_date_range`), location, and format pills.
- **Admin Backend**:
  - Added cover image upload, preview, and removal controls to `Admin::EventsController` and views.
- **Public Views & SEO**:
  - Overhauled `app/views/events/index.html.erb` with card grids displaying cover images or fallback gradient banners, date/location rows, format pills, and a **'View on Calendar'** action button in the header.
  - Injected `og:image` and `twitter:image:src` tags into event show and challenge templates.
  - Added complete i18n translations across `en`, `fr`, and `pt` under `config/locales/views/events/`.
- **Seeds & Testing**:
  - Enriched `db/seeds.rb` with diverse events (cover images, tag gradients, default palettes).
  - Added comprehensive unit specs in `spec/models/event_spec.rb` and request specs in `spec/requests/admin/events_spec.rb` and `spec/requests/events_spec.rb`.

## Verification
- Automated test suite passing: `bundle exec rspec spec/models/event_spec.rb spec/requests/admin/events_spec.rb spec/requests/events_spec.rb` (69 examples, 0 failures).
- Verified live deployment and UI rendering on exe.dev VM.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789745315&installation_model_id=424141&pr_number=23757&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23757&signature=6242722e4c44e35bf4a269fa1b54ab91c6022a64ecc3101a3ad5e4028c7c0289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->