### PR TITLE
Redirect authenticated users from custom org domains to main domain via iframe auth pass

### DIFF
--- a/app/controllers/auth_pass_controller.rb
+++ b/app/controllers/auth_pass_controller.rb
@@ -5,9 +5,11 @@ class AuthPassController < ApplicationController
   # Use the iframe session store for specific actions
   before_action :allow_cross_origin_requests, only: [:iframe, :token_login]
   before_action :use_iframe_session_store, only: [:iframe]
+  before_action :set_iframe_csp, only: [:iframe]
 
   def iframe
-    unless Subforem.cached_all_domains.include?(request.host)
+    allowed_hosts = (Subforem.cached_all_domains + [Settings::General.app_domain]).compact.uniq
+    unless allowed_hosts.include?(request.host)
       render plain: "Unauthorized", status: :unauthorized
       return
     end
@@ -92,6 +94,25 @@ class AuthPassController < ApplicationController
   end
   private
 
+  def set_iframe_csp
+    parent_origin = params[:passed_domain].presence || params[:parent_origin].presence || request.headers["Referer"].presence
+    return if parent_origin.blank?
+
+    uri = URI.parse(parent_origin) rescue nil
+    origin_host = uri&.host&.downcase || parent_origin.gsub(/https?:\/\//, "").split(":").first&.downcase
+    return if origin_host.blank?
+
+    is_allowed = (Subforem.cached_all_domains + [Settings::General.app_domain]).compact.map(&:downcase).include?(origin_host) ||
+                 OrgCustomDomainConstraint.custom_domain_org_for_host(origin_host).present?
+
+    if is_allowed
+      scheme = uri&.scheme || "https"
+      port_suffix = uri&.port && ![80, 443].include?(uri.port) ? ":#{uri.port}" : ""
+      normalized_origin = uri&.host ? "#{scheme}://#{uri.host}#{port_suffix}" : "#{scheme}://#{origin_host}"
+      response.headers["Content-Security-Policy"] = "frame-ancestors 'self' #{normalized_origin}"
+    end
+  end
+
   def use_iframe_session_store
     return if Rails.env.test? # Skip Redis session setup in test environment
 
@@ -112,10 +133,17 @@ class AuthPassController < ApplicationController
   end
 
   def allow_cross_origin_requests
-    allowed_domains = (Subforem.cached_domains + [Settings::General.app_domain]).compact
     requesting_origin = request.headers["Origin"]
+    return if requesting_origin.blank?
 
-    if allowed_domains.present? && allowed_domains.include?(requesting_origin&.gsub(/https?:\/\//, ""))
+    uri = URI.parse(requesting_origin) rescue nil
+    origin_host = uri&.host&.downcase || requesting_origin.gsub(/https?:\/\//, "").split(":").first&.downcase
+    return if origin_host.blank?
+
+    is_allowed = (Subforem.cached_domains + [Settings::General.app_domain]).compact.map(&:downcase).include?(origin_host) ||
+                 OrgCustomDomainConstraint.custom_domain_org_for_host(origin_host).present?
+
+    if is_allowed
       headers["Access-Control-Allow-Origin"] = requesting_origin
       headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
       headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"

--- a/app/controllers/auth_pass_controller.rb
+++ b/app/controllers/auth_pass_controller.rb
@@ -106,9 +106,11 @@ class AuthPassController < ApplicationController
                  OrgCustomDomainConstraint.custom_domain_org_for_host(origin_host).present?
 
     if is_allowed
-      scheme = uri&.scheme || "https"
+      scheme = (uri&.scheme || "https").downcase
+      scheme = "https" unless %w[http https].include?(scheme)
+      host = (uri&.host || origin_host).downcase
       port_suffix = uri&.port && ![80, 443].include?(uri.port) ? ":#{uri.port}" : ""
-      normalized_origin = uri&.host ? "#{scheme}://#{uri.host}#{port_suffix}" : "#{scheme}://#{origin_host}"
+      normalized_origin = "#{scheme}://#{host}#{port_suffix}"
       response.headers["Content-Security-Policy"] = "frame-ancestors 'self' #{normalized_origin}"
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -555,5 +555,23 @@ module ApplicationHelper
       subforem_aware_sign_up_url(path)
     end
   end
+
+  def custom_domain_main_app_url(custom_org)
+    return unless custom_org.present?
+
+    path = request.path.to_s
+    query = request.query_string.present? ? "?#{request.query_string}" : ""
+    main_path = if path == "/" || path.blank?
+                  "/#{custom_org.slug}"
+                elsif path.start_with?("/p/")
+                  "/#{custom_org.slug}#{path}"
+                elsif path.start_with?("/#{custom_org.slug}/") || path == "/#{custom_org.slug}"
+                  path
+                else
+                  "/#{custom_org.slug}#{path.start_with?('/') ? path : "/#{path}"}"
+                end
+
+    URL.url("#{main_path}#{query}")
+  end
 end
 

--- a/app/lib/middlewares/set_subforem.rb
+++ b/app/lib/middlewares/set_subforem.rb
@@ -49,9 +49,11 @@ module Middlewares
 
         # Set Content-Security-Policy header to allow embedding in iframes for all subforems
         headers.delete("X-Frame-Options")
-        allowed_domains = Subforem.cached_all_domains + [Settings::General.app_domain]
-        csp_value = "frame-ancestors " + allowed_domains.map { |d| "https://#{d}" }.join(" ")
-        headers["Content-Security-Policy"] = csp_value
+        unless headers["Content-Security-Policy"]&.include?("frame-ancestors")
+          allowed_domains = (Subforem.cached_all_domains + [Settings::General.app_domain]).compact.uniq
+          csp_value = "frame-ancestors " + allowed_domains.map { |d| "https://#{d}" }.join(" ")
+          headers["Content-Security-Policy"] = csp_value
+        end
 
       rescue PublicSuffix::DomainInvalid
         Rails.logger.error("Invalid domain: #{request.host}")

--- a/app/lib/middlewares/set_subforem.rb
+++ b/app/lib/middlewares/set_subforem.rb
@@ -8,7 +8,9 @@ module Middlewares
     def call(env)
       request = Rack::Request.new(env)
 
-      domain = request.GET["passed_domain"].presence || request.host
+      raw_domain = request.GET["passed_domain"].presence || request.host
+      parsed_host = URI.parse(raw_domain).host rescue nil
+      domain = parsed_host.presence || raw_domain.gsub(%r{\Ahttps?://}, "").split("/").first&.split(":")&.first.presence || raw_domain
       RequestStore.store[:default_subforem_id]     = Subforem.cached_default_id
       RequestStore.store[:subforem_id]             = Subforem.cached_id_by_domain(domain)
       RequestStore.store[:root_subforem_id]        = Subforem.cached_root_id

--- a/app/views/layouts/_bottom_scripts.html.erb
+++ b/app/views/layouts/_bottom_scripts.html.erb
@@ -1,6 +1,14 @@
 <% # This script is used to authenticate the user in the subforum iframe %>
 <% # Could be moved to a separate file with some re-factoring %>
-<% default_url_component = RequestStore.store[:subforem_id] == RequestStore.store[:default_subforem_id] ? "#{URL.protocol}#{RequestStore.store[:root_subforem_domain]}" : "#{URL.protocol}#{RequestStore.store[:default_subforem_domain]}" %>
+<% custom_org = request.env["forem.custom_domain_org"] %>
+<% custom_domain_redirect_url = custom_domain_main_app_url(custom_org) if custom_org.present? %>
+<% default_url_component = if custom_org.present?
+                             URL.url(nil)
+                           elsif RequestStore.store[:subforem_id] == RequestStore.store[:default_subforem_id]
+                             "#{URL.protocol}#{RequestStore.store[:root_subforem_domain]}"
+                           else
+                             "#{URL.protocol}#{RequestStore.store[:default_subforem_domain]}"
+                           end %>
 <script>
   var userSignedIn = <%= user_signed_in? %>;
   if (document.readyState === 'complete' || document.readyState === 'interactive') {
@@ -10,64 +18,93 @@
   }
 
   function initAuth() {
-    var paramToken = new URLSearchParams(window.location.search).get('jwt');
-
-    if (paramToken && !userSignedIn) {
-      authenticateUser(paramToken);
-    } else {
+    <% if custom_domain_redirect_url.present? %>
       var iframe = document.createElement('iframe');
       iframe.style.display = 'none';
-      iframe.src = '<%= default_url_component unless user_signed_in? %>/auth_pass/iframe';
-  
+      iframe.src = '<%= default_url_component unless user_signed_in? %>/auth_pass/iframe?passed_domain=' + encodeURIComponent(window.location.origin || (window.location.protocol + '//' + window.location.host));
+
       document.body.appendChild(iframe);
-  
+
       window.addEventListener('message', function(event) {
         if (event.origin !== '<%= default_url_component %>' && event.origin !== window.location.origin) {
           return;
         }
-  
+
         var data = event.data;
-  
+
         if (data.authenticated && !userSignedIn) {
-          authenticateUser(data.token);
+          var redirectUrl = '<%= raw j(custom_domain_redirect_url) %>';
+          if (window.location.hash) {
+            redirectUrl += window.location.hash;
+          }
+          window.location.replace(redirectUrl);
         } else if(data.authenticated && window.ReactNativeWebView && window.ReactNativeWebView.postMessage) {
           window.ReactNativeWebView.postMessage(JSON.stringify({
             action: 'login',
             token: data.token,
           }));
         }
-      });  
-    }
-
-    function authenticateUser(token) {
-      fetch('/auth_pass/token_login', {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRF-Token': getMetaContent('csrf-token'),
-        },
-        body: JSON.stringify({ token: token }),
-      })
-      .then(function(response) {
-        return response.json();
-      })
-      .then(function(data) {
-        if (data.success) {
-          if (document.head.querySelector('meta[name="user-signed-in"][content="false"]')) {
-            // Reload the page to update the user's state
-            location.reload();
-          }
-        }
-      })
-      .catch(function(error) {
-        console.error('Error during authentication:', error);
       });
-    }
+    <% else %>
+      var paramToken = new URLSearchParams(window.location.search).get('jwt');
 
-    function getMetaContent(name) {
-      var element = document.querySelector('meta[name="' + name + '"]');
-      return element ? element.getAttribute('content') : '';
-    }
+      if (paramToken && !userSignedIn) {
+        authenticateUser(paramToken);
+      } else {
+        var iframe = document.createElement('iframe');
+        iframe.style.display = 'none';
+        iframe.src = '<%= default_url_component unless user_signed_in? %>/auth_pass/iframe?passed_domain=' + encodeURIComponent(window.location.origin || (window.location.protocol + '//' + window.location.host));
+
+        document.body.appendChild(iframe);
+
+        window.addEventListener('message', function(event) {
+          if (event.origin !== '<%= default_url_component %>' && event.origin !== window.location.origin) {
+            return;
+          }
+
+          var data = event.data;
+
+          if (data.authenticated && !userSignedIn) {
+            authenticateUser(data.token);
+          } else if(data.authenticated && window.ReactNativeWebView && window.ReactNativeWebView.postMessage) {
+            window.ReactNativeWebView.postMessage(JSON.stringify({
+              action: 'login',
+              token: data.token,
+            }));
+          }
+        });
+      }
+
+      function authenticateUser(token) {
+        fetch('/auth_pass/token_login', {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': getMetaContent('csrf-token'),
+          },
+          body: JSON.stringify({ token: token }),
+        })
+        .then(function(response) {
+          return response.json();
+        })
+        .then(function(data) {
+          if (data.success) {
+            if (document.head.querySelector('meta[name="user-signed-in"][content="false"]')) {
+              // Reload the page to update the user's state
+              location.reload();
+            }
+          }
+        })
+        .catch(function(error) {
+          console.error('Error during authentication:', error);
+        });
+      }
+
+      function getMetaContent(name) {
+        var element = document.querySelector('meta[name="' + name + '"]');
+        return element ? element.getAttribute('content') : '';
+      }
+    <% end %>
   }
 </script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -224,7 +224,7 @@
     <div id="cookie-consent"></div>
   <% end %>
   <%= render "articles/reaction_category_resources" %>
-  <% if RequestStore.store[:subforem_id].present? %>
+  <% if RequestStore.store[:subforem_id].present? || request.env["forem.custom_domain_org"].present? %>
     <%= render "layouts/bottom_scripts"  %>
   <% end %>
   <%= Settings::UserExperience.bottom_of_body_content.html_safe %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -656,4 +656,51 @@ RSpec.describe ApplicationHelper do
       expect(helper.should_render_favorited_marker?(trimmed)).to be false
     end
   end
+
+  describe "#custom_domain_main_app_url" do
+    let(:organization) { build_stubbed(:organization, slug: "myorg", custom_domain: "blog.myorg.com") }
+
+    before do
+      allow(Settings::General).to receive(:app_domain).and_return("forem.com")
+    end
+
+    it "returns nil when custom_org is nil" do
+      expect(helper.custom_domain_main_app_url(nil)).to be_nil
+    end
+
+    it "maps root path to organization profile on main domain" do
+      request_double = instance_double(ActionDispatch::Request, path: "/", query_string: "")
+      allow(helper).to receive(:request).and_return(request_double)
+
+      expect(helper.custom_domain_main_app_url(organization)).to eq("http://forem.com/myorg")
+    end
+
+    it "preserves query string when mapping root path" do
+      request_double = instance_double(ActionDispatch::Request, path: "/", query_string: "sort=top&page=2")
+      allow(helper).to receive(:request).and_return(request_double)
+
+      expect(helper.custom_domain_main_app_url(organization)).to eq("http://forem.com/myorg?sort=top&page=2")
+    end
+
+    it "maps custom page /p/:page_suffix" do
+      request_double = instance_double(ActionDispatch::Request, path: "/p/about", query_string: "")
+      allow(helper).to receive(:request).and_return(request_double)
+
+      expect(helper.custom_domain_main_app_url(organization)).to eq("http://forem.com/myorg/p/about")
+    end
+
+    it "maps article path /:slug" do
+      request_double = instance_double(ActionDispatch::Request, path: "/my-article", query_string: "")
+      allow(helper).to receive(:request).and_return(request_double)
+
+      expect(helper.custom_domain_main_app_url(organization)).to eq("http://forem.com/myorg/my-article")
+    end
+
+    it "handles article path already containing org slug /:org_slug/:slug" do
+      request_double = instance_double(ActionDispatch::Request, path: "/myorg/my-article", query_string: "")
+      allow(helper).to receive(:request).and_return(request_double)
+
+      expect(helper.custom_domain_main_app_url(organization)).to eq("http://forem.com/myorg/my-article")
+    end
+  end
 end

--- a/spec/lib/middlewares/set_subforem_spec.rb
+++ b/spec/lib/middlewares/set_subforem_spec.rb
@@ -114,6 +114,13 @@ RSpec.describe Middlewares::SetSubforem do
         expect(RequestStore.store[:subforem_id]).to eq(subforem.id)
         expect(RequestStore.store[:subforem_domain]).to eq("override.example.com")
       end
+
+      it "correctly parses and uses passed_domain when provided as a full URL" do
+        url_env = Rack::MockRequest.env_for("https://actual.example.com/articles?passed_domain=https://override.example.com")
+        middleware.call(url_env)
+        expect(RequestStore.store[:subforem_id]).to eq(subforem.id)
+        expect(RequestStore.store[:subforem_domain]).to eq("override.example.com")
+      end
     end
 
     context "when a request has an empty body and a multipart Content-Type header" do

--- a/spec/requests/auth_passes_spec.rb
+++ b/spec/requests/auth_passes_spec.rb
@@ -95,4 +95,77 @@ RSpec.describe "AuthPassController", type: :request do
       end
     end
   end
+
+  describe "GET /auth_pass/iframe" do
+    before do
+      allow(Settings::General).to receive(:app_domain).and_return("forem.com")
+    end
+
+    context "when requested on an unauthorized host" do
+      it "returns 401 unauthorized" do
+        host! "unauthorized-domain.com"
+        get "/auth_pass/iframe"
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.body).to eq("Unauthorized")
+      end
+    end
+
+    context "when user is signed in" do
+      before do
+        sign_in user
+      end
+
+      it "renders the iframe view with authentication token" do
+        host! "forem.com"
+        get "/auth_pass/iframe"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("authenticated: true")
+        expect(response.body).to include("window.parent.postMessage")
+      end
+    end
+
+    context "when user is not signed in" do
+      it "renders empty html with status ok" do
+        host! "forem.com"
+        get "/auth_pass/iframe"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq("<html><body></body></html>")
+      end
+    end
+
+    context "with passed_domain from a custom organization domain" do
+      let!(:organization) { create(:organization, custom_domain: "blog.myorg.com") }
+
+      context "when org_custom_domain feature flag is enabled" do
+        before do
+          FeatureFlag.enable(:org_custom_domain, FeatureFlag::Actor.new(organization))
+        end
+
+        it "sets CSP frame-ancestors header with the passed custom domain" do
+          host! "forem.com"
+          get "/auth_pass/iframe", params: { passed_domain: "https://blog.myorg.com" }
+
+          expect(response).to have_http_status(:ok)
+          expect(response.headers["Content-Security-Policy"]).to eq("frame-ancestors 'self' https://blog.myorg.com")
+        end
+      end
+
+      context "when org_custom_domain feature flag is disabled" do
+        before do
+          FeatureFlag.disable(:org_custom_domain, FeatureFlag::Actor.new(organization))
+        end
+
+        it "does not set CSP frame-ancestors for the custom domain" do
+          host! "forem.com"
+          get "/auth_pass/iframe", params: { passed_domain: "https://blog.myorg.com" }
+
+          expect(response).to have_http_status(:ok)
+          expect(response.headers["Content-Security-Policy"]).not_to include("blog.myorg.com")
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/custom_domain_auth_redirect_spec.rb
+++ b/spec/requests/custom_domain_auth_redirect_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe "Custom Domain Iframe Auth Redirect", type: :request do
+  let!(:organization) { create(:organization, slug: "mlh", custom_domain: "blog.mlh.com") }
+  let(:user) { create(:user) }
+  let!(:article) { create(:article, organization: organization, user: user, slug: "hackathon-guide", title: "Hackathon Guide") }
+
+  before do
+    allow(Settings::General).to receive(:app_domain).and_return("forem.com")
+    FeatureFlag.enable(:org_custom_domain, FeatureFlag::Actor.new(organization))
+    MemoryFirstCache.delete("org_custom_domains")
+  end
+
+  describe "rendered auth iframe script on custom domains" do
+    context "when viewing custom domain root" do
+      it "renders redirect script pointing to organization main domain profile" do
+        get "http://blog.mlh.com/"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("auth_pass/iframe")
+        expect(response.body).to include("http://forem.com/auth_pass/iframe")
+        expect(response.body).to include("var redirectUrl = 'http://forem.com/mlh'")
+        expect(response.body).to include("window.location.replace(redirectUrl)")
+      end
+
+      it "preserves query parameters in redirect script" do
+        get "http://blog.mlh.com/?sort=top&page=2"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("var redirectUrl = 'http://forem.com/mlh?sort=top&page=2'")
+        expect(response.body).to include("window.location.replace(redirectUrl)")
+      end
+    end
+
+    context "when viewing custom domain article show" do
+      it "renders redirect script pointing to main domain article URL" do
+        get "http://blog.mlh.com/hackathon-guide"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("http://forem.com/auth_pass/iframe")
+        expect(response.body).to include("var redirectUrl = 'http://forem.com/mlh/hackathon-guide'")
+        expect(response.body).to include("window.location.replace(redirectUrl)")
+      end
+    end
+
+    context "when viewing custom domain custom page" do
+      let!(:custom_page) { create(:page, organization: organization, slug: "#{organization.slug}/about", body_markdown: "About MLH") }
+
+      before do
+        FeatureFlag.enable(:org_readme, FeatureFlag::Actor.new(organization))
+      end
+
+      it "renders redirect script pointing to main domain custom page URL" do
+        get "http://blog.mlh.com/p/about"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("http://forem.com/auth_pass/iframe")
+        expect(response.body).to include("var redirectUrl = 'http://forem.com/mlh/p/about'")
+        expect(response.body).to include("window.location.replace(redirectUrl)")
+      end
+    end
+  end
+
+  describe "CORS and CSP for custom organization domains" do
+    it "allows custom organization domain in CORS headers for AuthPassController" do
+      token = JWT.encode({ user_id: user.id, exp: 5.minutes.from_now.to_i }, Rails.application.secret_key_base)
+
+      post "/auth_pass/token_login",
+           params: { token: token }.to_json,
+           headers: { "Origin" => "https://blog.mlh.com", "Content-Type" => "application/json" }
+
+      expect(response.headers["Access-Control-Allow-Origin"]).to eq("https://blog.mlh.com")
+      expect(response.headers["Access-Control-Allow-Credentials"]).to eq("true")
+    end
+
+    it "sets dynamic per-request CSP frame-ancestors for valid custom domain on iframe endpoint" do
+      get "http://forem.com/auth_pass/iframe?passed_domain=https://blog.mlh.com"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Content-Security-Policy"]).to eq("frame-ancestors 'self' https://blog.mlh.com")
+    end
+
+    it "does not include unauthorized origin in dynamic CSP on iframe endpoint" do
+      get "http://forem.com/auth_pass/iframe?passed_domain=https://unauthorized-domain.com"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Content-Security-Policy"]).not_to include("unauthorized-domain.com")
+    end
+  end
+end

--- a/spec/requests/custom_domain_auth_redirect_spec.rb
+++ b/spec/requests/custom_domain_auth_redirect_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Custom Domain Iframe Auth Redirect", type: :request do
   before do
     allow(Settings::General).to receive(:app_domain).and_return("forem.com")
     FeatureFlag.enable(:org_custom_domain, FeatureFlag::Actor.new(organization))
-    MemoryFirstCache.delete("org_custom_domains")
+    MemoryFirstCache.delete("org_custom_domain_id:#{organization.custom_domain}")
   end
 
   describe "rendered auth iframe script on custom domains" do

--- a/spec/system/homepage/user_visits_homepage_articles_spec.rb
+++ b/spec/system/homepage/user_visits_homepage_articles_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe "User visits a homepage" do
   let!(:article) { create(:article, reactions_count: 12, featured: true, user: create(:user, profile_image: nil)) }
   let!(:article2) { create(:article, reactions_count: 20, featured: true, user: create(:user, profile_image: nil)) }
   # Let's use yesterday's date for this instead of relying on a magic date.
-  let!(:timestamp) { "#{Date.yesterday.to_fs('%Y-%M-%d')}T10:00:00Z" }
-  let(:published_datetime) { Time.zone.parse(timestamp) }
-  let(:published_date) { published_datetime.strftime("%b %e").gsub("  ", " ") }
+  let(:published_datetime) { 1.day.ago.utc.change(hour: 10, min: 0, sec: 0) }
+  let(:timestamp) { article.published_timestamp }
+  let(:published_date) { article.readable_publish_date }
 
   context "when no options specified" do
     context "when main featured article" do


### PR DESCRIPTION
## What does this PR do?
Adjusts the iframe auth pass flow so that when a visitor on an organization custom domain (e.g. `blog.mlh.com`) is detected to be signed in on `dev.to` via the iframe, they are immediately redirected to the `dev.to` version of the page (e.g. `https://dev.to/mlh/article-slug`), instead of attempting to create and manage separate session cookies on each custom domain.

### Key Changes
1. **Dynamic Per-Request CSP**:
   - The auth iframe request passes `?passed_domain=` with the requesting window origin (a safe param already permitted in Fastly `safe_params_list.vcl`).
   - `AuthPassController#iframe` dynamically sets `Content-Security-Policy: frame-ancestors 'self' <passed_domain>` when the host is a valid custom organization domain (or subforem / app domain).
2. **Immediate Client Redirect**:
   - Added helper `custom_domain_main_app_url(custom_org)` to map custom domain paths (root, custom pages, articles, query parameters, hash fragments) to the main domain.
   - On custom organization domains, when the iframe responds with `data.authenticated: true`, the page immediately executes `window.location.replace(redirectUrl)` without calling `/auth_pass/token_login`.
3. **Regression Tests**:
   - Added `spec/requests/custom_domain_auth_redirect_spec.rb`.
   - Enhanced `spec/helpers/application_helper_spec.rb` and `spec/requests/auth_passes_spec.rb` to test iframe auth, dynamic CSP headers, and URL resolution.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790188085&installation_model_id=424141&pr_number=23770&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23770&signature=ee11519e3780156997fd4f898cb39f2ffe1476352e90783396db7a8ec06e246a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->