### PR TITLE
Add Auth Identities and additional detail tabs with 'More details' dropdown in Admin Users view

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -69,6 +69,13 @@ module Admin
       set_feedback_messages
       set_related_reactions
       set_audit_logs
+      set_identities
+      set_badges
+      set_reactions
+      set_agent_sessions
+      set_collections
+      set_follows
+      set_blocks
       @articles = @user.articles.order(created_at: :desc)
       # Remove the .includes(:commentable)
       @comments = @user.comments.order(created_at: :desc)
@@ -854,6 +861,74 @@ new_email = user_params[:email].to_s.strip.presence
         .order(created_at: :desc)
         .page(params[:page])
         .per(25)
+    end
+
+    def set_identities
+      return unless @current_tab == "identities"
+
+      @identities = @user.identities.order(created_at: :desc)
+    end
+
+    def set_badges
+      return unless @current_tab == "badges"
+
+      @badge_achievements = @user.badge_achievements
+        .includes(:badge, :rewarder)
+        .order(created_at: :desc)
+    end
+
+    def set_reactions
+      return unless @current_tab == "reactions"
+
+      @reactions = @user.reactions
+        .includes(:reactable)
+        .order(created_at: :desc)
+        .page(params[:page])
+        .per(25)
+    end
+
+    def set_agent_sessions
+      return unless @current_tab == "agent_sessions"
+
+      @agent_sessions = @user.agent_sessions
+        .order(created_at: :desc)
+        .page(params[:page])
+        .per(25)
+    end
+
+    def set_collections
+      return unless @current_tab == "collections"
+
+      @collections = @user.collections
+        .order(created_at: :desc)
+        .page(params[:page])
+        .per(25)
+    end
+
+    def set_follows
+      return unless @current_tab == "follows"
+
+      @follows_filter = %w[followers following].include?(params[:filter]) ? params[:filter] : "followers"
+      scope = case @follows_filter
+              when "following"
+                Follow.where(follower: @user, followable_type: "User").includes(:followable)
+              else
+                Follow.where(followable: @user, followable_type: "User").includes(:follower)
+              end
+      @follows = scope.order(created_at: :desc).page(params[:page]).per(25)
+    end
+
+    def set_blocks
+      return unless @current_tab == "blocks"
+
+      @blocks_filter = %w[blocked_by blocking].include?(params[:filter]) ? params[:filter] : "blocking"
+      scope = case @blocks_filter
+              when "blocked_by"
+                @user.blocked_blocks.includes(:blocker)
+              else
+                @user.blocker_blocks.includes(:blocked)
+              end
+      @blocks = scope.order(created_at: :desc).page(params[:page]).per(25)
     end
 
     def set_unpublish_all_log

--- a/app/javascript/packs/admin/editUser.jsx
+++ b/app/javascript/packs/admin/editUser.jsx
@@ -6,4 +6,9 @@ initializeDropdown({
   dropdownContentId: 'options-dropdown',
 });
 
+initializeDropdown({
+  triggerElementId: 'more-details-dropdown-trigger',
+  dropdownContentId: 'more-details-dropdown',
+});
+
 document.body.addEventListener('click', showUserModal);

--- a/app/lib/constants/user_details.rb
+++ b/app/lib/constants/user_details.rb
@@ -9,6 +9,13 @@ module Constants
       Flags
       Articles
       Comments
+      Identities
+      Badges
+      Reactions
+      AgentSessions
+      Collections
+      Follows
+      Blocks
       AuditLog
       UnpublishLogs
     ].freeze

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -76,4 +76,32 @@
   <section class="crayons-card p-3 s:p-4 m:p-7">
     <%= render "admin/users/show/comments/index" %>
   </section>
+<% elsif @current_tab == 'identities' %>
+  <section class="crayons-card p-3 s:p-4 m:p-7">
+    <%= render "admin/users/show/identities/index" %>
+  </section>
+<% elsif @current_tab == 'badges' %>
+  <section class="crayons-card p-3 s:p-4 m:p-7">
+    <%= render "admin/users/show/badges/index" %>
+  </section>
+<% elsif @current_tab == 'reactions' %>
+  <section class="crayons-card p-3 s:p-4 m:p-7">
+    <%= render "admin/users/show/reactions/index" %>
+  </section>
+<% elsif @current_tab == 'agent_sessions' %>
+  <section class="crayons-card p-3 s:p-4 m:p-7">
+    <%= render "admin/users/show/agent_sessions/index" %>
+  </section>
+<% elsif @current_tab == 'collections' %>
+  <section class="crayons-card p-3 s:p-4 m:p-7">
+    <%= render "admin/users/show/collections/index" %>
+  </section>
+<% elsif @current_tab == 'follows' %>
+  <section class="crayons-card p-3 s:p-4 m:p-7">
+    <%= render "admin/users/show/follows/index" %>
+  </section>
+<% elsif @current_tab == 'blocks' %>
+  <section class="crayons-card p-3 s:p-4 m:p-7">
+    <%= render "admin/users/show/blocks/index" %>
+  </section>
 <% end %>

--- a/app/views/admin/users/show/_tabs.html.erb
+++ b/app/views/admin/users/show/_tabs.html.erb
@@ -1,19 +1,52 @@
-<nav class="mb-2" aria-label="Member details">
-  <ul class="crayons-navigation crayons-navigation--horizontal">
-    <li><%= link_to t("views.admin.users.tabs.overview"), admin_user_path(@user.id), class: "crayons-navigation__item #{'crayons-navigation__item crayons-navigation__item--current' if @current_tab == 'overview'}", aria: @current_tab == "overview" ? { current: "page" } : {} %></li>
-    <li><%= link_to t("views.admin.users.tabs.notes"), admin_user_path(@user.id, tab: :notes), class: "crayons-navigation__item #{'crayons-navigation__item crayons-navigation__item--current' if @current_tab == 'notes'}", aria: @current_tab == "notes" ? { current: "page" } : {} %></li>
-    <li><%= link_to t("views.admin.users.tabs.emails"), admin_user_path(@user.id, tab: :emails), class: "crayons-navigation__item #{'crayons-navigation__item crayons-navigation__item--current' if @current_tab == 'emails'}", aria: @current_tab == "emails" ? { current: "page" } : {} %></li>
-    <li><%= link_to t("views.admin.users.tabs.security"), admin_user_path(@user.id, tab: :security), class: "crayons-navigation__item #{'crayons-navigation__item crayons-navigation__item--current' if @current_tab == 'security'}", aria: @current_tab == "security" ? { current: "page" } : {} %></li>
-    <li><%= link_to t("views.admin.users.tabs.reports"), admin_user_path(@user.id, tab: :reports), class: "crayons-navigation__item #{'crayons-navigation__item crayons-navigation__item--current' if @current_tab == 'reports'}", aria: @current_tab == "reports" ? { current: "page" } : {} %></li>
-    <li><%= link_to t("views.admin.users.tabs.flags"), admin_user_path(@user.id, tab: :flags), class: "crayons-navigation__item #{'crayons-navigation__item crayons-navigation__item--current' if @current_tab == 'flags'}", aria: @current_tab == "flags" ? { current: "page" } : {} %></li>
-    <li><%= link_to t("views.admin.users.tabs.articles"), admin_user_path(@user.id, tab: :articles), class: "crayons-navigation__item #{'crayons-navigation__item crayons-navigation__item--current' if @current_tab == 'articles'}", aria: @current_tab == "articles" ? { current: "page" } : {} %></li>
-    <li><%= link_to t("views.admin.users.tabs.comments"), admin_user_path(@user.id, tab: :comments), class: "crayons-navigation__item #{'crayons-navigation__item crayons-navigation__item--current' if @current_tab == 'comments'}", aria: @current_tab == "comments" ? { current: "page" } : {} %></li>
-    <li><%= link_to t("views.admin.users.tabs.audit_log"), admin_user_path(@user.id, tab: :audit_log), class: "crayons-navigation__item #{'crayons-navigation__item crayons-navigation__item--current' if @current_tab == 'audit_log'}", aria: @current_tab == "audit_log" ? { current: "page" } : {} %></li>
+<% is_more_tab_current = %w[identities badges reactions agent_sessions collections follows blocks].include?(@current_tab) %>
+<nav class="mb-2 flex justify-between items-center flex-wrap gap-2" aria-label="Member details">
+  <ul class="crayons-navigation crayons-navigation--horizontal flex-wrap">
+    <li><%= link_to t("views.admin.users.tabs.overview"), admin_user_path(@user.id), class: "crayons-navigation__item #{'crayons-navigation__item--current' if @current_tab == 'overview'}", aria: @current_tab == "overview" ? { current: "page" } : {} %></li>
+    <li><%= link_to t("views.admin.users.tabs.notes"), admin_user_path(@user.id, tab: :notes), class: "crayons-navigation__item #{'crayons-navigation__item--current' if @current_tab == 'notes'}", aria: @current_tab == "notes" ? { current: "page" } : {} %></li>
+    <li><%= link_to t("views.admin.users.tabs.emails"), admin_user_path(@user.id, tab: :emails), class: "crayons-navigation__item #{'crayons-navigation__item--current' if @current_tab == 'emails'}", aria: @current_tab == "emails" ? { current: "page" } : {} %></li>
+    <li><%= link_to t("views.admin.users.tabs.security"), admin_user_path(@user.id, tab: :security), class: "crayons-navigation__item #{'crayons-navigation__item--current' if @current_tab == 'security'}", aria: @current_tab == "security" ? { current: "page" } : {} %></li>
+    <li><%= link_to t("views.admin.users.tabs.reports"), admin_user_path(@user.id, tab: :reports), class: "crayons-navigation__item #{'crayons-navigation__item--current' if @current_tab == 'reports'}", aria: @current_tab == "reports" ? { current: "page" } : {} %></li>
+    <li><%= link_to t("views.admin.users.tabs.flags"), admin_user_path(@user.id, tab: :flags), class: "crayons-navigation__item #{'crayons-navigation__item--current' if @current_tab == 'flags'}", aria: @current_tab == "flags" ? { current: "page" } : {} %></li>
+    <li><%= link_to t("views.admin.users.tabs.articles"), admin_user_path(@user.id, tab: :articles), class: "crayons-navigation__item #{'crayons-navigation__item--current' if @current_tab == 'articles'}", aria: @current_tab == "articles" ? { current: "page" } : {} %></li>
+    <li><%= link_to t("views.admin.users.tabs.comments"), admin_user_path(@user.id, tab: :comments), class: "crayons-navigation__item #{'crayons-navigation__item--current' if @current_tab == 'comments'}", aria: @current_tab == "comments" ? { current: "page" } : {} %></li>
+    <li><%= link_to t("views.admin.users.tabs.audit_log"), admin_user_path(@user.id, tab: :audit_log), class: "crayons-navigation__item #{'crayons-navigation__item--current' if @current_tab == 'audit_log'}", aria: @current_tab == "audit_log" ? { current: "page" } : {} %></li>
     <% if @unpublish_all_data.exists? %>
       <li><%= link_to t("views.admin.users.tabs.unpublish_logs"),
                       admin_user_path(@user.id, tab: :unpublish_logs),
-                      class: "crayons-navigation__item #{'crayons-navigation__item crayons-navigation__item--current' if @current_tab == 'unpublish_logs'}",
-                      aria: @current_tab == "flags" ? { current: "page" } : {} %></li>
+                      class: "crayons-navigation__item #{'crayons-navigation__item--current' if @current_tab == 'unpublish_logs'}",
+                      aria: @current_tab == "unpublish_logs" ? { current: "page" } : {} %></li>
     <% end %>
   </ul>
+
+  <div class="dropdown-trigger-container relative ml-auto">
+    <button type="button" class="c-btn c-btn--secondary c-btn--s flex items-center gap-1 dropdown-trigger <%= 'crayons-navigation__item--current font-bold' if is_more_tab_current %>" id="more-details-dropdown-trigger" aria-haspopup="true" aria-expanded="false" aria-controls="more-details-dropdown">
+      <span><%= is_more_tab_current ? t("views.admin.users.tabs.#{@current_tab}") : t("views.admin.users.tabs.more_details") %></span>
+      <%= crayons_icon_tag("chevron-down", class: "shrink-0", width: 16, height: 16) %>
+    </button>
+    <div class="crayons-dropdown right-0 top-100 mt-1" id="more-details-dropdown" style="min-width: 180px;">
+      <ul class="p-0">
+        <li>
+          <%= link_to t("views.admin.users.tabs.identities"), admin_user_path(@user.id, tab: :identities), class: "c-link c-link--block #{'font-bold' if @current_tab == 'identities'}", aria: @current_tab == "identities" ? { current: "page" } : {} %>
+        </li>
+        <li>
+          <%= link_to t("views.admin.users.tabs.badges"), admin_user_path(@user.id, tab: :badges), class: "c-link c-link--block #{'font-bold' if @current_tab == 'badges'}", aria: @current_tab == "badges" ? { current: "page" } : {} %>
+        </li>
+        <li>
+          <%= link_to t("views.admin.users.tabs.reactions"), admin_user_path(@user.id, tab: :reactions), class: "c-link c-link--block #{'font-bold' if @current_tab == 'reactions'}", aria: @current_tab == "reactions" ? { current: "page" } : {} %>
+        </li>
+        <li>
+          <%= link_to t("views.admin.users.tabs.agent_sessions"), admin_user_path(@user.id, tab: :agent_sessions), class: "c-link c-link--block #{'font-bold' if @current_tab == 'agent_sessions'}", aria: @current_tab == "agent_sessions" ? { current: "page" } : {} %>
+        </li>
+        <li>
+          <%= link_to t("views.admin.users.tabs.collections"), admin_user_path(@user.id, tab: :collections), class: "c-link c-link--block #{'font-bold' if @current_tab == 'collections'}", aria: @current_tab == "collections" ? { current: "page" } : {} %>
+        </li>
+        <li>
+          <%= link_to t("views.admin.users.tabs.follows"), admin_user_path(@user.id, tab: :follows), class: "c-link c-link--block #{'font-bold' if @current_tab == 'follows'}", aria: @current_tab == "follows" ? { current: "page" } : {} %>
+        </li>
+        <li>
+          <%= link_to t("views.admin.users.tabs.blocks"), admin_user_path(@user.id, tab: :blocks), class: "c-link c-link--block #{'font-bold' if @current_tab == 'blocks'}", aria: @current_tab == "blocks" ? { current: "page" } : {} %>
+        </li>
+      </ul>
+    </div>
+  </div>
 </nav>

--- a/app/views/admin/users/show/agent_sessions/_index.html.erb
+++ b/app/views/admin/users/show/agent_sessions/_index.html.erb
@@ -1,0 +1,57 @@
+<div class="flex flex-col h-100">
+  <div class="flex justify-between items-center mb-5">
+    <h3 class="crayons-subtitle-2"><%= t("views.admin.users.agent_sessions_tab.title") %></h3>
+  </div>
+
+  <% if @agent_sessions.blank? %>
+    <div class="align-center flex flex-col justify-center my-auto py-7">
+      <p class="color-secondary"><%= t("views.admin.users.agent_sessions_tab.empty") %></p>
+    </div>
+  <% else %>
+    <%= paginate @agent_sessions if respond_to?(:paginate) %>
+
+    <div class="overflow-x-auto">
+      <table class="crayons-table" width="100%">
+        <thead>
+          <tr>
+            <th scope="col"><%= t("views.admin.users.agent_sessions_tab.table.title") %></th>
+            <th scope="col"><%= t("views.admin.users.agent_sessions_tab.table.tool") %></th>
+            <th scope="col"><%= t("views.admin.users.agent_sessions_tab.table.status") %></th>
+            <th scope="col"><%= t("views.admin.users.agent_sessions_tab.table.messages") %></th>
+            <th scope="col"><%= t("views.admin.users.agent_sessions_tab.table.created_at") %></th>
+            <th scope="col" class="align-right"><%= t("views.admin.users.agent_sessions_tab.table.actions") %></th>
+          </tr>
+        </thead>
+        <tbody class="crayons-card">
+          <% @agent_sessions.each do |session| %>
+            <tr>
+              <td>
+                <strong><%= link_to session.title, agent_session_path(session), class: "c-link", target: "_blank", rel: "noopener" %></strong>
+              </td>
+              <td>
+                <span class="crayons-tag"><%= session.tool_name.titleize %></span>
+              </td>
+              <td>
+                <% if session.published? %>
+                  <span class="crayons-tag crayons-tag--success"><%= t("views.admin.users.agent_sessions_tab.published") %></span>
+                <% else %>
+                  <span class="crayons-tag"><%= t("views.admin.users.agent_sessions_tab.draft") %></span>
+                <% end %>
+              </td>
+              <td><%= session.total_messages %></td>
+              <td class="whitespace-nowrap"><%= l(session.created_at, format: :short_with_yy) rescue session.created_at.to_s %></td>
+              <td class="align-right">
+                <div class="flex gap-2 justify-end">
+                  <%= link_to t("views.admin.users.agent_sessions_tab.view"), agent_session_path(session), class: "c-btn c-btn--secondary c-btn--s", target: "_blank", rel: "noopener" %>
+                  <%= link_to t("views.admin.users.agent_sessions_tab.curate"), edit_agent_session_path(session), class: "c-btn c-btn--ghost c-btn--s", target: "_blank", rel: "noopener" %>
+                </div>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <%= paginate @agent_sessions if respond_to?(:paginate) %>
+  <% end %>
+</div>

--- a/app/views/admin/users/show/badges/_index.html.erb
+++ b/app/views/admin/users/show/badges/_index.html.erb
@@ -1,0 +1,56 @@
+<div class="flex flex-col h-100">
+  <div class="flex justify-between items-center mb-5">
+    <h3 class="crayons-subtitle-2"><%= t("views.admin.users.badges_tab.title") %></h3>
+    <%= link_to t("views.admin.users.badges_tab.manage_badges"), admin_badges_path, class: "c-btn c-btn--secondary c-btn--s" %>
+  </div>
+
+  <% if @badge_achievements.blank? %>
+    <div class="align-center flex flex-col justify-center my-auto py-7">
+      <p class="color-secondary"><%= t("views.admin.users.badges_tab.empty") %></p>
+    </div>
+  <% else %>
+    <div class="overflow-x-auto">
+      <table class="crayons-table" width="100%">
+        <thead>
+          <tr>
+            <th scope="col"><%= t("views.admin.users.badges_tab.table.badge") %></th>
+            <th scope="col"><%= t("views.admin.users.badges_tab.table.description") %></th>
+            <th scope="col"><%= t("views.admin.users.badges_tab.table.awarded_by") %></th>
+            <th scope="col"><%= t("views.admin.users.badges_tab.table.awarded_at") %></th>
+          </tr>
+        </thead>
+        <tbody class="crayons-card">
+          <% @badge_achievements.each do |achievement| %>
+            <% badge = achievement.badge %>
+            <tr>
+              <td>
+                <div class="flex items-center gap-3">
+                  <% if badge.badge_image.present? %>
+                    <img src="<%= badge.badge_image_url %>" alt="<%= badge.title %>" class="w-8 h-8 object-contain shrink-0" width="32" height="32">
+                  <% end %>
+                  <div>
+                    <strong><%= link_to badge.title, badge.path, class: "c-link", target: "_blank", rel: "noopener" %></strong>
+                  </div>
+                </div>
+              </td>
+              <td>
+                <p class="fs-s"><%= badge.description %></p>
+                <% if achievement.rewarding_context_message.present? %>
+                  <p class="fs-xs color-secondary mt-1"><em><%= sanitize achievement.rewarding_context_message %></em></p>
+                <% end %>
+              </td>
+              <td>
+                <% if achievement.rewarder %>
+                  <%= link_to achievement.rewarder.name, admin_user_path(achievement.rewarder_id), class: "c-link" %>
+                <% else %>
+                  <span class="color-secondary"><%= t("views.admin.users.badges_tab.system") %></span>
+                <% end %>
+              </td>
+              <td class="whitespace-nowrap"><%= l(achievement.created_at, format: :short_with_yy) rescue achievement.created_at.to_s %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/users/show/blocks/_index.html.erb
+++ b/app/views/admin/users/show/blocks/_index.html.erb
@@ -1,0 +1,62 @@
+<div class="flex flex-col h-100">
+  <div class="flex justify-between items-center mb-5">
+    <h3 class="crayons-subtitle-2"><%= t("views.admin.users.blocks_tab.title") %></h3>
+  </div>
+
+  <nav class="mb-4" aria-label="Blocks filters">
+    <ul class="crayons-navigation crayons-navigation--horizontal">
+      <li><%= link_to t("views.admin.users.blocks_tab.blocking"),
+              admin_user_path(@user.id, tab: :blocks, filter: :blocking),
+              class: "crayons-navigation__item #{'crayons-navigation__item--current' if @blocks_filter == 'blocking'}",
+              aria: @blocks_filter == "blocking" ? { current: "page" } : {} %></li>
+      <li><%= link_to t("views.admin.users.blocks_tab.blocked_by"),
+              admin_user_path(@user.id, tab: :blocks, filter: :blocked_by),
+              class: "crayons-navigation__item #{'crayons-navigation__item--current' if @blocks_filter == 'blocked_by'}",
+              aria: @blocks_filter == "blocked_by" ? { current: "page" } : {} %></li>
+    </ul>
+  </nav>
+
+  <% if @blocks.blank? %>
+    <div class="align-center flex flex-col justify-center my-auto py-7">
+      <p class="color-secondary"><%= t("views.admin.users.blocks_tab.empty") %></p>
+    </div>
+  <% else %>
+    <%= paginate @blocks if respond_to?(:paginate) %>
+
+    <div class="overflow-x-auto">
+      <table class="crayons-table" width="100%">
+        <thead>
+          <tr>
+            <th scope="col"><%= t("views.admin.users.blocks_tab.table.user") %></th>
+            <th scope="col"><%= t("views.admin.users.blocks_tab.table.username") %></th>
+            <th scope="col"><%= t("views.admin.users.blocks_tab.table.blocked_at") %></th>
+          </tr>
+        </thead>
+        <tbody class="crayons-card">
+          <% @blocks.each do |block| %>
+            <% target_user = @blocks_filter == 'blocked_by' ? block.blocker : block.blocked %>
+            <tr>
+              <td>
+                <% if target_user %>
+                  <%= link_to target_user.name, admin_user_path(target_user.id), class: "c-link" %>
+                <% else %>
+                  <span class="color-secondary">-</span>
+                <% end %>
+              </td>
+              <td>
+                <% if target_user %>
+                  <span class="color-secondary">@<%= target_user.username %></span>
+                <% else %>
+                  -
+                <% end %>
+              </td>
+              <td class="whitespace-nowrap"><%= l(block.created_at, format: :short_with_yy) rescue block.created_at.to_s %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <%= paginate @blocks if respond_to?(:paginate) %>
+  <% end %>
+</div>

--- a/app/views/admin/users/show/collections/_index.html.erb
+++ b/app/views/admin/users/show/collections/_index.html.erb
@@ -1,0 +1,46 @@
+<div class="flex flex-col h-100">
+  <div class="flex justify-between items-center mb-5">
+    <h3 class="crayons-subtitle-2"><%= t("views.admin.users.collections_tab.title") %></h3>
+  </div>
+
+  <% if @collections.blank? %>
+    <div class="align-center flex flex-col justify-center my-auto py-7">
+      <p class="color-secondary"><%= t("views.admin.users.collections_tab.empty") %></p>
+    </div>
+  <% else %>
+    <%= paginate @collections if respond_to?(:paginate) %>
+
+    <div class="overflow-x-auto">
+      <table class="crayons-table" width="100%">
+        <thead>
+          <tr>
+            <th scope="col"><%= t("views.admin.users.collections_tab.table.title") %></th>
+            <th scope="col"><%= t("views.admin.users.collections_tab.table.description") %></th>
+            <th scope="col"><%= t("views.admin.users.collections_tab.table.articles_count") %></th>
+            <th scope="col"><%= t("views.admin.users.collections_tab.table.created_at") %></th>
+          </tr>
+        </thead>
+        <tbody class="crayons-card">
+          <% @collections.each do |collection| %>
+            <tr>
+              <td>
+                <strong>
+                  <%= link_to collection.title, collection.path, class: "c-link", target: "_blank", rel: "noopener" %>
+                </strong>
+              </td>
+              <td>
+                <p class="fs-s"><%= collection.description.presence || "-" %></p>
+              </td>
+              <td>
+                <%= collection.articles.count %>
+              </td>
+              <td class="whitespace-nowrap"><%= l(collection.created_at, format: :short_with_yy) rescue collection.created_at.to_s %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <%= paginate @collections if respond_to?(:paginate) %>
+  <% end %>
+</div>

--- a/app/views/admin/users/show/follows/_index.html.erb
+++ b/app/views/admin/users/show/follows/_index.html.erb
@@ -1,0 +1,62 @@
+<div class="flex flex-col h-100">
+  <div class="flex justify-between items-center mb-5">
+    <h3 class="crayons-subtitle-2"><%= t("views.admin.users.follows_tab.title") %></h3>
+  </div>
+
+  <nav class="mb-4" aria-label="Follows filters">
+    <ul class="crayons-navigation crayons-navigation--horizontal">
+      <li><%= link_to t("views.admin.users.follows_tab.followers"),
+              admin_user_path(@user.id, tab: :follows, filter: :followers),
+              class: "crayons-navigation__item #{'crayons-navigation__item--current' if @follows_filter == 'followers'}",
+              aria: @follows_filter == "followers" ? { current: "page" } : {} %></li>
+      <li><%= link_to t("views.admin.users.follows_tab.following"),
+              admin_user_path(@user.id, tab: :follows, filter: :following),
+              class: "crayons-navigation__item #{'crayons-navigation__item--current' if @follows_filter == 'following'}",
+              aria: @follows_filter == "following" ? { current: "page" } : {} %></li>
+    </ul>
+  </nav>
+
+  <% if @follows.blank? %>
+    <div class="align-center flex flex-col justify-center my-auto py-7">
+      <p class="color-secondary"><%= t("views.admin.users.follows_tab.empty") %></p>
+    </div>
+  <% else %>
+    <%= paginate @follows if respond_to?(:paginate) %>
+
+    <div class="overflow-x-auto">
+      <table class="crayons-table" width="100%">
+        <thead>
+          <tr>
+            <th scope="col"><%= t("views.admin.users.follows_tab.table.user") %></th>
+            <th scope="col"><%= t("views.admin.users.follows_tab.table.username") %></th>
+            <th scope="col"><%= t("views.admin.users.follows_tab.table.followed_at") %></th>
+          </tr>
+        </thead>
+        <tbody class="crayons-card">
+          <% @follows.each do |follow| %>
+            <% target_user = @follows_filter == 'following' ? follow.followable : follow.follower %>
+            <tr>
+              <td>
+                <% if target_user.is_a?(User) %>
+                  <%= link_to target_user.name, admin_user_path(target_user.id), class: "c-link" %>
+                <% else %>
+                  <span><%= target_user.try(:name) || target_user.to_s %></span>
+                <% end %>
+              </td>
+              <td>
+                <% if target_user.is_a?(User) %>
+                  <span class="color-secondary">@<%= target_user.username %></span>
+                <% else %>
+                  -
+                <% end %>
+              </td>
+              <td class="whitespace-nowrap"><%= l(follow.created_at, format: :short_with_yy) rescue follow.created_at.to_s %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <%= paginate @follows if respond_to?(:paginate) %>
+  <% end %>
+</div>

--- a/app/views/admin/users/show/identities/_index.html.erb
+++ b/app/views/admin/users/show/identities/_index.html.erb
@@ -1,0 +1,59 @@
+<div class="flex flex-col h-100">
+  <div class="flex justify-between items-center mb-5">
+    <h3 class="crayons-subtitle-2"><%= t("views.admin.users.identities_tab.title") %></h3>
+  </div>
+
+  <% if @identities.blank? %>
+    <div class="align-center flex flex-col justify-center my-auto py-7">
+      <p class="color-secondary"><%= t("views.admin.users.identities_tab.empty") %></p>
+    </div>
+  <% else %>
+    <div class="overflow-x-auto">
+      <table class="crayons-table" width="100%">
+        <thead>
+          <tr>
+            <th scope="col"><%= t("views.admin.users.identities_tab.table.provider") %></th>
+            <th scope="col"><%= t("views.admin.users.identities_tab.table.uid") %></th>
+            <th scope="col"><%= t("views.admin.users.identities_tab.table.username") %></th>
+            <th scope="col"><%= t("views.admin.users.identities_tab.table.email") %></th>
+            <th scope="col"><%= t("views.admin.users.identities_tab.table.created_at") %></th>
+            <th scope="col" class="align-right"><%= t("views.admin.users.identities_tab.table.actions") %></th>
+          </tr>
+        </thead>
+        <tbody class="crayons-card">
+          <% @identities.each do |identity| %>
+            <% nickname = identity.auth_data_dump.present? ? (identity.auth_data_dump.dig("info", "nickname") || identity.auth_data_dump.dig("info", "name")) : nil %>
+            <tr>
+              <td>
+                <div class="flex items-center gap-2">
+                  <%= crayons_icon_tag(identity.provider, class: "shrink-0", width: 20, height: 20) rescue crayons_icon_tag(:user, width: 20, height: 20) %>
+                  <strong><%= t("views.admin.users.identities.#{identity.provider}", default: identity.provider.titleize) %></strong>
+                </div>
+              </td>
+              <td class="font-mono fs-s"><%= identity.uid %></td>
+              <td><%= nickname.presence || "-" %></td>
+              <td>
+                <% if identity.email.present? && identity.email != I18n.t("models.identity.no_email_msg", provider: identity.provider) %>
+                  <a href="mailto:<%= identity.email %>" class="c-link"><%= identity.email %></a>
+                <% else %>
+                  <span class="color-secondary">-</span>
+                <% end %>
+              </td>
+              <td class="whitespace-nowrap"><%= l(identity.created_at, format: :short_with_yy) rescue identity.created_at.to_s %></td>
+              <td class="align-right">
+                <%= form_for(@user, url: remove_identity_admin_user_path(@user),
+                                    html: { method: :delete, onsubmit: "return confirm('#{j t('views.admin.users.social.onsubmit')}')", class: "inline-block", id: nil }) do |f| %>
+                  <%= f.hidden_field :identity_id, value: identity.id %>
+                  <%= f.button class: "c-btn c-btn--destructive c-btn--s", type: "submit" do %>
+                    <%= crayons_icon_tag(:bin, class: "c-btn__icon", width: 16, height: 16) %>
+                    <%= t("views.admin.users.identities_tab.remove") %>
+                  <% end %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/users/show/reactions/_index.html.erb
+++ b/app/views/admin/users/show/reactions/_index.html.erb
@@ -1,0 +1,61 @@
+<div class="flex flex-col h-100">
+  <div class="flex justify-between items-center mb-5">
+    <h3 class="crayons-subtitle-2"><%= t("views.admin.users.reactions_tab.title") %></h3>
+  </div>
+
+  <% if @reactions.blank? %>
+    <div class="align-center flex flex-col justify-center my-auto py-7">
+      <p class="color-secondary"><%= t("views.admin.users.reactions_tab.empty") %></p>
+    </div>
+  <% else %>
+    <%= paginate @reactions if respond_to?(:paginate) %>
+
+    <div class="overflow-x-auto">
+      <table class="crayons-table" width="100%">
+        <thead>
+          <tr>
+            <th scope="col"><%= t("views.admin.users.reactions_tab.table.category") %></th>
+            <th scope="col"><%= t("views.admin.users.reactions_tab.table.target_type") %></th>
+            <th scope="col"><%= t("views.admin.users.reactions_tab.table.target") %></th>
+            <th scope="col"><%= t("views.admin.users.reactions_tab.table.status") %></th>
+            <th scope="col"><%= t("views.admin.users.reactions_tab.table.created_at") %></th>
+          </tr>
+        </thead>
+        <tbody class="crayons-card">
+          <% @reactions.each do |reaction| %>
+            <tr>
+              <td>
+                <span class="inline-flex items-center gap-1 font-semibold">
+                  <%= reaction.category.humanize.titleize %>
+                </span>
+              </td>
+              <td><%= reaction.reactable_type %></td>
+              <td>
+                <% if reaction.reactable.present? %>
+                  <% case reaction.reactable_type %>
+                  <% when "Article" %>
+                    <%= link_to reaction.reactable.title.presence || "Article ##{reaction.reactable_id}", reaction.reactable.path, class: "c-link", target: "_blank", rel: "noopener" %>
+                  <% when "Comment" %>
+                    <%= link_to truncate(reaction.reactable.body_markdown.to_s, length: 80).presence || "Comment ##{reaction.reactable_id}", reaction.reactable.path, class: "c-link", target: "_blank", rel: "noopener" %>
+                  <% when "User" %>
+                    <%= link_to reaction.reactable.name.presence || "@#{reaction.reactable.username}", admin_user_path(reaction.reactable_id), class: "c-link" %>
+                  <% else %>
+                    <span>#<%= reaction.reactable_id %></span>
+                  <% end %>
+                <% else %>
+                  <span class="color-secondary"><%= t("views.admin.users.reactions_tab.deleted_target") %> (#<%= reaction.reactable_id %>)</span>
+                <% end %>
+              </td>
+              <td>
+                <span class="crayons-tag <%= reaction.status == 'valid' ? 'crayons-tag--success' : '' %>"><%= reaction.status %></span>
+              </td>
+              <td class="whitespace-nowrap"><%= l(reaction.created_at, format: :short_with_yy) rescue reaction.created_at.to_s %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <%= paginate @reactions if respond_to?(:paginate) %>
+  <% end %>
+</div>

--- a/config/locales/views/admin/en.yml
+++ b/config/locales/views/admin/en.yml
@@ -471,8 +471,16 @@ en:
           flags: Flags
           articles: Articles
           comments: Comments
+          identities: Auth Identities
+          badges: Badges
+          reactions: Reactions
+          agent_sessions: Agent Sessions
+          collections: Series
+          follows: Follows
+          blocks: Blocks
           audit_log: Audit Log
           unpublish_logs: Unpublish All History
+          more_details: More Details
         status_title: Current status
         status_reader: "Current status:"
         more_orgs:
@@ -526,6 +534,77 @@ en:
           facebook: Facebook
           github: GitHub
           twitter: Twitter
+        identities_tab:
+          title: Connected Auth Identities
+          empty: No auth identities associated with this user.
+          remove: Remove Auth Identity
+          table:
+            provider: Provider
+            uid: UID
+            username: Username / Name
+            email: Email
+            created_at: Linked At
+            actions: Actions
+        collections_tab:
+          title: Series & Collections
+          empty: No series or collections found for this user.
+          table:
+            title: Title
+            description: Description
+            articles_count: Articles
+            created_at: Created At
+        follows_tab:
+          title: Follows & Followers
+          followers: Followers
+          following: Following
+          empty: No follows found.
+          table:
+            user: User
+            username: Username
+            followed_at: Followed At
+        blocks_tab:
+          title: User Blocks
+          blocking: Blocking
+          blocked_by: Blocked By
+          empty: No user blocks found.
+          table:
+            user: User
+            username: Username
+            blocked_at: Blocked At
+        badges_tab:
+          title: Badges & Achievements
+          empty: No badges earned or awarded yet.
+          manage_badges: Manage Badges
+          system: System Awarded
+          table:
+            badge: Badge
+            description: Description
+            awarded_by: Awarded By
+            awarded_at: Awarded At
+        reactions_tab:
+          title: User Reactions
+          empty: No reactions found for this user.
+          deleted_target: Deleted Content
+          table:
+            category: Category
+            target_type: Type
+            target: Content
+            status: Status
+            created_at: Created At
+        agent_sessions_tab:
+          title: Agent Sessions
+          empty: No agent sessions found for this user.
+          published: Published
+          draft: Draft
+          view: View
+          curate: Curate
+          table:
+            title: Title
+            tool: Tool
+            status: Status
+            messages: Messages
+            created_at: Created At
+            actions: Actions
       organizations:
         profile:
           id: ID %{organizationid}

--- a/config/locales/views/admin/fr.yml
+++ b/config/locales/views/admin/fr.yml
@@ -454,14 +454,24 @@ fr:
           commentable: commentable
           created: "Created at: %{time}"
         tabs:
-          overview: Overview
+          overview: Aperçu
           notes: Notes
-          emails: Emails
-          security: Security
-          reports: Reports
-          flags: Flags
+          emails: E-mails
+          security: Sécurité
+          reports: Signalements
+          flags: Drapeaux
+          articles: Articles
+          comments: Commentaires
+          identities: Identités d'authentification
+          badges: Badges
+          reactions: Réactions
+          agent_sessions: Sessions d'agent
+          collections: Séries
+          follows: Abonnements
+          blocks: Blocages
           audit_log: Journal d'audit
-          unpublish_logs: Unpublish All History
+          unpublish_logs: Historique de dépublication
+          more_details: Plus de détails
         status_title: Current status
         status_reader: "Current status:"
         more_orgs:
@@ -515,6 +525,77 @@ fr:
           facebook: Facebook
           github: GitHub
           twitter: Twitter
+        identities_tab:
+          title: Identités d'authentification
+          empty: Aucune identité d'authentification associée à cet utilisateur.
+          remove: Supprimer l'identité
+          table:
+            provider: Fournisseur
+            uid: UID
+            username: Nom d'utilisateur / Nom
+            email: E-mail
+            created_at: Associé le
+            actions: Actions
+        collections_tab:
+          title: Séries et collections
+          empty: Aucune série ou collection trouvée pour cet utilisateur.
+          table:
+            title: Titre
+            description: Description
+            articles_count: Articles
+            created_at: Créé le
+        follows_tab:
+          title: Abonnements et abonnés
+          followers: Abonnés
+          following: Abonnements
+          empty: Aucun abonnement trouvé.
+          table:
+            user: Utilisateur
+            username: Nom d'utilisateur
+            followed_at: Suivi le
+        blocks_tab:
+          title: Blocages
+          blocking: Bloqués
+          blocked_by: Bloqué par
+          empty: Aucun blocage trouvé.
+          table:
+            user: Utilisateur
+            username: Nom d'utilisateur
+            blocked_at: Bloqué le
+        badges_tab:
+          title: Badges et accomplissements
+          empty: Aucun badge obtenu ou attribué pour le moment.
+          manage_badges: Gérer les badges
+          system: Attribué par le système
+          table:
+            badge: Badge
+            description: Description
+            awarded_by: Attribué par
+            awarded_at: Attribué le
+        reactions_tab:
+          title: Réactions de l'utilisateur
+          empty: Aucune réaction trouvée pour cet utilisateur.
+          deleted_target: Contenu supprimé
+          table:
+            category: Catégorie
+            target_type: Type
+            target: Contenu
+            status: Statut
+            created_at: Créé le
+        agent_sessions_tab:
+          title: Sessions d'agent
+          empty: Aucune session d'agent trouvée pour cet utilisateur.
+          published: Publié
+          draft: Brouillon
+          view: Voir
+          curate: Organiser
+          table:
+            title: Titre
+            tool: Outil
+            status: Statut
+            messages: Messages
+            created_at: Créé le
+            actions: Actions
       organizations:
         profile:
           id: ID %{organizationid}

--- a/config/locales/views/admin/pt.yml
+++ b/config/locales/views/admin/pt.yml
@@ -416,8 +416,91 @@ pt:
           flags: Sinalizações
           articles: Artigos
           comments: Comentários
+          identities: Identidades de Autenticação
+          badges: Emblemas
+          reactions: Reações
+          agent_sessions: Sessões de Agente
+          collections: Séries
+          follows: Seguidores
+          blocks: Bloqueios
           audit_log: Log de Auditoria
           unpublish_logs: Histórico de Despublicação
+          more_details: Mais detalhes
+        identities:
+          facebook: Facebook
+          github: GitHub
+          twitter: Twitter
+        identities_tab:
+          title: Identidades de Autenticação Conectadas
+          empty: Nenhuma identidade de autenticação associada a este usuário.
+          remove: Remover Identidade
+          table:
+            provider: Provedor
+            uid: UID
+            username: Nome de Usuário / Nome
+            email: E-mail
+            created_at: Vinculado Em
+            actions: Ações
+        collections_tab:
+          title: Séries e Coleções
+          empty: Nenhuma série ou coleção encontrada para este usuário.
+          table:
+            title: Título
+            description: Descrição
+            articles_count: Artigos
+            created_at: Criado Em
+        follows_tab:
+          title: Seguidores e Conexões
+          followers: Seguidores
+          following: Seguindo
+          empty: Nenhuma conexão encontrada.
+          table:
+            user: Usuário
+            username: Nome de Usuário
+            followed_at: Seguido Em
+        blocks_tab:
+          title: Bloqueios de Usuário
+          blocking: Bloqueando
+          blocked_by: Bloqueado Por
+          empty: Nenhum bloqueio encontrado.
+          table:
+            user: Usuário
+            username: Nome de Usuário
+            blocked_at: Bloqueado Em
+        badges_tab:
+          title: Emblemas e Conquistas
+          empty: Nenhum emblema obtido ou concedido ainda.
+          manage_badges: Gerenciar Emblemas
+          system: Concedido pelo Sistema
+          table:
+            badge: Emblema
+            description: Descrição
+            awarded_by: Concedido Por
+            awarded_at: Concedido Em
+        reactions_tab:
+          title: Reações do Usuário
+          empty: Nenhuma reação encontrada para este usuário.
+          deleted_target: Conteúdo Excluído
+          table:
+            category: Categoria
+            target_type: Tipo
+            target: Conteúdo
+            status: Status
+            created_at: Criado Em
+        agent_sessions_tab:
+          title: Sessões de Agente
+          empty: Nenhuma sessão de agente encontrada para este usuário.
+          published: Publicado
+          draft: Rascunho
+          view: Visualizar
+          curate: Curar
+          table:
+            title: Título
+            tool: Ferramenta
+            status: Status
+            messages: Mensagens
+            created_at: Criado Em
+            actions: Ações
       organizations:
         profile:
           id: ID %{organizationid}

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -1101,4 +1101,139 @@ RSpec.describe "/admin/member_manager/users" do
       expect(response.body).to include("Next")
     end
   end
+
+  describe "GET /admin/member_manager/users/:id?tab=identities" do
+    it "displays the identities tab with user's identities" do
+      identity = user.identities.first
+      get "#{admin_user_path(user.id)}?tab=identities"
+      expect(response).to be_successful
+      expect(response.body).to include("Connected Auth Identities")
+      expect(response.body).to include(identity.uid)
+      expect(response.body).to include("GitHub")
+    end
+
+    it "displays an empty message when user has no identities" do
+      user_without_identities = create(:user)
+      get "#{admin_user_path(user_without_identities.id)}?tab=identities"
+      expect(response).to be_successful
+      expect(response.body).to include("No auth identities associated with this user.")
+    end
+  end
+
+  describe "GET /admin/member_manager/users/:id?tab=badges" do
+    it "displays the badges tab with user's badge achievements" do
+      badge = create(:badge, title: "Super Contributor", description: "Awarded for amazing work")
+      create(:badge_achievement, user: user, badge: badge, rewarder: admin)
+      get "#{admin_user_path(user.id)}?tab=badges"
+      expect(response).to be_successful
+      expect(response.body).to include("Badges &amp; Achievements")
+      expect(response.body).to include("Super Contributor")
+      expect(response.body).to include("Awarded for amazing work")
+      expect(response.body).to include(CGI.escapeHTML(admin.name))
+    end
+
+    it "displays an empty message when user has no badges" do
+      get "#{admin_user_path(user.id)}?tab=badges"
+      expect(response).to be_successful
+      expect(response.body).to include("No badges earned or awarded yet.")
+    end
+  end
+
+  describe "GET /admin/member_manager/users/:id?tab=reactions" do
+    it "displays the reactions tab with user's reactions" do
+      article = create(:article, title: "Fascinating Post")
+      create(:reaction, user: user, reactable: article, category: "like", status: "valid")
+      get "#{admin_user_path(user.id)}?tab=reactions"
+      expect(response).to be_successful
+      expect(response.body).to include("User Reactions")
+      expect(response.body).to include("Like")
+      expect(response.body).to include("Fascinating Post")
+    end
+
+    it "displays an empty message when user has no reactions" do
+      get "#{admin_user_path(user.id)}?tab=reactions"
+      expect(response).to be_successful
+      expect(response.body).to include("No reactions found for this user.")
+    end
+  end
+
+  describe "GET /admin/member_manager/users/:id?tab=agent_sessions" do
+    it "displays the agent sessions tab with user's agent sessions" do
+      create(:agent_session, user: user, title: "Refactoring Auth Module", tool_name: "claude_code", published: true)
+      get "#{admin_user_path(user.id)}?tab=agent_sessions"
+      expect(response).to be_successful
+      expect(response.body).to include("Agent Sessions")
+      expect(response.body).to include("Refactoring Auth Module")
+      expect(response.body).to include("Claude Code")
+      expect(response.body).to include("Published")
+    end
+
+    it "displays an empty message when user has no agent sessions" do
+      get "#{admin_user_path(user.id)}?tab=agent_sessions"
+      expect(response).to be_successful
+      expect(response.body).to include("No agent sessions found for this user.")
+    end
+  end
+
+  describe "GET /admin/member_manager/users/:id?tab=collections" do
+    it "displays the collections tab with user's series and collections" do
+      create(:collection, user: user, title: "Complete Rails Guide", description: "All parts of the guide")
+      get "#{admin_user_path(user.id)}?tab=collections"
+      expect(response).to be_successful
+      expect(response.body).to include("Series &amp; Collections")
+      expect(response.body).to include("Complete Rails Guide")
+      expect(response.body).to include("All parts of the guide")
+    end
+
+    it "displays an empty message when user has no collections" do
+      get "#{admin_user_path(user.id)}?tab=collections"
+      expect(response).to be_successful
+      expect(response.body).to include("No series or collections found for this user.")
+    end
+  end
+
+  describe "GET /admin/member_manager/users/:id?tab=follows" do
+    let(:other_user) { create(:user, name: "Followed Friend") }
+
+    it "displays the follows tab with followers and following" do
+      create(:follow, follower: other_user, followable: user)
+      get "#{admin_user_path(user.id)}?tab=follows"
+      expect(response).to be_successful
+      expect(response.body).to include("Follows &amp; Followers")
+      expect(response.body).to include("Followed Friend")
+
+      create(:follow, follower: user, followable: other_user)
+      get "#{admin_user_path(user.id)}?tab=follows&filter=following"
+      expect(response).to be_successful
+      expect(response.body).to include("Followed Friend")
+    end
+
+    it "displays an empty message when user has no follows" do
+      get "#{admin_user_path(user.id)}?tab=follows"
+      expect(response).to be_successful
+      expect(response.body).to include("No follows found.")
+    end
+  end
+
+  describe "GET /admin/member_manager/users/:id?tab=blocks" do
+    let(:blocked_user) { create(:user, name: "Blocked Spammer") }
+
+    it "displays the blocks tab with user blocks" do
+      UserBlock.create!(blocker: user, blocked: blocked_user, config: "default")
+      get "#{admin_user_path(user.id)}?tab=blocks"
+      expect(response).to be_successful
+      expect(response.body).to include("User Blocks")
+      expect(response.body).to include("Blocked Spammer")
+
+      get "#{admin_user_path(blocked_user.id)}?tab=blocks&filter=blocked_by"
+      expect(response).to be_successful
+      expect(response.body).to include(CGI.escapeHTML(user.name))
+    end
+
+    it "displays an empty message when user has no blocks" do
+      get "#{admin_user_path(user.id)}?tab=blocks"
+      expect(response).to be_successful
+      expect(response.body).to include("No user blocks found.")
+    end
+  end
 end


### PR DESCRIPTION
## Context
This PR adds comprehensive user detail tabs to the Admin User Management view (`/admin/member_manager/users/:id`) and organizes them cleanly with a right-aligned **"More details"** dropdown to avoid horizontal navigation clutter.

## Key Changes
1. **Right-aligned "More details" dropdown**:
   - Secondary detail tabs are neatly grouped into a dropdown menu on the right side of the navigation bar.
   - Dynamically highlights and displays the active tab name when selected.
   - Initialized with Crayons accessible dropdown handler (<kbd>Esc</kbd> / <kbd>Tab</kbd> support).
2. **New Detail Tabs Added**:
   - **Auth identities** (`tab=identities`): Lists connected OAuth identities with provider icons, UIDs, usernames, emails, timestamps, and unlink actions.
   - **Badges** (`tab=badges`): Lists badge achievements earned or awarded.
   - **Reactions** (`tab=reactions`): Lists reactions made by the user across articles, comments, and users.
   - **Agent Sessions** (`tab=agent_sessions`): Lists AI agent sessions created by the user with tool tags, publication status, message counts, and view/curate actions.
   - **Series** (`tab=collections`): Lists user's article collections and series with article counts and links.
   - **Follows** (`tab=follows`): Lists user's followers and following members with sub-tab filter toggle.
   - **Blocks** (`tab=blocks`): Lists blocked members and users who blocked this account with sub-tab filter toggle.
3. **i18n**:
   - Full translations added in English (`en.yml`), French (`fr.yml`), and Portuguese (`pt.yml`).
4. **Tests**:
   - Full request spec coverage in `spec/requests/admin/users_spec.rb` (106 examples passing).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790540299&installation_model_id=424141&pr_number=23781&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23781&signature=d27af8795cd024637c05939f1c9191c5febc252c57a46b79d0a6a35c6b7b3d80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->