### PR TITLE
Fix CSS stripping on InstantClick navigation and edge cache mismatch

### DIFF
--- a/app/views/layouts/_nav_link.html.erb
+++ b/app/views/layouts/_nav_link.html.erb
@@ -1,6 +1,6 @@
 <% if display_navigation_link?(link: link) %>
   <li class="footer__nav-link flex items-center">
-    <a href="<%= link.url %>">
+    <a href="<%= link.url %>" <%= "data-no-instant" if link.url.start_with?("/challenges", "/page/") || link.url.include?("://") %>>
       <%= t("views.main.nav_name.#{link.name}", default: link.name) %>
     </a>
     <span class="dot ml-2"></span>

--- a/app/views/layouts/_sidebar_nav_link.html.erb
+++ b/app/views/layouts/_sidebar_nav_link.html.erb
@@ -1,6 +1,6 @@
 <% if display_navigation_link?(link: link) %>
   <li>
-    <a href="<%= link.url %>" class="sidebar-navigation-link c-link c-link--block c-link--icon-left">
+    <a href="<%= link.url %>" class="sidebar-navigation-link c-link c-link--block c-link--icon-left" <%= "data-no-instant" if link.url.start_with?("/challenges", "/page/") || link.url.include?("://") %>>
       <span class="c-link__icon">
         <% if link.respond_to?(:image) && link.image.present? %>
           <%= optimized_image_tag(link.image.url, optimizer_options: { width: 24, height: 24, crop: "fill" }, image_options: { alt: "#{link.name} icon", style: "width: 24px; height: 24px;" }) %>

--- a/app/views/layouts/_styles.html.erb
+++ b/app/views/layouts/_styles.html.erb
@@ -1,3 +1,3 @@
-<%= stylesheet_link_tag "minimal", media: "all", id: "#{qualifier}-minimal-stylesheet" %>
-<%= stylesheet_link_tag "views", media: "all", id: "#{qualifier}-views-stylesheet" %>
-<%= stylesheet_link_tag "crayons", media: "all", id: "#{qualifier}-crayons-stylesheet" %>
+<%= stylesheet_link_tag "minimal", media: "all", id: "#{qualifier}-minimal-stylesheet", "data-instant-track": true %>
+<%= stylesheet_link_tag "views", media: "all", id: "#{qualifier}-views-stylesheet", "data-instant-track": true %>
+<%= stylesheet_link_tag "crayons", media: "all", id: "#{qualifier}-crayons-stylesheet", "data-instant-track": true %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -68,6 +68,7 @@
     <body
       class="<%= Settings::UserExperience.default_font.tr("_", "-") %>-article-body default-header"
       data-user-status="<%= j(user_logged_in_status) %>"
+      <%= "data-no-instant" if @page.present? %>
       data-is-root-subforem="<%= j(is_root_subforem?) %>"
       <% if RequestStore.store[:subforem_id].present? %>
         data-subforem-id="<%= j(RequestStore.store[:subforem_id]) %>"
@@ -159,63 +160,6 @@
     <%= yield %>
     <div id="runtime-banner-container"></div>
     <div id="i18n-translations" data-translations="<%= i18n_translations_for_javascript.to_json %>"></div>
-    <% if internal_navigation? %>
-      <script>
-        (function() {
-          var expectedStyles = {
-            "minimal": "<%= stylesheet_path('minimal') %>",
-            "views": "<%= stylesheet_path('views') %>",
-            "crayons": "<%= stylesheet_path('crayons') %>"
-          };
-          var qualifiers = ["main", "secondary"];
-          Object.keys(expectedStyles).forEach(function(name) {
-            var expectedHref = expectedStyles[name];
-            for (var i = 0; i < qualifiers.length; i++) {
-              var id = qualifiers[i] + "-" + name + "-stylesheet";
-              var link = document.getElementById(id);
-              if (link) {
-                var currentHref = link.getAttribute('href');
-                if (currentHref && currentHref !== expectedHref && link.dataset.pendingHref !== expectedHref) {
-                  link.dataset.pendingHref = expectedHref;
-                  var newLink = document.createElement('link');
-                  newLink.rel = 'stylesheet';
-                  newLink.media = link.media || 'all';
-                  newLink.href = expectedHref;
-                  newLink.onload = (function(targetId, expectedUrl, replacementLink) {
-                    return function() {
-                      var currentTarget = document.getElementById(targetId);
-                      if (currentTarget && currentTarget.dataset.pendingHref === expectedUrl) {
-                        replacementLink.id = targetId;
-                        delete currentTarget.dataset.pendingHref;
-                        if (currentTarget.parentNode) {
-                          currentTarget.parentNode.replaceChild(replacementLink, currentTarget);
-                          return;
-                        }
-                      }
-                      if (replacementLink.parentNode) {
-                        replacementLink.parentNode.removeChild(replacementLink);
-                      }
-                    };
-                  })(id, expectedHref, newLink);
-                  newLink.onerror = (function(targetId, expectedUrl, replacementLink) {
-                    return function() {
-                      var currentTarget = document.getElementById(targetId);
-                      if (currentTarget && currentTarget.dataset.pendingHref === expectedUrl) {
-                        delete currentTarget.dataset.pendingHref;
-                      }
-                      if (replacementLink.parentNode) {
-                        replacementLink.parentNode.removeChild(replacementLink);
-                      }
-                    };
-                  })(id, expectedHref, newLink);
-                  document.head.appendChild(newLink);
-                }
-              }
-            }
-          });
-        })();
-      </script>
-    <% end %>
   </div>
 </div>
 <% unless internal_navigation? %>

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -637,9 +637,11 @@ RSpec.describe "StoriesIndex" do
     it "renders stylesheet link tags with data-instant-track under normal navigation" do
       get "/"
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include('id="main-minimal-stylesheet"', 'data-instant-track="true"')
-      expect(response.body).to include('id="main-views-stylesheet"', 'data-instant-track="true"')
-      expect(response.body).to include('id="main-crayons-stylesheet"', 'data-instant-track="true"')
+      doc = Nokogiri::HTML(response.body)
+      %w[minimal views crayons].each do |name|
+        link = doc.at_css("link#main-#{name}-stylesheet")
+        expect(link["data-instant-track"]).to eq("true")
+      end
     end
 
     it "excludes the outer layout stylesheets under internal navigation" do

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -633,27 +633,18 @@ RSpec.describe "StoriesIndex" do
     end
   end
 
-  describe "InstantClick stylesheet alignment" do
-    it "does not render the alignment script under normal navigation" do
+  describe "InstantClick stylesheet tracking" do
+    it "renders stylesheet link tags with data-instant-track under normal navigation" do
       get "/"
       expect(response).to have_http_status(:ok)
-      expect(response.body).not_to include("expectedStyles")
-      # Expect outer shell link tags
-      expect(response.body).to include('id="main-minimal-stylesheet"')
+      expect(response.body).to include('id="main-minimal-stylesheet"', 'data-instant-track="true"')
+      expect(response.body).to include('id="main-views-stylesheet"', 'data-instant-track="true"')
+      expect(response.body).to include('id="main-crayons-stylesheet"', 'data-instant-track="true"')
     end
 
-    it "renders the alignment script with correct asset paths under internal navigation" do
+    it "excludes the outer layout stylesheets under internal navigation" do
       get "/", params: { i: "i" }
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("expectedStyles")
-      expected_minimal = ActionController::Base.helpers.stylesheet_path("minimal")
-      expected_views = ActionController::Base.helpers.stylesheet_path("views")
-      expected_crayons = ActionController::Base.helpers.stylesheet_path("crayons")
-      expect(response.body).to include(%("minimal": "#{expected_minimal}"))
-      expect(response.body).to include(%("views": "#{expected_views}"))
-      expect(response.body).to include(%("crayons": "#{expected_crayons}"))
-      expect(response.body).to include("pendingHref")
-      expect(response.body).to include("replaceChild")
       # Internal navigation excludes the outer layout, so the outer shell links should not be rendered
       expect(response.body).not_to include('id="main-minimal-stylesheet"')
     end

--- a/spec/views/layouts/sidebar_nav_link_spec.rb
+++ b/spec/views/layouts/sidebar_nav_link_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "layouts/_sidebar_nav_link" do
+  let(:custom_page_link) { build(:navigation_link, url: "/challenges", name: "Challenges") }
+  let(:internal_link) { build(:navigation_link, url: "/tags", name: "Tags") }
+  let(:page_prefix_link) { build(:navigation_link, url: "/page/about", name: "About") }
+
+  it "renders data-no-instant for /challenges link" do
+    render partial: "layouts/sidebar_nav_link", locals: { link: custom_page_link }
+    expect(rendered).to include("data-no-instant")
+  end
+
+  it "renders data-no-instant for /page/* link" do
+    render partial: "layouts/sidebar_nav_link", locals: { link: page_prefix_link }
+    expect(rendered).to include("data-no-instant")
+  end
+
+  it "does not render data-no-instant for standard internal links" do
+    render partial: "layouts/sidebar_nav_link", locals: { link: internal_link }
+    expect(rendered).not_to include("data-no-instant")
+  end
+end

--- a/spec/views/layouts/styles_spec.rb
+++ b/spec/views/layouts/styles_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe "layouts/_styles" do
+  it "renders all stylesheet link tags with data-instant-track attribute" do
+    render partial: "layouts/styles", locals: { qualifier: "main" }
+
+    expect(rendered).to include('id="main-minimal-stylesheet"', 'data-instant-track="true"')
+    expect(rendered).to include('id="main-views-stylesheet"', 'data-instant-track="true"')
+    expect(rendered).to include('id="main-crayons-stylesheet"', 'data-instant-track="true"')
+  end
+end

--- a/spec/views/layouts/styles_spec.rb
+++ b/spec/views/layouts/styles_spec.rb
@@ -4,8 +4,10 @@ RSpec.describe "layouts/_styles" do
   it "renders all stylesheet link tags with data-instant-track attribute" do
     render partial: "layouts/styles", locals: { qualifier: "main" }
 
-    expect(rendered).to include('id="main-minimal-stylesheet"', 'data-instant-track="true"')
-    expect(rendered).to include('id="main-views-stylesheet"', 'data-instant-track="true"')
-    expect(rendered).to include('id="main-crayons-stylesheet"', 'data-instant-track="true"')
+    doc = Nokogiri::HTML.fragment(rendered)
+    %w[minimal views crayons].each do |name|
+      link = doc.at_css("link#main-#{name}-stylesheet")
+      expect(link["data-instant-track"]).to eq("true")
+    end
   end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Fixes an issue where client-side page transitions via InstantClick caused stripped/unapplied CSS stylesheets (such as navigating to `/challenges` or navigating between pages with different Fastly cache TTLs/asset digests).

### Stylesheet Synchronization & Asset Tracking
- The inline `expectedStyles` script in `application.html.erb` was designed to keep stylesheets synchronized during transitions. However, replacing active `<link>` elements dynamically during an in-flight DOM swap can cause the browser to unapply existing styles before the new stylesheet finishes loading.
- This functionality is fully accounted for by enabling InstantClick's native asset tracking via `data-instant-track: true` on core stylesheets in `_styles.html.erb`.
- When asset fingerprints change (e.g., after a new deployment or across varying Fastly cache TTLs), InstantClick natively detects the asset hash difference and performs a standard browser navigation (`location.href = url`), ensuring stylesheets remain synchronized reliably.

### Custom Page Stylesheet Isolation
Standalone custom pages (`@page` like `/challenges`) embed their own Tailwind CSS and Alpine.js in the body. I added `data-no-instant` to `<body ...>` when `@page.present?` and to navigation links pointing to custom pages (`/challenges`, `/page/*`, external URLs) to ensure clean browser navigation into and out of custom pages.

## Related Tickets & Documents

- Closes #23751

## QA Instructions, Screenshots, Recordings

### Reproduction & Console Tests
I confirmed the root cause and fix in production using DevTools:

1. **Custom Page Navigation (`/` $\rightarrow$ `/challenges`)**:
   - Setting `data-no-instant` on the sidebar "Challenges" link (`document.querySelector('a[href*="/challenges"]').setAttribute('data-no-instant', 'true')`) performs native browser navigation, loading `/challenges` with full styles on first click.
2. **Logged-out Article / Popup Navigation (`/article` $\rightarrow$ `/`)**:
   - Setting `data-no-instant` on the announcement popup buttons and navigating home bypassed the partial DOM swap and rendered the home feed with full styles.

### Local Testing Steps
1. Run `bin/dev`.
2. Click **Challenges** in the left sidebar; verify it loads with full styling on first click.
3. Click the **DEV** logo to return home; verify styling remains intact.
4. Navigate between articles and feeds; verify transitions are smooth without flashing or stripping styles.

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [x] Semantic HTML implemented?
- [x] Keyboard operability supported?
- [x] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [x] Color contrast tested?

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests

### Test Summary:
- Added `spec/views/layouts/styles_spec.rb` (verifies `data-instant-track` on core stylesheets).
- Added `spec/views/layouts/sidebar_nav_link_spec.rb` (verifies `data-no-instant` on custom page links).
- Updated `spec/requests/stories_index_spec.rb` (verifies InstantClick asset tracking).
- Full suite passing: 179 examples, 0 failures.

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790548991&installation_model_id=424141&pr_number=23782&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23782&signature=24f100d1554f343dc8b3e81de47e97f7c118327e687a5759a64a087f989540c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->