### PR TITLE
Enhance Events Admin API for Idempotent Sync and Rich Serialization

### DIFF
--- a/app/controllers/api/v0/events_controller.rb
+++ b/app/controllers/api/v0/events_controller.rb
@@ -21,16 +21,18 @@ module Api
         unless @event.published? || @user&.administrative_access_to?(resource: Event)
           return render json: { error: "Event not found" }, status: :not_found
         end
+
         render json: @event
       end
 
       def create
         authorize Event
-        @event = Event.new(event_params.except(:user_id))
+        @event = find_or_initialize_event
+        @event.assign_attributes(event_params.except(:user_id))
         @event.user_id = @user.id if @event.user_id.blank?
 
         if @event.save
-          render json: @event, status: :created
+          render json: @event, status: @event.previously_new_record? ? :created : :ok
         else
           render json: { error: @event.errors.full_messages }, status: :unprocessable_entity
         end
@@ -57,32 +59,57 @@ module Api
       def evaluate_authentication
         # Forem's ApiController usually requires valid token if provided, but optional if omitted.
         # This safely tries to log them in if token is sent.
-        if request.headers["api-key"]
-          authenticate!
-        end
+        return unless request.headers["api-key"]
+
+        authenticate!
       end
 
       def set_event
-        @event = Event.find(params[:id])
-      rescue ActiveRecord::RecordNotFound
-        render json: { error: "Event not found" }, status: :not_found
+        @event = if params[:id].to_s.match?(/\A\d+\z/)
+                   Event.find_by(id: params[:id])
+                 else
+                   Event.find_by(event_name_slug: params[:id])
+                 end
+        render json: { error: "Event not found" }, status: :not_found unless @event
+      end
+
+      def find_or_initialize_event
+        if params[:id].present? && params[:id].to_s.match?(/\A\d+\z/)
+          Event.find_by(id: params[:id]) || Event.new
+        elsif event_params[:event_name_slug].present? && event_params[:event_variation_slug].present?
+          Event.find_by(
+            event_name_slug: event_params[:event_name_slug],
+            event_variation_slug: event_params[:event_variation_slug],
+          ) || Event.new
+        else
+          Event.new
+        end
       end
 
       def event_params
         params.require(:event).permit(
-          :title, 
+          :title,
           :event_name_slug,
           :event_variation_slug,
-          :description, 
-          :primary_stream_url, 
-          :published, 
-          :start_time, 
-          :end_time, 
-          :type_of, 
-          :user_id, 
-          :organization_id, 
+          :description,
+          :primary_stream_url,
+          :published,
+          :elevated,
+          :start_time,
+          :end_time,
+          :type_of,
+          :broadcast_config,
+          :manual_broadcast_end,
+          :user_id,
+          :organization_id,
           :tag_list,
-          data: {}
+          :page_id,
+          :delegate_to_page,
+          :cover_image,
+          :remove_cover_image,
+          :remote_cover_image_url,
+          :bg_color_hex,
+          data: {},
         )
       end
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -129,6 +129,18 @@ class Event < ApplicationRecord
     end
   end
 
+  def as_json(options = nil)
+    super(options).merge(
+      "background_hex_color" => background_hex_color,
+      "cover_image_url" => cover_image&.url,
+      "social_image_url" => social_image_url,
+      "formatted_date_range" => formatted_date_range,
+      "location" => location_display,
+      "format" => format_pill_label,
+      "tag_list" => tag_list,
+    )
+  end
+
   def signup_button_text(signed_up: false)
     if challenge?
       signed_up ? "Signed Up" : "Sign Up"

--- a/spec/requests/api/v0/events_spec.rb
+++ b/spec/requests/api/v0/events_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Api::V0::Events", type: :request do
+RSpec.describe "Api::V0::Events" do
   let!(:admin) { create(:user).tap { |u| u.add_role(:super_admin) } }
   let!(:admin_api_secret) { create(:api_secret, user: admin) }
   let!(:admin_headers) { { "api-key" => admin_api_secret.secret, "content-type" => "application/json" } }
@@ -17,8 +17,8 @@ RSpec.describe "Api::V0::Events", type: :request do
       it "returns only published events" do
         get "/api/events"
         expect(response).to have_http_status(:success)
-        
-        json = JSON.parse(response.body)
+
+        json = response.parsed_body
         expect(json.count).to eq(1)
         expect(json.first["id"]).to eq(published_event.id)
       end
@@ -27,7 +27,7 @@ RSpec.describe "Api::V0::Events", type: :request do
     context "when authenticated as basic user" do
       it "returns only published events" do
         get "/api/events", headers: user_headers
-        json = JSON.parse(response.body)
+        json = response.parsed_body
         expect(json.count).to eq(1)
       end
     end
@@ -35,7 +35,7 @@ RSpec.describe "Api::V0::Events", type: :request do
     context "when authenticated as an administrator" do
       it "returns all events including drafts" do
         get "/api/events", headers: admin_headers
-        json = JSON.parse(response.body)
+        json = response.parsed_body
         expect(json.count).to eq(2)
       end
     end
@@ -78,7 +78,9 @@ RSpec.describe "Api::V0::Events", type: :request do
           end_time: 2.days.from_now,
           type_of: "live_stream",
           primary_stream_url: "https://twitch.tv/ThePracticalDev",
-          published: false
+          published: false,
+          bg_color_hex: "#7C3AED",
+          data: { "location" => "Virtual / Worldwide", "format" => "DIGITAL" }
         }
       }.to_json
     end
@@ -94,10 +96,69 @@ RSpec.describe "Api::V0::Events", type: :request do
     end
 
     it "allows administrators to create events" do
-      expect {
+      expect do
         post "/api/events", params: valid_params, headers: admin_headers
-      }.to change(Event, :count).by(1)
+      end.to change(Event, :count).by(1)
       expect(response).to have_http_status(:created)
+
+      json = response.parsed_body
+      expect(json["title"]).to eq("New Stream")
+      expect(json["bg_color_hex"]).to eq("#7C3AED")
+      expect(json["background_hex_color"]).to eq("#7C3AED")
+      expect(json["location"]).to eq("Virtual / Worldwide")
+      expect(json["format"]).to eq("DIGITAL")
+      expect(json["social_image_url"]).to be_present
+    end
+
+    it "performs idempotent upsert when an event with matching slugs already exists" do
+      existing = create(:event, event_name_slug: "sync-event", event_variation_slug: "2026", title: "Old Title")
+
+      sync_params = {
+        event: {
+          title: "Updated Title via Sync",
+          event_name_slug: "sync-event",
+          event_variation_slug: "2026",
+          start_time: 1.day.from_now,
+          end_time: 2.days.from_now,
+          bg_color_hex: "#0D9488"
+        }
+      }.to_json
+
+      expect do
+        post "/api/events", params: sync_params, headers: admin_headers
+      end.not_to change(Event, :count)
+
+      expect(response).to have_http_status(:ok)
+      expect(existing.reload.title).to eq("Updated Title via Sync")
+      expect(existing.bg_color_hex).to eq("#0D9488")
+    end
+  end
+
+  describe "PATCH /api/events/:id" do
+    let!(:event) { create(:event, title: "Original Event", event_name_slug: "original-slug") }
+
+    it "allows administrators to update an event by numeric id" do
+      patch "/api/events/#{event.id}", params: { event: { title: "Updated by ID" } }.to_json, headers: admin_headers
+      expect(response).to have_http_status(:ok)
+      expect(event.reload.title).to eq("Updated by ID")
+    end
+
+    it "allows administrators to update an event by slug" do
+      patch "/api/events/#{event.event_name_slug}", params: { event: { title: "Updated by Slug" } }.to_json,
+                                                    headers: admin_headers
+      expect(response).to have_http_status(:ok)
+      expect(event.reload.title).to eq("Updated by Slug")
+    end
+  end
+
+  describe "DELETE /api/events/:id" do
+    let!(:event) { create(:event) }
+
+    it "allows administrators to delete an event" do
+      expect do
+        delete "/api/events/#{event.id}", headers: admin_headers
+      end.to change(Event, :count).by(-1)
+      expect(response).to have_http_status(:no_content)
     end
   end
 end


### PR DESCRIPTION
### Summary of Changes

Enhances Forem's Events API (`Api::V0::EventsController`) to support seamless bidirectional synchronization with MLH Core:

1. **Idempotent Upsert**: `POST /api/events` automatically resolves existing records by composite slug (`event_name_slug` + `event_variation_slug`) or numeric `id`, updating existing records (`200 OK`) or creating new records (`201 Created`).
2. **Slug-Based Lookup**: Supports finding events by `event_name_slug` in `GET /api/events/:slug`, `PATCH /api/events/:slug`, and `DELETE /api/events/:slug`.
3. **Full Parameter Permitting**:
   - `:bg_color_hex` for database-stored and tag-derived event background colors.
   - `:cover_image`, `:remove_cover_image`, and `:remote_cover_image_url` for URL-based image ingestion.
   - `:broadcast_config`, `:manual_broadcast_end`, `:page_id`, `:delegate_to_page`, `:elevated`, and `data: {}`.
4. **Rich JSON Serialization**: Enhanced `Event#as_json` to include `cover_image_url`, `social_image_url`, `background_hex_color`, `formatted_date_range`, `location`, and `format`.
5. **Comprehensive Tests**: 14 automated request specs covering auth, creation, idempotent upsert, slug lookups, updates, and deletion.

### Verification
- `bundle exec rspec spec/requests/api/v0/events_spec.rb` passed (14 examples, 0 failures).
- Full event suite passed (87 examples, 0 failures).
- RuboCop passed with zero offenses.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789760910&installation_model_id=424141&pr_number=23763&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23763&signature=86cc85a3cbf8671000715ec0e454f7d2807f5b7d63ca4565a40745c2556cdcb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->