### PR TITLE
Add fallback width and height attributes to liquid embed templates

### DIFF
--- a/app/views/liquids/_bandcamp.html.erb
+++ b/app/views/liquids/_bandcamp.html.erb
@@ -1,4 +1,6 @@
 <iframe
+  width="100%"
+  height="<%= height %>"
   style="border: 0; width: 100%; height: <%= height %>;"
   src="<%= player_src %>"
   allowfullscreen

--- a/app/views/liquids/_blogcast.html.erb
+++ b/app/views/liquids/_blogcast.html.erb
@@ -1,5 +1,7 @@
 <div class="ltag_blogcast">
   <iframe frameborder="0"
+    width="100%"
+    height="132"
     scrolling="no"
     id="blogcast_<%= id %>"
     mozallowfullscreen="true"

--- a/app/views/liquids/_cloud_run.html.erb
+++ b/app/views/liquids/_cloud_run.html.erb
@@ -11,6 +11,7 @@
 <div class="ltag__cloud-run">
   <iframe 
     frameborder="0" 
+    width="100%"
     height="<%= height_px %>" 
     src="<%= url %>" 
     loading="lazy"

--- a/app/views/liquids/_codesandbox.html.erb
+++ b/app/views/liquids/_codesandbox.html.erb
@@ -1,5 +1,7 @@
 <iframe
   src="<%= "https://codesandbox.io/embed/#{id}#{query}" %>"
+  width="100%"
+  height="500"
   style="width:100%; height:calc(300px + 8vw); border:0; border-radius: 4px; overflow:hidden;"
   allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
   loading="lazy"

--- a/app/views/liquids/_glitch.html.erb
+++ b/app/views/liquids/_glitch.html.erb
@@ -1,5 +1,7 @@
 <div class="glitch-embed-wrap" style="height: 450px; width: 100%;margin: 1em auto 1.3em">
   <iframe
+    width="100%"
+    height="450"
     sandbox="allow-same-origin allow-scripts allow-forms allow-top-navigation-by-user-activation allow-popups"
     src="https://glitch.com/embed/#!/embed/<%= id %>?<%= query %>"
     alt="<%= id %> on glitch"

--- a/app/views/liquids/_jsitor.html.erb
+++ b/app/views/liquids/_jsitor.html.erb
@@ -1,4 +1,5 @@
 <iframe
+  width="100%"
   height="<%= height %>"
   src="<%= link %>"
   scrolling="no"

--- a/app/views/liquids/_kotlin.html.erb
+++ b/app/views/liquids/_kotlin.html.erb
@@ -1,5 +1,7 @@
 <iframe
   src="<%= url %>"
+  width="100%"
+  height="450"
   allowtransparency="true"
   scrolling="no"
   frameborder="0"

--- a/app/views/liquids/_livecodes.html.erb
+++ b/app/views/liquids/_livecodes.html.erb
@@ -1,4 +1,6 @@
 <iframe
+  width="100%"
+  height="<%= height %>"
   loading="lazy"
   src="<%= src %>"
   style="height: <%= height %>; width: 100%; border: 1px solid rgba(0, 0, 0, 0.35); border-radius: 8px;"

--- a/app/views/liquids/_loom.html.erb
+++ b/app/views/liquids/_loom.html.erb
@@ -1,6 +1,8 @@
 <div style="position: relative; padding-bottom: 56.25%; height: 0;">
   <iframe
     src="https://loom.com/embed/<%= id %>"
+    width="100%"
+    height="400"
     frameborder="0"
     webkitallowfullscreen
     mozallowfullscreen

--- a/app/views/liquids/_neon.html.erb
+++ b/app/views/liquids/_neon.html.erb
@@ -1,5 +1,7 @@
 <iframe
   class="neon-ltag"
+  width="100%"
+  height="600"
   frameborder="0"
   loading="lazy"
   sandbox="allow-same-origin allow-scripts"

--- a/app/views/liquids/_nexttech.html.erb
+++ b/app/views/liquids/_nexttech.html.erb
@@ -1,4 +1,6 @@
 <iframe
   src="https://next.tech/projects/<%= token %>/embed"
+  width="100%"
+  height="450"
   style="width:100%; height:calc(350px + 8vw); border:0; border-radius: 4px; overflow:hidden;">
 </iframe>

--- a/app/views/liquids/_youtube.html.erb
+++ b/app/views/liquids/_youtube.html.erb
@@ -2,6 +2,8 @@
   <div style="max-width: 315px; margin: 0 auto;">
     <iframe
       src="https://www.youtube.com/embed/<%= id %>"
+      width="100%"
+      height="560"
       style="width: 100%; aspect-ratio: 9 / 16;"
       allowfullscreen
       loading="lazy">
@@ -10,6 +12,8 @@
 <% else %>
   <iframe
     src="https://www.youtube.com/embed/<%= id %>"
+    width="100%"
+    height="390"
     style="width: 100%; aspect-ratio: 16 / 9;"
     allowfullscreen
     loading="lazy">

--- a/spec/liquid_tags/details_tag_spec.rb
+++ b/spec/liquid_tags/details_tag_spec.rb
@@ -145,6 +145,21 @@ RSpec.describe DetailsTag, type: :liquid_tag do
       end
     end
 
+    context "when a youtube liquid tag is nested inside" do
+      it "renders the youtube iframe preserving fallback width and height attributes" do
+        template = Liquid::Template.parse(
+          "{% details Watch video %} {% youtube vKeCr-MAyH4 %} {% enddetails %}",
+        )
+        rendered = template.render
+
+        expect(rendered).to include("<iframe")
+        expect(rendered).to include("https://www.youtube.com/embed/vKeCr-MAyH4")
+        expect(rendered).to include('width="100%"')
+        expect(rendered).to include('height="390"')
+        expect(rendered).to include("<details")
+      end
+    end
+
     context "when content has unpermitted tags" do
       let(:summary) { "Click to see the answer!" }
       let(:content) { "<script>alert(1)</script><object>foo</object>" }

--- a/spec/liquid_tags/youtube_tag_spec.rb
+++ b/spec/liquid_tags/youtube_tag_spec.rb
@@ -51,11 +51,15 @@ RSpec.describe YoutubeTag, type: :liquid_tag do
     it "uses a vertical aspect ratio for YouTube Shorts" do
       result = generate_tag("https://www.youtube.com/shorts/#{valid_id}")
       expect(result).to include("aspect-ratio: 9 / 16")
+      expect(result).to include('width="100%"')
+      expect(result).to include('height="560"')
     end
 
     it "uses a horizontal aspect ratio for regular videos" do
       result = generate_tag("https://www.youtube.com/watch?v=#{valid_id}")
       expect(result).to include("aspect-ratio: 16 / 9")
+      expect(result).to include('width="100%"')
+      expect(result).to include('height="390"')
     end
 
     it "accepts a YouTube Shorts URL with query parameters" do


### PR DESCRIPTION
## Description
Follow-up to #23492. While #23492 successfully prevents `DetailsTag` from stripping `<div>` and `<iframe>` elements, its sanitizer intentionally strips untrusted inline `style` attributes for XSS protection. 

Several liquid embed templates (such as YouTube, Bandcamp, CodeSandbox, Glitch, etc.) previously relied exclusively on inline `style` (e.g. `style="aspect-ratio: 16 / 9;"` or dynamic `style="height: <%= height %>;"`) without setting HTML `width` and `height` attributes. Consequently, when rendered inside `<details>` blocks, those iframes collapsed to the default browser height (150px) or rendered squished.

This PR adds explicit fallback HTML `width` and `height` attributes across liquid embed iframe partials so their dimensions survive sanitizer passes across all rendering contexts.

## Changes Made
- `_bandcamp.html.erb`: Added `width="100%"` and `height="<%= height %>"` attributes (preserving dynamic multi-track playlist height).
- `_youtube.html.erb`: Added `width="100%"` and `height="390"` (standard 16:9) and `height="560"` (shorts).
- `_codesandbox.html.erb`: Added `width="100%"` and `height="500"`.
- `_glitch.html.erb`: Added `width="100%"` and `height="450"`.
- `_livecodes.html.erb`: Added `width="100%"` and `height="<%= height %>"`.
- `_blogcast.html.erb`: Added `width="100%"` and `height="132"`.
- `_loom.html.erb`: Added `width="100%"` and `height="400"`.
- `_neon.html.erb`: Added `width="100%"` and `height="600"`.
- `_nexttech.html.erb`: Added `width="100%"` and `height="450"`.
- `_cloud_run.html.erb`: Added `width="100%"`.
- `_kotlin.html.erb`: Added `width="100%"` and `height="450"`.
- `_jsitor.html.erb`: Added `width="100%"`.
- `details_tag_spec.rb` & `youtube_tag_spec.rb`: Added regression tests verifying attributes are rendered and preserved inside `<details>`.

## QA & Testing
- `bundle exec rspec spec/liquid_tags/` (616 examples, 0 failures)
- `bundle exec rubocop spec/liquid_tags/` (Clean, 0 offenses)
- Manual QA: Verified YouTube and Bandcamp embeds render at full 16:9 and full tracklist heights inside collapsible blocks in the post preview.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790452640&installation_model_id=424141&pr_number=23778&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23778&signature=89caa701da2b36774d1dff221357059fc55fbbdb4aaa62368599d01136576d53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->