### PR TITLE
Fix User#trackable_payload spec for moderator newsletter consents

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe User do
         "id", "username", "email", "name", "registered_at", "confirmed_at", "email_newsletter",
         "email_digest_periodic", "email_comment_notifications", "email_follower_notifications",
         "email_mention_notifications", "email_unread_notifications", "email_badge_notifications",
+        "email_tag_mod_newsletter", "email_community_mod_newsletter",
         "mlh_user_id",
         "signed_up_with_html", "unsubscribe_url", "notification_settings_url"
       )
@@ -80,7 +81,7 @@ RSpec.describe User do
 
     # Core maps each of these onto its own Customer.io subscription topic, and
     # can only learn the state of an account that never toggles anything from
-    # this payload, so all seven consents have to ride along.
+    # this payload, so all nine consents have to ride along.
     it "seeds every email consent Core mirrors, not just the newsletter and digest" do
       user = create(:user)
       user.notification_setting.update!(email_comment_notifications: false,


### PR DESCRIPTION
### Summary
When `email_tag_mod_newsletter` and `email_community_mod_newsletter` were added to `Users::NotificationSetting::EMAIL_CONSENT_EVENTS`, `User#trackable_payload` began including these keys via `trackable_email_consents`.

This PR updates `spec/models/user_spec.rb` to include `email_tag_mod_newsletter` and `email_community_mod_newsletter` in the `trackable_payload` keys expectation.

### Verification
- Ran `bundle exec rspec spec/models/user_spec.rb:70` (passed).
- Ran all trackable payload specs in `spec/models/user_spec.rb` (10 examples, 0 failures).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789752732&installation_model_id=424141&pr_number=23760&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23760&signature=1ceb8bc7ecee68e6f7fcce32dae21779e580a07d9f6c390ef79a70c857de08ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->