### PR TITLE
Customer.io: stop overriding the template sender, and stop double-sending broadcasts to the rollout cohort

### DIFF
--- a/app/mailers/custom_mailer.rb
+++ b/app/mailers/custom_mailer.rb
@@ -20,6 +20,15 @@ class CustomMailer < ApplicationMailer
     return if ForemInstance.customerio_email_cutover?
 
     @user = params[:user]
+
+    # That guard is global, but :customerio_email_delivery rolls out per actor:
+    # while it is partially on, the enabled cohort is already receiving this
+    # broadcast/newsletter/drip from the Customer.io side. Sending it from here
+    # too would deliver it twice to exactly those people. Emails::BatchCustomSendWorker
+    # skips them before we get here; this backstop also covers the drip worker,
+    # which builds its sends itself.
+    return if customerio_managed_recipient?
+
     @content = Email.replace_merge_tags(params[:content], @user)
     @subject = Email.replace_merge_tags(params[:subject], @user)
     @unsubscribe = generate_unsubscribe_token(@user.id, :email_newsletter)
@@ -40,5 +49,16 @@ class CustomMailer < ApplicationMailer
     end
 
     mail(to: @user.email, subject: @subject, from: email_from(@from_topic))
+  end
+
+  private
+
+  # Test sends are exempt: nothing on the Customer.io side duplicates them, and
+  # admins still need the preview while the flag is rolling out.
+  def customerio_managed_recipient?
+    return false unless ForemInstance.customerio_enabled?
+    return false if params[:subject].to_s.start_with?(Email::TEST_SUBJECT_PREFIX)
+
+    FeatureFlag.enabled_for_user?(Deliverable::CUSTOMERIO_FLAG, @user)
   end
 end

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -1,4 +1,8 @@
 class Email < ApplicationRecord
+  # Test sends are the same broadcast with a marked subject. Several guards key
+  # off it, so keep the marker in one place.
+  TEST_SUBJECT_PREFIX = "[TEST] ".freeze
+
   belongs_to :audience_segment, optional: true
   belongs_to :user_query, optional: true
   belongs_to :event, optional: true
@@ -90,8 +94,8 @@ class Email < ApplicationRecord
     users_batch = User.where(email: email_array)
     return if users_batch.empty?
 
-    Emails::BatchCustomSendWorker.perform_async(users_batch.map(&:id), "[TEST] #{subject}", body, type_of, id,
-                                                default_from_name_based_on_type)
+    Emails::BatchCustomSendWorker.perform_async(users_batch.map(&:id), "#{TEST_SUBJECT_PREFIX}#{subject}", body,
+                                                type_of, id, default_from_name_based_on_type)
   end
 
   def deliver_to_users

--- a/app/services/delivery_methods/customer_io.rb
+++ b/app/services/delivery_methods/customer_io.rb
@@ -33,9 +33,14 @@ module DeliveryMethods
     def build_message(mail)
       {}.tap do |message|
         # With a transactional_message_id the Customer.io template renders the
-        # content; without one this is a body passthrough send.
-        message[:body] = build_body(mail) unless settings[:transactional_message_id]
-        message[:from] = mail.from.first if mail.from
+        # content; without one this is a body passthrough send. The App API
+        # treats body/from in the request as overrides of what the template
+        # already defines, so the template's own sender identity only survives
+        # if we leave both out.
+        unless settings[:transactional_message_id]
+          message[:body] = build_body(mail)
+          message[:from] = mail.from.first if mail.from
+        end
         message[:subject] = mail.subject if mail.subject
         message[:identifiers] = { email: mail.to.first } if mail.to
         message[:reply_to] = mail.reply_to.first if mail.reply_to

--- a/app/workers/emails/batch_custom_send_worker.rb
+++ b/app/workers/emails/batch_custom_send_worker.rb
@@ -18,10 +18,15 @@ module Emails
                         .select(:id, :email, :name, :username)
                         .index_by(&:id)
 
+      test_send = subject.start_with?(Email::TEST_SUBJECT_PREFIX)
+
+      # Skip recipients Customer.io is already sending this broadcast to.
+      customerio_user_ids = test_send ? Set.new : customerio_managed_user_ids(users_by_id.values)
+
       # Bulk check: skip users who already received a non-test email for this email_id.
       # Uses a subquery with DISTINCT ON to get the most recent message per user,
       # then filters out [TEST] subjects — all in a single SQL round-trip.
-      already_sent_user_ids = if subject.start_with?("[TEST] ")
+      already_sent_user_ids = if test_send
                                 Set.new
                               else
                                 sql = Ahoy::Message.sanitize_sql_array([<<~SQL.squish, user_ids, email_id])
@@ -40,6 +45,7 @@ module Emails
         user = users_by_id[id]
         next unless user
         next if already_sent_user_ids.include?(id)
+        next if customerio_user_ids.include?(id)
 
         CustomMailer
           .with(
@@ -54,6 +60,24 @@ module Emails
           .deliver_now
       rescue StandardError => e
         Rails.logger.error("Error sending email to user with id: #{id}. Error: #{e.message}")
+      end
+    end
+
+    private
+
+    # The cutover guards in Email, this worker and Admin::EmailsController all
+    # key off the *global* flag state, but :customerio_email_delivery rolls out
+    # per actor. While it is partially on, the enabled cohort already receives
+    # broadcasts and newsletters from the Customer.io side, so sending from here
+    # too would deliver the same message twice to exactly those people.
+    #
+    # Test sends are exempt (see #perform): nothing on the Customer.io side
+    # duplicates them, and admins still need the preview during the rollout.
+    def customerio_managed_user_ids(users)
+      return Set.new unless ForemInstance.customerio_enabled?
+
+      users.each_with_object(Set.new) do |user, ids|
+        ids << user.id if FeatureFlag.enabled_for_user?(Deliverable::CUSTOMERIO_FLAG, user)
       end
     end
   end

--- a/spec/mailers/custom_mailer_spec.rb
+++ b/spec/mailers/custom_mailer_spec.rb
@@ -163,6 +163,47 @@ RSpec.describe CustomMailer, type: :mailer do
       end
     end
 
+    # Emails::BatchCustomSendWorker filters these recipients out first; this is
+    # the backstop for senders that build their own sends (the drip worker).
+    context "when the recipient has the Customer.io delivery flag enabled" do
+      let(:email) { create(:email, type_of: "newsletter") }
+
+      before do
+        allow(ForemInstance).to receive_messages(smtp_enabled?: true, customerio_enabled?: true)
+        allow(FeatureFlag).to receive(:enabled_for_user?)
+          .with(Deliverable::CUSTOMERIO_FLAG, having_attributes(id: user.id)).and_return(true)
+      end
+
+      it "sends nothing -- Customer.io is already sending this broadcast" do
+        expect do
+          described_class.with(
+            user: user, content: content, subject: subject, email_id: email.id,
+          ).custom_email.deliver_now
+        end.not_to change(ActionMailer::Base.deliveries, :count)
+      end
+
+      it "does not record an ahoy message" do
+        expect do
+          described_class.with(
+            user: user, content: content, subject: subject, email_id: email.id,
+          ).custom_email.deliver_now
+        end.not_to change(EmailMessage, :count)
+      end
+
+      it "still sends a test email so admins can preview during the rollout" do
+        # The recipient is flagged, so the send routes through Customer.io
+        # rather than landing in ActionMailer::Base.deliveries.
+        api_client = instance_double(Customerio::APIClient, send_email: { "delivery_id" => "dev-123" })
+        stub_const("CUSTOMERIO_API", api_client)
+
+        described_class.with(
+          user: user, content: content, subject: "[TEST] #{subject}", email_id: email.id,
+        ).custom_email.deliver_now
+
+        expect(api_client).to have_received(:send_email)
+      end
+    end
+
     context "when SendGrid is disabled" do
       before do
         allow(ForemInstance).to receive(:sendgrid_enabled?).and_return(false)

--- a/spec/services/delivery_methods/customer_io_spec.rb
+++ b/spec/services/delivery_methods/customer_io_spec.rb
@@ -39,6 +39,19 @@ RSpec.describe DeliveryMethods::CustomerIo do
     expect(message[:message_data]).to eq("name" => "Sloan")
   end
 
+  # The App API treats a from in the request as an override of the sender
+  # identity configured on the transactional message, so sending the Rails-side
+  # default would make every template send from ForemInstance.from_email_address.
+  it "omits the from when a transactional_message_id is present so the template's sender is used" do
+    message = delivered_message(transactional_message_id: "dev_test_template")
+    expect(message).not_to have_key(:from)
+  end
+
+  it "still lets a mailer override the sender explicitly through the delivery options" do
+    message = delivered_message(transactional_message_id: "dev_test_template", from: "custom@dev.to")
+    expect(message[:from]).to eq("custom@dev.to")
+  end
+
   it "forwards the one-click unsubscribe headers so RFC 8058 survives the Customer.io render" do
     mail["List-Unsubscribe"] = "<https://dev.to/email_subscriptions/unsubscribe?ut=token>"
     mail["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"

--- a/spec/workers/emails/batch_custom_send_worker_spec.rb
+++ b/spec/workers/emails/batch_custom_send_worker_spec.rb
@@ -28,6 +28,45 @@ RSpec.describe Emails::BatchCustomSendWorker, type: :worker do
       end
     end
 
+    # The cutover guard above is global, but the flag rolls out per actor: the
+    # enabled cohort already gets the broadcast from Customer.io, so sending it
+    # from here too would double-send to exactly those people.
+    context "when some recipients have the Customer.io delivery flag enabled" do
+      before do
+        allow(ForemInstance).to receive(:customerio_enabled?).and_return(true)
+        allow(FeatureFlag).to receive(:enabled_for_user?)
+          .with(Deliverable::CUSTOMERIO_FLAG, anything).and_return(false)
+        allow(FeatureFlag).to receive(:enabled_for_user?)
+          .with(Deliverable::CUSTOMERIO_FLAG, having_attributes(id: user.id)).and_return(true)
+      end
+
+      it "skips them and still sends to everyone else" do
+        worker.perform(user_ids, subject_line, content, type_of, email_id)
+
+        expect(CustomMailer).to have_received(:with).once
+        expect(CustomMailer).to have_received(:with).with(hash_including(user: user2))
+      end
+
+      it "still sends test emails so admins can preview during the rollout" do
+        worker.perform(user_ids, "[TEST] Subject", content, type_of, email_id)
+
+        expect(CustomMailer).to have_received(:with).twice
+      end
+    end
+
+    context "when Customer.io is not configured" do
+      before { allow(ForemInstance).to receive(:customerio_enabled?).and_return(false) }
+
+      it "does not consult the flag at all" do
+        allow(FeatureFlag).to receive(:enabled_for_user?)
+
+        worker.perform(user_ids, subject_line, content, type_of, email_id)
+
+        expect(FeatureFlag).not_to have_received(:enabled_for_user?)
+        expect(CustomMailer).to have_received(:with).twice
+      end
+    end
+
     context "when testing the async call" do
       it "queues the job with the correct arguments regardless of user ID order" do
         # Stub the class method perform_async


### PR DESCRIPTION
## What's this?

Two Customer.io delivery fixes found while auditing the rollout.

### 1. Stop overriding the transactional message's sender

`DeliveryMethods::CustomerIo#build_message` copied `mail.from` into the App API payload on every send. Customer.io treats a `from` in the request as an **override** of the sender identity configured on the transactional message, so every template send went out as `ForemInstance.from_email_address` (i.e. `"#{community_name} <#{Settings::SMTP.from_email_address}>"`), ignoring whatever the message is set up with in Customer.io.

`from` is now only sent on the body-passthrough path (no `transactional_message_id`), where the API needs it — mirroring the existing guard on `body`. A mailer can still override the sender explicitly by passing `from:` through `customerio_delivery_options`. Scoped to `from` only: `subject` and `reply_to` are still forwarded as before.

### 2. Don't double-send broadcasts to the rollout cohort

The cutover guards in `Email`, `Emails::BatchCustomSendWorker` and `Admin::EmailsController` all key off `ForemInstance.customerio_email_cutover?`, which reads the **global** `:customerio_email_delivery` state. The flag rolls out per actor, so while it is partially on those guards stay `false` and Forem keeps broadcasting to everyone — including the enabled cohort, who are already receiving the same broadcast from the Customer.io side. Those people get it twice.

- `Emails::BatchCustomSendWorker` now filters flag-enabled recipients out of each batch, alongside the existing already-sent filter.
- `CustomMailer#custom_email` has a per-recipient backstop, which also covers `Emails::DripEmailWorker` — it builds its sends itself and never passes through the batch worker.
- Test sends (`[TEST] ` subjects) stay exempt: nothing on the Customer.io side duplicates them, and admins need the preview during the rollout. The marker moved to `Email::TEST_SUBJECT_PREFIX` so all three guards agree on it.
- Forems without `CUSTOMERIO_APP_KEY` never consult the flag, so behaviour is unchanged for them.

## Related Tickets & Documents

n/a

## QA Instructions

```
bundle exec rspec spec/services/delivery_methods/customer_io_spec.rb \
                  spec/workers/emails/batch_custom_send_worker_spec.rb \
                  spec/mailers/custom_mailer_spec.rb
```

Behavioural checks:
1. Trigger any Customer.io-delivered transactional email (e.g. `dev_new_follower_email`) and confirm the delivery uses the sender configured on the transactional message rather than the Forem SMTP from address.
2. With `:customerio_email_delivery` enabled for a single actor, activate an admin broadcast and confirm that user receives nothing from Forem while everyone else does. Send a `[TEST]` email to that same user and confirm it still arrives.

## Added/updated tests?

- [x] Yes

https://claude.ai/code/session_012jDiQz996H7daE3dZbz1Hu