### PR TITLE
Add `type_of` query parameter filtering to events API

### DIFF
--- a/app/controllers/api/v0/events_controller.rb
+++ b/app/controllers/api/v0/events_controller.rb
@@ -14,6 +14,9 @@ module Api
         unless @user&.administrative_access_to?(resource: Event)
           @events = @events.published
         end
+        if params[:type_of].present? && Event.type_ofs.key?(params[:type_of])
+          @events = @events.where(type_of: params[:type_of])
+        end
         render json: @events.order(created_at: :desc)
       end
 
@@ -21,6 +24,7 @@ module Api
         unless @event.published? || @user&.administrative_access_to?(resource: Event)
           return render json: { error: "Event not found" }, status: :not_found
         end
+
         render json: @event
       end
 
@@ -57,9 +61,9 @@ module Api
       def evaluate_authentication
         # Forem's ApiController usually requires valid token if provided, but optional if omitted.
         # This safely tries to log them in if token is sent.
-        if request.headers["api-key"]
-          authenticate!
-        end
+        return unless request.headers["api-key"]
+
+        authenticate!
       end
 
       def set_event
@@ -70,19 +74,19 @@ module Api
 
       def event_params
         params.require(:event).permit(
-          :title, 
+          :title,
           :event_name_slug,
           :event_variation_slug,
-          :description, 
-          :primary_stream_url, 
-          :published, 
-          :start_time, 
-          :end_time, 
-          :type_of, 
-          :user_id, 
-          :organization_id, 
+          :description,
+          :primary_stream_url,
+          :published,
+          :start_time,
+          :end_time,
+          :type_of,
+          :user_id,
+          :organization_id,
           :tag_list,
-          data: {}
+          data: {},
         )
       end
     end

--- a/spec/requests/api/v0/events_spec.rb
+++ b/spec/requests/api/v0/events_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Api::V0::Events", type: :request do
+RSpec.describe "Api::V0::Events" do
   let!(:admin) { create(:user).tap { |u| u.add_role(:super_admin) } }
   let!(:admin_api_secret) { create(:api_secret, user: admin) }
   let!(:admin_headers) { { "api-key" => admin_api_secret.secret, "content-type" => "application/json" } }
@@ -17,8 +17,8 @@ RSpec.describe "Api::V0::Events", type: :request do
       it "returns only published events" do
         get "/api/events"
         expect(response).to have_http_status(:success)
-        
-        json = JSON.parse(response.body)
+
+        json = response.parsed_body
         expect(json.count).to eq(1)
         expect(json.first["id"]).to eq(published_event.id)
       end
@@ -27,7 +27,7 @@ RSpec.describe "Api::V0::Events", type: :request do
     context "when authenticated as basic user" do
       it "returns only published events" do
         get "/api/events", headers: user_headers
-        json = JSON.parse(response.body)
+        json = response.parsed_body
         expect(json.count).to eq(1)
       end
     end
@@ -35,8 +35,47 @@ RSpec.describe "Api::V0::Events", type: :request do
     context "when authenticated as an administrator" do
       it "returns all events including drafts" do
         get "/api/events", headers: admin_headers
-        json = JSON.parse(response.body)
+        json = response.parsed_body
         expect(json.count).to eq(2)
+      end
+    end
+
+    context "when filtering by type_of" do
+      let!(:challenge_event) { create(:event, published: true, type_of: :challenge) }
+      let!(:draft_challenge_event) { create(:event, published: false, type_of: :challenge) }
+      let!(:stream_event) { create(:event, published: true, type_of: :live_stream) }
+
+      it "returns only events matching the requested type_of when unauthenticated" do
+        get "/api/events", params: { type_of: "challenge" }
+        expect(response).to have_http_status(:success)
+
+        json = response.parsed_body
+        expect(json.pluck("id")).to contain_exactly(challenge_event.id)
+      end
+
+      it "returns only events matching the requested type_of for basic users" do
+        get "/api/events", params: { type_of: "live_stream" }, headers: user_headers
+        expect(response).to have_http_status(:success)
+
+        json = response.parsed_body
+        expect(json.pluck("id")).to include(stream_event.id)
+        expect(json.pluck("id")).not_to include(challenge_event.id)
+      end
+
+      it "returns matching events including drafts for administrators" do
+        get "/api/events", params: { type_of: "challenge" }, headers: admin_headers
+        expect(response).to have_http_status(:success)
+
+        json = response.parsed_body
+        expect(json.pluck("id")).to contain_exactly(challenge_event.id, draft_challenge_event.id)
+      end
+
+      it "ignores invalid type_of values" do
+        get "/api/events", params: { type_of: "nonexistent_type" }
+        expect(response).to have_http_status(:success)
+
+        json = response.parsed_body
+        expect(json.pluck("id")).to include(published_event.id, challenge_event.id, stream_event.id)
       end
     end
   end
@@ -94,9 +133,9 @@ RSpec.describe "Api::V0::Events", type: :request do
     end
 
     it "allows administrators to create events" do
-      expect {
+      expect do
         post "/api/events", params: valid_params, headers: admin_headers
-      }.to change(Event, :count).by(1)
+      end.to change(Event, :count).by(1)
       expect(response).to have_http_status(:created)
     end
   end

--- a/spec/requests/api/v1/docs/events_spec.rb
+++ b/spec/requests/api/v1/docs/events_spec.rb
@@ -1,0 +1,149 @@
+require "rails_helper"
+require "swagger_helper"
+
+# rubocop:disable RSpec/EmptyExampleGroup
+# rubocop:disable RSpec/VariableName
+
+RSpec.describe "Api::V1::Docs::Events" do
+  let(:admin) { create(:user, :super_admin) }
+  let(:admin_api_secret) { create(:api_secret, user: admin) }
+  let!(:event) { create(:event, published: true, type_of: :challenge) }
+
+  describe "GET /api/events" do
+    path "/api/events" do
+      get "Retrieve events" do
+        tags "events"
+        security []
+        description "Retrieve a list of events on the platform.
+
+### Query Parameters:
+- **type_of**: Filter events by their type (`live_stream`, `takeover`, `other`, `challenge`)."
+        operationId "getEvents"
+        produces "application/json"
+        parameter name: :type_of,
+                  in: :query,
+                  required: false,
+                  description: "Filter events by type.",
+                  schema: {
+                    type: :string,
+                    enum: %w[live_stream takeover other challenge]
+                  }
+
+        response "200", "A list of events" do
+          let(:type_of) { "challenge" }
+          schema type: :array, items: { "$ref": "#/components/schemas/Event" }
+          add_examples
+
+          run_test!
+        end
+      end
+
+      post "Create an event" do
+        tags "events"
+        description "Create a new event. Requires administrator privileges."
+        operationId "createEvent"
+        consumes "application/json"
+        produces "application/json"
+        parameter name: :event_params,
+                  in: :body,
+                  description: "Event parameters to create.",
+                  schema: { "$ref": "#/components/schemas/EventInput" }
+
+        response "201", "Event created" do
+          let(:"api-key") { admin_api_secret.secret }
+          let(:event_params) do
+            {
+              event: {
+                title: "Community Challenge",
+                event_name_slug: "community-challenge",
+                event_variation_slug: "2026",
+                start_time: 1.day.from_now.iso8601,
+                end_time: 2.days.from_now.iso8601,
+                type_of: "challenge",
+                published: true
+              }
+            }
+          end
+          schema "$ref": "#/components/schemas/Event"
+          add_examples
+
+          run_test!
+        end
+      end
+    end
+  end
+
+  describe "GET /api/events/{id}" do
+    path "/api/events/{id}" do
+      get "Retrieve an event" do
+        tags "events"
+        security []
+        description "Retrieve a single event by ID."
+        operationId "getEventById"
+        produces "application/json"
+        parameter name: :id, in: :path, required: true,
+                  description: "ID of the event.",
+                  schema: { type: :integer }
+
+        response "200", "The requested event" do
+          let(:id) { event.id }
+          schema "$ref": "#/components/schemas/Event"
+          add_examples
+
+          run_test!
+        end
+      end
+
+      patch "Update an event" do
+        tags "events"
+        description "Update an existing event. Requires administrator privileges."
+        operationId "updateEvent"
+        consumes "application/json"
+        produces "application/json"
+        parameter name: :id, in: :path, required: true,
+                  description: "ID of the event to update.",
+                  schema: { type: :integer }
+        parameter name: :event_params,
+                  in: :body,
+                  description: "Event parameters to update.",
+                  schema: { "$ref": "#/components/schemas/EventInput" }
+
+        response "200", "Event updated" do
+          let(:"api-key") { admin_api_secret.secret }
+          let(:id) { event.id }
+          let(:event_params) do
+            {
+              event: {
+                title: "Updated Challenge Title"
+              }
+            }
+          end
+          schema "$ref": "#/components/schemas/Event"
+          add_examples
+
+          run_test!
+        end
+      end
+
+      delete "Delete an event" do
+        tags "events"
+        description "Delete an event. Requires administrator privileges."
+        operationId "deleteEvent"
+        parameter name: :id, in: :path, required: true,
+                  description: "ID of the event to delete.",
+                  schema: { type: :integer }
+
+        response "204", "Event deleted" do
+          let(:"api-key") { admin_api_secret.secret }
+          let(:id) { event.id }
+          add_examples
+
+          run_test!
+        end
+      end
+    end
+  end
+end
+
+# rubocop:enable RSpec/VariableName
+# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -848,6 +848,59 @@ The default maximum value can be overridden by \"API_PER_PAGE_MAX\" environment 
               cover_image_url: { type: :string }
             },
             required: %w[id domain root name description logo_image_url cover_image_url]
+          },
+          Event: {
+            description: "Representation of an event",
+            type: :object,
+            properties: {
+              id: { type: :integer, format: :int64 },
+              title: { type: :string },
+              event_name_slug: { type: :string },
+              event_variation_slug: { type: :string },
+              description: { type: :string, nullable: true },
+              type_of: { type: :string, enum: %w[live_stream takeover other challenge] },
+              start_time: { type: :string, format: "date-time" },
+              end_time: { type: :string, format: "date-time" },
+              published: { type: :boolean },
+              primary_stream_url: { type: :string, nullable: true },
+              bg_color_hex: { type: :string, nullable: true },
+              broadcast_config: { type: :string, enum: %w[no_broadcast tagged_broadcast global_broadcast] },
+              broadcast_ended_at: { type: :string, format: "date-time", nullable: true },
+              user_id: { type: :integer, format: :int64, nullable: true },
+              organization_id: { type: :integer, format: :int64, nullable: true },
+              page_id: { type: :integer, format: :int64, nullable: true },
+              data: { type: :object, nullable: true },
+              tags_array: { type: :array, items: { type: :string } },
+              cached_tag_list: { type: :string, nullable: true },
+              created_at: { type: :string, format: "date-time" },
+              updated_at: { type: :string, format: "date-time" }
+            },
+            required: %w[id title event_name_slug event_variation_slug type_of start_time end_time published created_at updated_at]
+          },
+          EventInput: {
+            description: "Representation of an Event to be created/updated",
+            type: :object,
+            properties: {
+              event: {
+                type: :object,
+                properties: {
+                  title: { type: :string },
+                  event_name_slug: { type: :string },
+                  event_variation_slug: { type: :string },
+                  description: { type: :string, nullable: true },
+                  primary_stream_url: { type: :string, nullable: true },
+                  published: { type: :boolean, default: false },
+                  start_time: { type: :string, format: "date-time" },
+                  end_time: { type: :string, format: "date-time" },
+                  type_of: { type: :string, enum: %w[live_stream takeover other challenge] },
+                  organization_id: { type: :integer, nullable: true },
+                  tag_list: { type: :string, nullable: true },
+                  data: { type: :object, nullable: true }
+                },
+                required: %w[title event_name_slug event_variation_slug start_time end_time]
+              }
+            },
+            required: %w[event]
           }
         }
       }

--- a/swagger/v1/api_v1.json
+++ b/swagger/v1/api_v1.json
@@ -2651,6 +2651,185 @@
         }
       }
     },
+    "/api/events": {
+      "get": {
+        "summary": "Retrieve events",
+        "tags": [
+          "events"
+        ],
+        "security": [
+
+        ],
+        "description": "Retrieve a list of events on the platform.\n\n### Query Parameters:\n- **type_of**: Filter events by their type (`live_stream`, `takeover`, `other`, `challenge`).",
+        "operationId": "getEvents",
+        "parameters": [
+          {
+            "name": "type_of",
+            "in": "query",
+            "required": false,
+            "description": "Filter events by type.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "live_stream",
+                "takeover",
+                "other",
+                "challenge"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of events",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Event"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create an event",
+        "tags": [
+          "events"
+        ],
+        "description": "Create a new event. Requires administrator privileges.",
+        "operationId": "createEvent",
+        "parameters": [
+
+        ],
+        "responses": {
+          "201": {
+            "description": "Event created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventInput"
+              }
+            }
+          },
+          "description": "Event parameters to create."
+        }
+      }
+    },
+    "/api/events/{id}": {
+      "get": {
+        "summary": "Retrieve an event",
+        "tags": [
+          "events"
+        ],
+        "security": [
+
+        ],
+        "description": "Retrieve a single event by ID.",
+        "operationId": "getEventById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "ID of the event.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested event",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update an event",
+        "tags": [
+          "events"
+        ],
+        "description": "Update an existing event. Requires administrator privileges.",
+        "operationId": "updateEvent",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "ID of the event to update.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Event updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventInput"
+              }
+            }
+          },
+          "description": "Event parameters to update."
+        }
+      },
+      "delete": {
+        "summary": "Delete an event",
+        "tags": [
+          "events"
+        ],
+        "description": "Delete an event. Requires administrator privileges.",
+        "operationId": "deleteEvent",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "ID of the event to delete.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Event deleted"
+          }
+        }
+      }
+    },
     "/api/feedback_messages/{id}": {
       "patch": {
         "summary": "Update a feedback message's status (Admin)",
@@ -7707,6 +7886,190 @@
           "description",
           "logo_image_url",
           "cover_image_url"
+        ]
+      },
+      "Event": {
+        "description": "Representation of an event",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "title": {
+            "type": "string"
+          },
+          "event_name_slug": {
+            "type": "string"
+          },
+          "event_variation_slug": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "type_of": {
+            "type": "string",
+            "enum": [
+              "live_stream",
+              "takeover",
+              "other",
+              "challenge"
+            ]
+          },
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "end_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "published": {
+            "type": "boolean"
+          },
+          "primary_stream_url": {
+            "type": "string",
+            "nullable": true
+          },
+          "bg_color_hex": {
+            "type": "string",
+            "nullable": true
+          },
+          "broadcast_config": {
+            "type": "string",
+            "enum": [
+              "no_broadcast",
+              "tagged_broadcast",
+              "global_broadcast"
+            ]
+          },
+          "broadcast_ended_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "user_id": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "organization_id": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "page_id": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "data": {
+            "type": "object",
+            "nullable": true
+          },
+          "tags_array": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "cached_tag_list": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "event_name_slug",
+          "event_variation_slug",
+          "type_of",
+          "start_time",
+          "end_time",
+          "published",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "EventInput": {
+        "description": "Representation of an Event to be created/updated",
+        "type": "object",
+        "properties": {
+          "event": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "event_name_slug": {
+                "type": "string"
+              },
+              "event_variation_slug": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string",
+                "nullable": true
+              },
+              "primary_stream_url": {
+                "type": "string",
+                "nullable": true
+              },
+              "published": {
+                "type": "boolean",
+                "default": false
+              },
+              "start_time": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "end_time": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "type_of": {
+                "type": "string",
+                "enum": [
+                  "live_stream",
+                  "takeover",
+                  "other",
+                  "challenge"
+                ]
+              },
+              "organization_id": {
+                "type": "integer",
+                "nullable": true
+              },
+              "tag_list": {
+                "type": "string",
+                "nullable": true
+              },
+              "data": {
+                "type": "object",
+                "nullable": true
+              }
+            },
+            "required": [
+              "title",
+              "event_name_slug",
+              "event_variation_slug",
+              "start_time",
+              "end_time"
+            ]
+          }
+        },
+        "required": [
+          "event"
         ]
       }
     }


### PR DESCRIPTION
## What does this PR do?

Adds support for filtering events by `type_of` (e.g. `challenge`, `live_stream`, `takeover`, `other`) in the `/api/events` endpoint (`Api::V0::EventsController#index`).

### Key Changes
- **Controller**: `Api::V0::EventsController#index` filters events by `params[:type_of]` when present and valid according to `Event.type_ofs`.
- **Request Specs**: Added regression specs in `spec/requests/api/v0/events_spec.rb` covering filtering for unauthenticated, basic, and administrator users, as well as handling invalid type values.
- **OpenAPI / RSWAG Documentation**: Added RSWAG documentation in `spec/requests/api/v1/docs/events_spec.rb` and updated `spec/swagger_helper.rb` and `swagger/v1/api_v1.json`.

## Testing
- `bundle exec rspec spec/requests/api/v0/events_spec.rb spec/requests/api/v1/docs/events_spec.rb`
- `bundle exec rake rswag:specs:swaggerize`
- `bundle exec rubocop`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790253979&installation_model_id=424141&pr_number=23772&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23772&signature=24603a19aab87148809b04a3753aabfa30f03cc6d7ffe9d1b1ddbe198c0f587e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->