### PR TITLE
Fix Fastly URL cache busting & signed-in context feed URLs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,7 @@ class ApplicationController < ActionController::Base
   before_action :forward_to_app_config_domain
   before_action :redirect_custom_domain_non_profile_pages
   before_action :determine_locale
+  before_action :set_request_signed_in_context
   after_action  :clear_request_store
 
   include SessionCurrentUser
@@ -398,6 +399,11 @@ class ApplicationController < ActionController::Base
       current_user.remember_me!
       remember_me(current_user)
     end
+  end
+
+  def set_request_signed_in_context
+    RequestStore.store[:user_signed_in] = user_signed_in?
+    RequestStore.store[:custom_domain_org] = request.env["forem.custom_domain_org"]
   end
 
   def after_sign_out_path_for(_resource_or_scope)

--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -45,21 +45,27 @@ module URL
   # Creates an article URL
   #
   # @param article [Article] the article to create the URL for
-  def self.article(article)
-    has_org_attr = article.is_a?(ActiveRecord::Base) ? article.has_attribute?(:organization_id) : article.respond_to?(:organization)
-    if has_org_attr && (org = article.try(:organization))
-      if org && org.respond_to?(:custom_domain) && org.custom_domain.present? && FeatureFlag.enabled?(:org_custom_domain, FeatureFlag::Actor.new(org))
-        return url("/#{article.slug}", org.custom_domain)
-      end
-    elsif (article.is_a?(ActiveRecord::Base) ? article.has_attribute?(:organization_id) : article.respond_to?(:organization_id)) && article.organization_id.present?
-      org_id = article.organization_id
-      custom_domain = MemoryFirstCache.fetch("org_custom_domain:#{org_id}", redis_expires_in: 12.hours, return_type: :string) do
-        Organization.where(id: org_id).pick(:custom_domain).to_s
-      end
-      if custom_domain.present?
-        org = Organization.find_by(id: org_id)
-        if org && FeatureFlag.enabled?(:org_custom_domain, FeatureFlag::Actor.new(org))
-          return url("/#{article.slug}", custom_domain)
+  # @param user_signed_in [Boolean, nil] whether the viewer is signed in (defaults to checking RequestStore)
+  def self.article(article, user_signed_in: nil)
+    is_signed_in = user_signed_in.nil? ? RequestStore.store[:user_signed_in] : user_signed_in
+    is_on_custom_domain = RequestStore.store[:custom_domain_org].present?
+
+    unless is_signed_in && !is_on_custom_domain
+      has_org_attr = article.is_a?(ActiveRecord::Base) ? article.has_attribute?(:organization_id) : article.respond_to?(:organization)
+      if has_org_attr && (org = article.try(:organization))
+        if org && org.respond_to?(:custom_domain) && org.custom_domain.present? && FeatureFlag.enabled?(:org_custom_domain, FeatureFlag::Actor.new(org))
+          return url("/#{article.slug}", org.custom_domain)
+        end
+      elsif (article.is_a?(ActiveRecord::Base) ? article.has_attribute?(:organization_id) : article.respond_to?(:organization_id)) && article.organization_id.present?
+        org_id = article.organization_id
+        custom_domain = MemoryFirstCache.fetch("org_custom_domain:#{org_id}", redis_expires_in: 12.hours, return_type: :string) do
+          Organization.where(id: org_id).pick(:custom_domain).to_s
+        end
+        if custom_domain.present?
+          org = Organization.find_by(id: org_id)
+          if org && FeatureFlag.enabled?(:org_custom_domain, FeatureFlag::Actor.new(org))
+            return url("/#{article.slug}", custom_domain)
+          end
         end
       end
     end

--- a/app/services/edge_cache/bust/fastly.rb
+++ b/app/services/edge_cache/bust/fastly.rb
@@ -11,7 +11,8 @@ module EdgeCache
                     "User-Agent" => "#{Settings::Community.community_name} (#{URL.url})" }
 
         urls(path).map do |url|
-          HTTParty.post("https://api.fastly.com/purge/#{url}", headers: headers)
+          clean_url = url.to_s.sub(%r{\Ahttps?://}, "")
+          HTTParty.post("https://api.fastly.com/purge/#{clean_url}", headers: headers)
         rescue HTTParty::Error, SocketError, Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNREFUSED, Timeout::Error => e
           ForemStatsClient.increment(
             "edgecache_bust.provider_error",
@@ -32,17 +33,29 @@ module EdgeCache
       private_class_method :fastly_purge
 
       def self.urls(path)
-        urls = [URL.url(path)]
+        urls = [formatted_url(path)]
         urls << if path.include?("?")
-                  URL.url("#{path}&i=i")
+                  formatted_url("#{path}&i=i")
                 else
-                  URL.url("#{path}?i=i")
+                  formatted_url("#{path}?i=i")
                 end
         urls
       rescue Addressable::URI::InvalidURIError
         []
       end
       private_class_method :urls
+
+      def self.formatted_url(path)
+        if path.to_s.start_with?("http://", "https://")
+          uri = Addressable::URI.parse(path)
+          raise Addressable::URI::InvalidURIError if uri.host.blank?
+
+          uri.normalize.to_s
+        else
+          URL.url(path)
+        end
+      end
+      private_class_method :formatted_url
     end
   end
 end

--- a/app/services/edge_cache/bust_article.rb
+++ b/app/services/edge_cache/bust_article.rb
@@ -15,10 +15,21 @@ module EdgeCache
 
       cache_bust = EdgeCache::Bust.new
 
+      bust_custom_domain_page(cache_bust, article)
       bust_home_pages(cache_bust, article)
       bust_tag_pages(cache_bust, article)
       bust_user_profile_pages(article)
     end
+
+    def self.bust_custom_domain_page(cache_bust, article)
+      org = article.organization
+      return unless org && org.respond_to?(:custom_domain) && org.custom_domain.present? && FeatureFlag.enabled?(:org_custom_domain, FeatureFlag::Actor.new(org))
+
+      custom_domain_url = URL.url("/#{article.slug}", org.custom_domain)
+      cache_bust.call(custom_domain_url)
+    end
+
+    private_class_method :bust_custom_domain_page
 
     def self.bust_home_pages(cache_bust, article)
       if article.published_at.to_i > Time.current.to_i

--- a/app/views/stories/feeds/show.json.jbuilder
+++ b/app/views/stories/feeds/show.json.jbuilder
@@ -51,7 +51,6 @@ json.array!(@stories) do |article|
     # Optimize main_image - avoid cloud_cover_url call when not needed
     json.main_image article.main_image? ? cloud_cover_url(article.main_image, article.subforem_id) : nil
 
-    json.url URL.article(article)
     json.tag_list article.cached_tag_list_array
 
     # Only include body_preview for status articles
@@ -96,7 +95,8 @@ json.array!(@stories) do |article|
     json.context_note article.context_notes.first&.processed_html
   end
   
-  # These fields are added outside the cache so they don't fragment the cache
+  # These fields are added outside the cache so they don't fragment the cache and respect signed-in context
+  json.url URL.article(article)
   json.current_user_signed_in user_signed_in?
   json.feed_config @feed_config&.id
 end

--- a/spec/lib/url_spec.rb
+++ b/spec/lib/url_spec.rb
@@ -127,12 +127,44 @@ RSpec.describe URL, type: :lib do
       expect(described_class.article(partial_article)).to eq("https://dev.to#{created_article.path}")
     end
 
-    it "handles organization custom domain when present" do
-      org = create(:organization, custom_domain: "org.custom.dev")
+    it "handles organization custom domain when present for anonymous users" do
+      org = create(:organization, custom_domain: "org.custom.dev", slug: "myorg")
       org_article = create(:article, organization: org, slug: "my-org-post")
       FeatureFlag.enable(:org_custom_domain, FeatureFlag::Actor[org])
 
+      expect(described_class.article(org_article, user_signed_in: false)).to eq("https://org.custom.dev/my-org-post")
+    end
+
+    it "returns the dev.to platform path for signed-in users" do
+      org = create(:organization, custom_domain: "org.custom.dev", slug: "myorg")
+      org_article = create(:article, organization: org, slug: "my-org-post")
+      FeatureFlag.enable(:org_custom_domain, FeatureFlag::Actor[org])
+
+      expect(described_class.article(org_article, user_signed_in: true)).to eq("https://dev.to/myorg/my-org-post")
+    end
+
+    it "returns the dev.to platform path when RequestStore indicates user is signed in" do
+      org = create(:organization, custom_domain: "org.custom.dev", slug: "myorg")
+      org_article = create(:article, organization: org, slug: "my-org-post")
+      FeatureFlag.enable(:org_custom_domain, FeatureFlag::Actor[org])
+
+      RequestStore.store[:user_signed_in] = true
+      expect(described_class.article(org_article)).to eq("https://dev.to/myorg/my-org-post")
+    ensure
+      RequestStore.store[:user_signed_in] = nil
+    end
+
+    it "returns the custom domain path when signed in but browsing directly on the custom domain" do
+      org = create(:organization, custom_domain: "org.custom.dev", slug: "myorg")
+      org_article = create(:article, organization: org, slug: "my-org-post")
+      FeatureFlag.enable(:org_custom_domain, FeatureFlag::Actor[org])
+
+      RequestStore.store[:user_signed_in] = true
+      RequestStore.store[:custom_domain_org] = org
       expect(described_class.article(org_article)).to eq("https://org.custom.dev/my-org-post")
+    ensure
+      RequestStore.store[:user_signed_in] = nil
+      RequestStore.store[:custom_domain_org] = nil
     end
   end
 

--- a/spec/requests/stories/feeds_spec.rb
+++ b/spec/requests/stories/feeds_spec.rb
@@ -30,6 +30,30 @@ RSpec.describe "Stories::Feeds" do
       )
     end
 
+    context "when article belongs to an organization with a custom domain" do
+      let(:custom_org) { create(:organization, name: "MLH", slug: "mlh", custom_domain: "blog.mlh.com") }
+      let!(:custom_org_article) { create(:article, title: "MLH Post", slug: "mlh-post", organization: custom_org, featured: true) }
+
+      before do
+        FeatureFlag.enable(:org_custom_domain, FeatureFlag::Actor.new(custom_org))
+      end
+
+      it "returns the custom domain url for anonymous users" do
+        get stories_feed_path
+
+        found = response_json.find { |a| a["id"] == custom_org_article.id }
+        expect(found["url"]).to eq(URL.url("/mlh-post", "blog.mlh.com"))
+      end
+
+      it "returns the platform dev.to url for signed-in users" do
+        sign_in user
+        get stories_feed_path
+
+        found = response_json.find { |a| a["id"] == custom_org_article.id }
+        expect(found["url"]).to eq("http://forem.test/mlh/mlh-post")
+      end
+    end
+
     context "when there are no params passed (base feed) and user is NOT signed in" do
       it "returns feed when feed_strategy is basic" do
         allow(Settings::UserExperience).to receive(:feed_strategy).and_return("basic")

--- a/spec/services/edge_cache/bust_article_spec.rb
+++ b/spec/services/edge_cache/bust_article_spec.rb
@@ -64,5 +64,15 @@ RSpec.describe EdgeCache::BustArticle, type: :service do
       described_class.call(article)
       expect(organization).to have_received(:purge).once
     end
+
+    it "busts the custom domain article URL when org custom domain is enabled" do
+      organization = create(:organization, custom_domain: "blog.example.com")
+      article.organization = organization
+      allow(organization).to receive(:purge)
+      FeatureFlag.enable(:org_custom_domain, FeatureFlag::Actor.new(organization))
+
+      described_class.call(article)
+      expect(cache_bust).to have_received(:call).with(URL.url("/#{article.slug}", organization.custom_domain))
+    end
   end
 end

--- a/spec/services/edge_cache/bust_spec.rb
+++ b/spec/services/edge_cache/bust_spec.rb
@@ -61,6 +61,33 @@ RSpec.describe EdgeCache::Bust, type: :service do
         expect(fastly_provider_class).to have_received(:call)
       end
 
+      it "strips protocol before calling Fastly purge API endpoint" do
+        allow(HTTParty).to receive(:post)
+
+        fastly_provider_class.call(path)
+
+        expected_url = URL.url(path).sub(%r{\Ahttps?://}, "")
+        expect(HTTParty).to have_received(:post).with(
+          "https://api.fastly.com/purge/#{expected_url}",
+          headers: hash_including("Fastly-Key" => "fake-key")
+        )
+      end
+
+      it "preserves custom domain in absolute URLs and strips protocol" do
+        allow(HTTParty).to receive(:post)
+
+        fastly_provider_class.call("https://blog.example.com/custom-post")
+
+        expect(HTTParty).to have_received(:post).with(
+          "https://api.fastly.com/purge/blog.example.com/custom-post",
+          headers: hash_including("Fastly-Key" => "fake-key")
+        )
+        expect(HTTParty).to have_received(:post).with(
+          "https://api.fastly.com/purge/blog.example.com/custom-post?i=i",
+          headers: hash_including("Fastly-Key" => "fake-key")
+        )
+      end
+
       it "gracefully ignores malformed URLs without raising an error or calling HTTParty" do
         allow(HTTParty).to receive(:post)
         


### PR DESCRIPTION
## What does this PR do?
1. **Fixes Fastly URL Cache Purges (`EdgeCache::Bust::Fastly`)**:
   - Strips `https?://` protocol prefix before issuing POST requests to Fastly's Purge API (`https://api.fastly.com/purge/{HOST}/{PATH}`).
   - Preserves custom domain hostnames when absolute URLs are passed to `EdgeCache::Bust`.
   - Validates URI format to handle malformed URLs gracefully.

2. **Auto-Purges Custom Domain URLs on Publish (`EdgeCache::BustArticle`)**:
   - Automatically purges `https://<custom_domain>/<slug>` whenever an organization post with a custom domain is saved or published, clearing any negative 404 cache entries created before publication.

3. **Signed-in Context Article URLs (`URL.article` & `show.json.jbuilder`)**:
   - When a user is signed in on the main platform (`dev.to`), article links in HTML views and the Preact JSON feed (`dev.to/stories/feed`) use the platform path (`dev.to/<org_slug>/<slug>`), allowing signed-in users to remain logged in for reactions, comments, and bookmarks.
   - Anonymous visitors and requests on the custom domain continue to resolve to the custom domain URL (`https://<custom_domain>/<slug>`).

## Testing
- Regression specs added and verified:
  - `spec/services/edge_cache/bust_spec.rb`
  - `spec/services/edge_cache/bust_article_spec.rb`
  - `spec/lib/url_spec.rb`
  - `spec/requests/stories/feeds_spec.rb`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789748256&installation_model_id=424141&pr_number=23759&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23759&signature=398c8063a5f565f761c3049b2bd88e97a6c519b51ca98f243e019e8b8116bb10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->