### PR TITLE
Emit article_read CDP event on 60-second reads

### DIFF
--- a/app/services/articles/page_view_updater.rb
+++ b/app/services/articles/page_view_updater.rb
@@ -29,10 +29,44 @@ module Articles
       page_view.update_column(:time_tracked_in_seconds, new_time_mark)
       if new_time_mark == EXTENDED_PAGEVIEW_NUMBER
         FeedEvent.record_journey_for(page_view.user, article: page_view.article, category: :extended_pageview)
-        UpdateUserInterestEmbeddingWorker.perform_async(user_id, article_id, 0.05) if user_id
+        if user_id
+          UpdateUserInterestEmbeddingWorker.perform_async(user_id, article_id, 0.05)
+          track_article_read(page_view)
+        end
       end
 
       true
     end
+
+    # Emitted to the CDP so Customer.io can trigger campaigns and score
+    # conversion goals off real reading behavior. Fires on the transition to
+    # EXTENDED_PAGEVIEW_NUMBER rather than on the >= state, so it is
+    # at-most-once per page view row. Unlike the FeedEvent above it carries no
+    # feed-click attribution requirement -- any 60-second read counts.
+    #
+    # Keyed to the reader, not the author: Article#trackable_user_ids resolves
+    # to the author, so the event is emitted from the User instead.
+    def self.track_article_read(page_view)
+      article = page_view.article
+      user = page_view.user
+      return if article.nil? || user.nil?
+
+      user.track!(
+        "article_read",
+        {
+          "article_id" => article.id,
+          "title" => article.title,
+          # user_signed_in: false so the canonical public URL (including an
+          # organization's custom domain) lands in the payload regardless of
+          # the request that triggered the read.
+          "url" => URL.article(article, user_signed_in: false),
+          "tags" => article.decorate.cached_tag_list_array,
+          "author_username" => article.user&.username,
+          "organization_id" => article.organization_id,
+          "subforem_id" => article.subforem_id
+        },
+      )
+    end
+    private_class_method :track_article_read
   end
 end

--- a/spec/services/articles/page_view_updater_spec.rb
+++ b/spec/services/articles/page_view_updater_spec.rb
@@ -60,5 +60,64 @@ RSpec.describe Articles::PageViewUpdater do
         expect(FeedEvent.all.size).to be 2
       end
     end
+
+    context "when emitting the article_read CDP event" do
+      let(:article) { create(:article, user: create(:user), tags: "ruby, rails") }
+      let(:events) { [] }
+
+      before do
+        allow(Trackable::Registry).to receive(:active_names).and_return([:any])
+        allow(Trackable::DispatchWorker).to receive(:perform_async) do |_adapter, name, ids, props, _ts|
+          events << { name: name, user_ids: ids, properties: props }
+        end
+        Settings::General.customerio_cdp_enabled = true
+        FeatureFlag.enable(:dev_core_user_sync)
+      end
+
+      after { FeatureFlag.remove(:dev_core_user_sync) }
+
+      around { |ex| with_trackable_events { ex.run } }
+
+      def read_events
+        events.select { |event| event[:name] == "article_read" }
+      end
+
+      it "emits article_read keyed to the reader once the 60 second mark is crossed" do
+        4.times { described_class.call(article_id: article.id, user_id: user.id) }
+
+        expect(read_events.size).to eq(1)
+        event = read_events.first
+        expect(event[:user_ids]).to eq([user.id])
+        expect(event[:properties]).to include(
+          "article_id" => article.id,
+          "title" => article.title,
+          "url" => URL.article(article, user_signed_in: false),
+          "tags" => %w[ruby rails],
+          "author_username" => article.user.username,
+        )
+      end
+
+      it "stays silent before the 60 second mark" do
+        2.times { described_class.call(article_id: article.id, user_id: user.id) }
+
+        expect(read_events).to be_empty
+      end
+
+      it "emits only once when reading continues past 60 seconds" do
+        8.times { described_class.call(article_id: article.id, user_id: user.id) }
+
+        expect(read_events.size).to eq(1)
+      end
+
+      # The sibling FeedEvent requires a preceding feed click; this event does not,
+      # so feed-sourced and organic reads are both campaign-triggerable.
+      it "emits without any preceding feed click" do
+        expect(FeedEvent.where(user: user, category: :click)).to be_empty
+
+        4.times { described_class.call(article_id: article.id, user_id: user.id) }
+
+        expect(read_events.size).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

Emits an `article_read` event to the existing CDP pipeline when a logged-in reader crosses 60 seconds on an article, so Customer.io can trigger campaigns and score conversion goals off real reading behavior.

## Why

We want to trigger CIO campaigns on genuine on-site engagement (reading articles, reading about specific topics) rather than just lifecycle events. Raw pageviews are the wrong shape for that — too noisy, and mostly logged-out. The 60-second mark is already the platform's existing "they actually read it" verdict.

## How

Hooks the transition branch in `Articles::PageViewUpdater` that already fires the `extended_pageview` FeedEvent and the interest-embedding update. Two deliberate differences from that sibling FeedEvent:

- **No feed-click attribution.** `FeedEvent.record_journey_for` bails unless the reader's last feed `click` was for this same article, which limits it to feed-sourced traffic. Organic reads should be campaign-triggerable too, so this event has no such guard.
- **Keyed to the reader.** `Article#trackable_user_ids` resolves to the *author*, so the event is emitted from `User#track!` instead. That also means it inherits the existing `customerio_cdp_enabled` setting, the `dev_core_user_sync` flag, the bot/suspended gates, and the `anonymous_id: "dev:<id>"` + MLH `user_id` identity stitching for free.

It fires on the transition to `EXTENDED_PAGEVIEW_NUMBER`, not the `>=` state, so it is at-most-once per page view row.

The payload carries `tags`, which is what makes topic targeting work: CIO campaign *triggers* can filter on event attributes, so "someone read a Rust article" is expressible without adding a profile-attribute/segmentation layer.

## Scope

No new adapter, config, or routing — this rides whichever adapter is currently active. Nothing about the existing pipeline changes.

## Volume

Measured on the prod replica: **~459/hr (~335k/mo)**. For scale, public reactions run ~584/hr. Dwell time barely separates the thresholds (540/hr over 30s vs 459/hr over 60s), so 60s gives nearly full coverage with the cleanest semantics.

## Tests

Four regression specs in `spec/services/articles/page_view_updater_spec.rb`, following the `ActivityTrackable` spec's registry-stub pattern: emits once at the 60s crossing with the right reader and properties, stays silent before it, does not re-emit past it, and emits with no preceding feed click. Full file passes (10 examples, 0 failures); RuboCop clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789833182&installation_model_id=424141&pr_number=23765&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23765&signature=b1d0bc5b59e865f3999faaa27ab1c50650116bcfc86a0583aa2e28a452562901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->