### PR TITLE
Fix flag dropdown not opening on the member Flags tab

### DIFF
--- a/app/views/admin/shared/_flag_reactions_table.html.erb
+++ b/app/views/admin/shared/_flag_reactions_table.html.erb
@@ -1,4 +1,12 @@
-<%= javascript_include_tag "admin/shared/flagReactionItemDropdownButton", defer: true %>
+<%# The dropdown script binds a single delegated click listener to #reaction-content.
+    This partial can be rendered more than once per page (a member's Flags tab lists
+    account flags and content flags separately), and including the script twice would
+    bind the listener twice, so every click would toggle a dropdown open and straight
+    back closed. Emit the tag only on the first render of the request. %>
+<% unless content_for?(:flag_reaction_dropdown_js) %>
+  <% content_for :flag_reaction_dropdown_js, javascript_include_tag("admin/shared/flagReactionItemDropdownButton", defer: true) %>
+  <%= yield :flag_reaction_dropdown_js %>
+<% end %>
 <% if vomit_reactions.present? %>
   <% vomit_reactions.each do |vomit_reaction| %>
     <%= render "admin/shared/flag_reaction_item",

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -226,6 +226,15 @@ RSpec.describe "/admin/member_manager/users" do
       expect(response.body).to include("Mark as Invalid")
     end
 
+    it "includes the flag dropdown script only once when both flag lists render" do
+      comment = create(:comment, user: user, commentable: create(:article))
+      create(:reaction, category: "vomit", reactable: comment, user: admin, status: "valid")
+
+      get "#{admin_user_path(user.id)}?tab=flags"
+
+      expect(response.body.scan("flagReactionItemDropdownButton").size).to eq(1)
+    end
+
     it "does not list content flags in the account flags section" do
       comment = create(:comment, user: user, commentable: create(:article))
       create(:reaction, category: "vomit", reactable: comment, user: admin, status: "valid")


### PR DESCRIPTION
Follow-up to #23776, which introduced this regression.

## Symptom

On `/admin/member_manager/users/:id?tab=flags`, clicking the `…` menu on any flag row does nothing. The button takes focus but no menu appears.

## Cause

`admin/shared/_flag_reactions_table` carried its own `javascript_include_tag`. #23776 renders that partial **twice** on the Flags tab (account flags, then content flags), so the page shipped two identical `<script>` tags and the dropdown script bound its delegated click listener to `#reaction-content` twice.

Both listeners fire on the same click:

1. First listener: `aria-expanded` is `false` → opens the menu, sets `aria-expanded="true"`, sets `display: block`.
2. Second listener: reads the value the first one just wrote, sees `true` → closes the menu, restores `aria-expanded="false"`, removes `display`, and calls `triggerButton.focus()`.

The menu opens and closes within one click, and the focus call is why the button visibly highlights while nothing else happens.

Confirmed against production: the rendered page contains two `<script src=".../flagReactionItemDropdownButton-….js">` tags. Replacing `#reaction-content` with a clone (which strips every listener) and binding a single handler opens the menu correctly — `aria-expanded: "true"`, `display: "block"`, menu contents `Mark as Valid / Mark as Invalid`.

## Fix

Emit the script tag only on the first render of a request, via a `content_for?` guard in the partial. Keeps the include colocated with the markup that needs it and requires no changes at the four call sites.

## Also improves (pre-existing)

`admin/comments/index.html.erb` and `admin/articles/index.html.erb` render their row partial as a **collection**, and each row contains both a `javascript_include_tag` and a `div#reaction-content`. Those pages were therefore already including the script N times and emitting N duplicate `reaction-content` IDs.

This PR reduces them to one script tag, so the first row's dropdown now works. The duplicate-ID problem on those pages is untouched and still leaves rows 2..N unwired — that predates #23776 and deserves its own fix, so I've deliberately left it out of scope here.

## Testing

New request spec asserts the script is included exactly once when both flag lists render. Verified it reports `got: 2` against the unfixed template.

`spec/requests/admin/users_spec.rb`, `comments_spec.rb`, `articles_spec.rb`: 118 examples, 0 failures. `erblint` clean.

Manual verification is worth doing post-deploy: open a member with a content flag, click the `…` menu, confirm it opens and Mark as Invalid recalculates the content's score.

https://claude.ai/code/session_01Mhbt1vtysxUGtHPdb9EcgB

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790435239&installation_model_id=424141&pr_number=23777&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23777&signature=263a5b077ded5beab56146c5a41abc7e87777845d7bada0e26ab30c9e1b6bf40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->