### PR TITLE
Enhance Community Curator dashboard, add gem curation flow, and update i18n copy

### DIFF
--- a/app/assets/stylesheets/views/article.scss
+++ b/app/assets/stylesheets/views/article.scss
@@ -246,8 +246,12 @@ html.is-twitter-in-app {
   &__count {
     color: var(--base-70);
     font-size: var(--fs-s);
+    line-height: 18px;
+    height: 18px;
+    min-height: 18px;
     display: inline-flex;
     align-items: center;
+    justify-content: center;
     margin-left: 0px;
     // padding-right: var(--su-1);
     min-width: var(--su-6);
@@ -255,7 +259,14 @@ html.is-twitter-in-app {
     @media (min-width: $breakpoint-m) {
       min-width: auto;
       margin-left: 0;
-      display: block;
+      display: flex;
+    }
+
+    > span {
+      height: 16px;
+      width: 16px;
+      padding: 0 !important;
+      display: inline-block;
     }
   }
 
@@ -364,16 +375,34 @@ html.is-twitter-in-app {
 
 .only-sidebar-menu-item {
   display: none !important;
+}
 
-  @media (min-width: $breakpoint-s) {
+@media (min-width: $breakpoint-s) {
+  body.community-leader-status-true .only-sidebar-menu-item.community-leader-visible-block {
+    display: block !important;
+  }
+  body.trusted-status-true .only-sidebar-menu-item.trusted-visible-block {
     display: block !important;
   }
 }
 
 .only-mobile-menu-item {
-  display: block !important;
+  display: none !important;
+}
 
-  @media (min-width: $breakpoint-s) {
+body.community-leader-status-true .only-mobile-menu-item.community-leader-visible-block {
+  display: block !important;
+}
+
+body.trusted-status-true .only-mobile-menu-item.trusted-visible-block {
+  display: block !important;
+}
+
+@media (min-width: $breakpoint-s) {
+  body.community-leader-status-true .only-mobile-menu-item.community-leader-visible-block {
+    display: none !important;
+  }
+  body.trusted-status-true .only-mobile-menu-item.trusted-visible-block {
     display: none !important;
   }
 }

--- a/app/assets/stylesheets/views/mod-actions.scss
+++ b/app/assets/stylesheets/views/mod-actions.scss
@@ -826,4 +826,8 @@
 
 body.trusted-status-true .only-mobile-menu-item.trusted-visible-block {
   display: block !important;
+
+  @media (min-width: $breakpoint-s) {
+    display: none !important;
+  }
 }

--- a/app/controllers/leadership_dashboards_controller.rb
+++ b/app/controllers/leadership_dashboards_controller.rb
@@ -2,31 +2,19 @@ class LeadershipDashboardsController < ApplicationController
   before_action :set_no_cache_header
   before_action :authenticate_user!
 
-  SECTIONS = %w[curation discussion].freeze
+  SECTIONS = %w[community yours].freeze
 
   def show
     # Not discoverable by non-leaders
     return head :not_found unless current_user.community_leader?
 
-    @section = SECTIONS.include?(params[:section]) ? params[:section] : "curation"
-
-    if @section == "discussion"
-      setup_discussion
-    else
-      setup_curation
-    end
-  end
-
-  private
-
-  def setup_curation
+    @section = SECTIONS.include?(params[:section]) ? params[:section] : "community"
     @favorite_allowance = current_user.favorite_allowance
-    @favorited = Favorites::Fetch.call(user: current_user, page: params[:page])
-  end
 
-  def setup_discussion
-    @discussion_feed = Articles::Feeds::EngagementCandidates.call(
-      exclude_author: current_user, page: params[:page],
-    )
+    if @section == "yours"
+      @favorited = Favorites::Fetch.call(user: current_user, page: params[:page])
+    else
+      @favorited = Favorites::Fetch.call(since: 24.hours.ago, page: params[:page])
+    end
   end
 end

--- a/app/helpers/favorites_helper.rb
+++ b/app/helpers/favorites_helper.rb
@@ -1,9 +1,66 @@
 module FavoritesHelper
-  # Emits the mount node for the Preact FavoriteControl
+  # Emits the mount node for the Preact FavoriteControl with initial server-rendered markup
   def favorite_control_tag(favoritable, variant: :article)
     return unless FeatureFlag.enabled?(:community_favorites)
 
     favoritable = favoritable.object if favoritable.try(:decorated?)
+
+    favorited = favoritable.favorited_by_user_id.present?
+    label = favorited ? t("favorites.favorited") : t("favorites.favorite")
+
+    inner_content = case variant.to_sym
+                    when :article
+                      if favorited
+                        tag.span(
+                          class: "favorite-reaction favorite-control favorite-control--favorited crayons-tooltip__activator relative",
+                          role: "img",
+                          aria: { label: label },
+                        ) do
+                          concat tag.span(crayons_icon_tag("favorite-filled", native: true), class: "crayons-reaction__icon crayons-reaction__icon--borderless")
+                          concat tag.span(label, data: { testid: "tooltip" }, class: "crayons-tooltip__content")
+                        end
+                      else
+                        tag.button(
+                          type: "button",
+                          class: "favorite-reaction favorite-control crayons-tooltip__activator relative",
+                          aria: { label: label },
+                        ) do
+                          concat tag.span(crayons_icon_tag("favorite", native: true), class: "crayons-reaction__icon crayons-reaction__icon--borderless")
+                          concat tag.span(label, data: { testid: "tooltip" }, class: "crayons-tooltip__content")
+                        end
+                      end
+                    when :dropdown
+                      if favorited
+                        tag.span(
+                          class: "flex justify-between crayons-link crayons-link--block w-100 bg-transparent border-0 favorite-control favorite-control--favorited",
+                          role: "img",
+                          aria: { label: label },
+                        ) do
+                          concat tag.span(label, class: "fw-bold")
+                          concat crayons_icon_tag("small-favorite-filled", native: true, class: "mx-2 shrink-0")
+                        end
+                      else
+                        tag.button(
+                          type: "button",
+                          class: "flex justify-between crayons-link crayons-link--block w-100 bg-transparent border-0 favorite-control",
+                          aria: { label: label },
+                        ) do
+                          concat tag.span(label, class: "fw-bold")
+                          concat crayons_icon_tag("small-favorite", native: true, class: "mx-2 shrink-0")
+                        end
+                      end
+                    when :comment
+                      if favorited
+                        tag.span(
+                          class: "crayons-btn crayons-btn--ghost crayons-btn--s crayons-btn--icon favorite-control favorite-control--favorited crayons-tooltip__activator relative",
+                          role: "img",
+                          aria: { label: label },
+                        ) do
+                          concat crayons_icon_tag("small-favorite-filled", native: true)
+                          concat tag.span(label, data: { testid: "tooltip" }, class: "crayons-tooltip__content")
+                        end
+                      end
+                    end
 
     tag.span(
       class: "favorite-control-root",
@@ -13,12 +70,14 @@ module FavoritesHelper
         favoritable_type: favoritable.class.name,
         favoritable_id: favoritable.id,
         favoritable_user_id: favoritable.user_id,
-        favorited: favoritable.favorited_by_user_id.present?,
+        favorited: favorited,
         favorited_by_user_id: favoritable.favorited_by_user_id,
         label_favorite: t("favorites.favorite"),
         label_favorited: t("favorites.favorited"),
         label_favorited_by_you: t("favorites.favorited_by_you")
       },
-    )
+    ) do
+      inner_content
+    end
   end
 end

--- a/app/javascript/favoriteControl/FavoriteControl.jsx
+++ b/app/javascript/favoriteControl/FavoriteControl.jsx
@@ -9,7 +9,7 @@ import SmallFavoriteFilledSVG from '@images/small-favorite-filled.svg';
 import SmallFavoriteCheckedSVG from '@images/small-favorite-checked.svg';
 import { makeFavorite } from './favoriteService';
 
-// The article bar gets the full-size icon, comments the compact one.
+// The article bar gets the full-size icon, comments and dropdowns the compact one.
 const ICONS = {
   article: {
     outline: FavoriteSVG,
@@ -17,6 +17,11 @@ const ICONS = {
     checked: FavoriteCheckedSVG,
   },
   comment: {
+    outline: SmallFavoriteSVG,
+    filled: SmallFavoriteFilledSVG,
+    checked: SmallFavoriteCheckedSVG,
+  },
+  dropdown: {
     outline: SmallFavoriteSVG,
     filled: SmallFavoriteFilledSVG,
     checked: SmallFavoriteCheckedSVG,
@@ -34,6 +39,7 @@ const iconFor = (variant, filled, checked) => {
 const VARIANT_CLASS = {
   article: 'favorite-reaction',
   comment: 'crayons-btn crayons-btn--ghost crayons-btn--s crayons-btn--icon',
+  dropdown: 'flex justify-between crayons-link crayons-link--block w-100 bg-transparent border-0',
 };
 
 const controlClass = (variant, favorited) =>
@@ -41,7 +47,7 @@ const controlClass = (variant, favorited) =>
     VARIANT_CLASS[variant] || VARIANT_CLASS.article,
     'favorite-control',
     favorited && 'favorite-control--favorited',
-    'crayons-tooltip__activator relative',
+    variant !== 'dropdown' && 'crayons-tooltip__activator relative',
   ]
     .filter(Boolean)
     .join(' ');
@@ -53,9 +59,10 @@ const FavoriteIcon = ({ variant, filled = false, checked = false }) => {
       native
       aria-hidden="true"
       focusable="false"
+      class={variant === 'dropdown' ? 'mx-2 shrink-0' : undefined}
     />
   );
-  if (variant === 'comment') {
+  if (variant === 'comment' || variant === 'dropdown') {
     return gem;
   }
   return (
@@ -100,6 +107,23 @@ export const FavoriteControl = ({
 
   if (favorited) {
     const label = favoritedByCurrentUser ? labelFavoritedByYou : labelFavorited;
+    if (variant === 'dropdown') {
+      return (
+        <span
+          class={controlClass(variant, true)}
+          role="img"
+          aria-label={label}
+        >
+          <span class="fw-bold">{label}</span>
+          <FavoriteIcon
+            variant={variant}
+            filled
+            checked={favoritedByCurrentUser}
+          />
+        </span>
+      );
+    }
+
     return (
       <span class={controlClass(variant, true)} role="img" aria-label={label}>
         <FavoriteIcon
@@ -148,6 +172,21 @@ export const FavoriteControl = ({
       setSubmitting(false);
     }
   };
+
+  if (variant === 'dropdown') {
+    return (
+      <button
+        type="button"
+        class={controlClass(variant, false)}
+        aria-label={labelFavorite}
+        disabled={submitting}
+        onClick={onClick}
+      >
+        <span class="fw-bold">{labelFavorite}</span>
+        <FavoriteIcon variant={variant} />
+      </button>
+    );
+  }
 
   return (
     <button

--- a/app/javascript/favoriteControl/__tests__/FavoriteControl.test.jsx
+++ b/app/javascript/favoriteControl/__tests__/FavoriteControl.test.jsx
@@ -23,9 +23,9 @@ const defaultProps = {
   favoritableUserId: '999',
   favorited: 'false',
   favoritedByUserId: '',
-  labelFavorite: 'Favorite',
-  labelFavorited: 'Favorited',
-  labelFavoritedByYou: 'Favorited by you',
+  labelFavorite: 'Pick as gem',
+  labelFavorited: 'Picked as gem',
+  labelFavoritedByYou: 'Picked as gem by you',
 };
 
 const renderControl = (overrides = {}) =>
@@ -76,10 +76,10 @@ describe('<FavoriteControl />', () => {
   describe('actionable state', () => {
     it('renders a button labelled for favoriting', () => {
       const { getByLabelText, getByTestId } = renderControl();
-      const button = getByLabelText('Favorite');
+      const button = getByLabelText('Pick as gem');
 
       expect(button.tagName).toBe('BUTTON');
-      expect(getByTestId('tooltip')).toHaveTextContent('Favorite');
+      expect(getByTestId('tooltip')).toHaveTextContent('Pick as gem');
     });
 
     it('has no a11y violations', async () => {
@@ -93,14 +93,14 @@ describe('<FavoriteControl />', () => {
     it('POSTs the favorite and switches to favorited state on click', async () => {
       const { getByLabelText, findByLabelText } = renderControl();
 
-      fireEvent.click(getByLabelText('Favorite'));
+      fireEvent.click(getByLabelText('Pick as gem'));
 
       expect(makeFavorite).toHaveBeenCalledWith({
         favoritableId: '3',
         favoritableType: 'Article',
       });
 
-      const indicator = await findByLabelText('Favorited by you');
+      const indicator = await findByLabelText('Picked as gem by you');
       expect(indicator.tagName).toBe('SPAN');
     });
 
@@ -108,17 +108,17 @@ describe('<FavoriteControl />', () => {
       makeFavorite.mockResolvedValue({
         ok: false,
         json: async () => ({
-          error: 'Unable to make this a favorite.',
+          error: 'Unable to pick this as a gem.',
           code: 'cannot_favorite',
         }),
       });
       const { getByLabelText } = renderControl();
 
-      fireEvent.click(getByLabelText('Favorite'));
+      fireEvent.click(getByLabelText('Pick as gem'));
 
       await waitFor(() =>
         expect(window.top.addSnackbarItem).toHaveBeenCalledWith({
-          message: 'Unable to make this a favorite.',
+          message: 'Unable to pick this as a gem.',
           addCloseButton: true,
         }),
       );
@@ -128,18 +128,18 @@ describe('<FavoriteControl />', () => {
       makeFavorite.mockResolvedValue({
         ok: false,
         json: async () => ({
-          error: 'This has already been made a favorite.',
+          error: 'This has already been picked as a gem.',
           code: 'already_favorited',
         }),
       });
       const { getByLabelText, findByLabelText } = renderControl();
 
-      fireEvent.click(getByLabelText('Favorite'));
+      fireEvent.click(getByLabelText('Pick as gem'));
 
-      const indicator = await findByLabelText('Favorited');
+      const indicator = await findByLabelText('Picked as gem');
       expect(indicator.tagName).toBe('SPAN');
       expect(window.top.addSnackbarItem).toHaveBeenCalledWith({
-        message: 'This has already been made a favorite.',
+        message: 'This has already been picked as a gem.',
         addCloseButton: true,
       });
     });
@@ -152,7 +152,7 @@ describe('<FavoriteControl />', () => {
         favoritedByUserId: String(CURRENT_USER_ID),
       });
 
-      const indicator = getByLabelText('Favorited by you');
+      const indicator = getByLabelText('Picked as gem by you');
       expect(indicator.tagName).toBe('SPAN');
     });
 
@@ -171,7 +171,7 @@ describe('<FavoriteControl />', () => {
         favoritedByUserId: '7',
       });
 
-      const indicator = getByLabelText('Favorited');
+      const indicator = getByLabelText('Picked as gem');
       expect(indicator.tagName).toBe('SPAN');
     });
 
@@ -182,7 +182,7 @@ describe('<FavoriteControl />', () => {
         favoritedByUserId: '7',
       });
 
-      expect(getByLabelText('Favorited').tagName).toBe('SPAN');
+      expect(getByLabelText('Picked as gem').tagName).toBe('SPAN');
     });
 
     it('does not tell a signed-out visitor they favorited it', () => {
@@ -192,8 +192,30 @@ describe('<FavoriteControl />', () => {
         favoritedByUserId: '',
       });
 
-      expect(queryByLabelText('Favorited by you')).toBeNull();
-      expect(getByLabelText('Favorited').tagName).toBe('SPAN');
+      expect(queryByLabelText('Picked as gem by you')).toBeNull();
+      expect(getByLabelText('Picked as gem').tagName).toBe('SPAN');
+    });
+  });
+
+  describe('dropdown variant', () => {
+    it('renders an actionable dropdown button with text and icon', () => {
+      const { getByRole, getByText } = renderControl({ variant: 'dropdown' });
+
+      const button = getByRole('button');
+      expect(button).toHaveClass('crayons-link');
+      expect(getByText('Pick as gem')).toHaveClass('fw-bold');
+    });
+
+    it('renders a favorited indicator in the dropdown', () => {
+      const { getByLabelText, getByText } = renderControl({
+        variant: 'dropdown',
+        favorited: 'true',
+        favoritedByUserId: String(CURRENT_USER_ID),
+      });
+
+      const indicator = getByLabelText('Picked as gem by you');
+      expect(indicator.tagName).toBe('SPAN');
+      expect(getByText('Picked as gem by you')).toHaveClass('fw-bold');
     });
   });
 });

--- a/app/services/favorites/fetch.rb
+++ b/app/services/favorites/fetch.rb
@@ -9,8 +9,9 @@ module Favorites
       new(...).call
     end
 
-    def initialize(user: nil, page: 1, per_page: DEFAULT_PER_PAGE)
+    def initialize(user: nil, since: nil, page: 1, per_page: DEFAULT_PER_PAGE)
       @user = user
+      @since = since
       @page = page
       @per_page = per_page
     end
@@ -28,7 +29,7 @@ module Favorites
 
     private
 
-    attr_reader :user, :page, :per_page
+    attr_reader :user, :since, :page, :per_page
 
     def favorited_refs
       favorited(Article).union_all(favorited(Comment))
@@ -43,6 +44,7 @@ module Favorites
               else
                 model.where.not(favorited_by_user_id: nil)
               end
+      scope = scope.where("favorited_at >= ?", since) if since.present?
 
       scope.select(
         ActiveRecord::Base.sanitize_sql_array(["? AS favoritable_type", model.name]),
@@ -54,9 +56,9 @@ module Favorites
     def hydrate(refs)
       grouped = refs.group_by(&:favoritable_type)
       articles = Article.where(id: Array(grouped["Article"]).map(&:favoritable_id))
-        .includes(:user).index_by(&:id)
+        .includes(:user, :favorited_by_user).index_by(&:id)
       comments = Comment.where(id: Array(grouped["Comment"]).map(&:favoritable_id))
-        .includes(:user, :commentable).index_by(&:id)
+        .includes(:user, :favorited_by_user, :commentable).index_by(&:id)
 
       refs.filter_map do |ref|
         (ref.favoritable_type == "Article" ? articles : comments)[ref.favoritable_id]

--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -4,25 +4,81 @@
   }
 </script>
 
+<style>
+  .community-leader-visible-block {
+    display: none !important;
+  }
+  .trusted-visible-block {
+    display: none !important;
+  }
+  .only-sidebar-menu-item {
+    display: none !important;
+  }
+  @media (min-width: 640px) {
+    body.community-leader-status-true .only-sidebar-menu-item.community-leader-visible-block {
+      display: block !important;
+    }
+    body.trusted-status-true .only-sidebar-menu-item.trusted-visible-block {
+      display: block !important;
+    }
+  }
+  .only-mobile-menu-item {
+    display: none !important;
+  }
+  body.community-leader-status-true .only-mobile-menu-item.community-leader-visible-block {
+    display: block !important;
+  }
+  body.trusted-status-true .only-mobile-menu-item.trusted-visible-block {
+    display: block !important;
+  }
+  @media (min-width: 640px) {
+    body.community-leader-status-true .only-mobile-menu-item.community-leader-visible-block {
+      display: none !important;
+    }
+    body.trusted-status-true .only-mobile-menu-item.trusted-visible-block {
+      display: none !important;
+    }
+  }
+  .crayons-reaction__count {
+    line-height: 18px !important;
+    height: 18px !important;
+    min-height: 18px !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+  }
+  @media (min-width: 768px) {
+    .crayons-reaction__count {
+      display: flex !important;
+    }
+  }
+  .crayons-reaction__count > span {
+    height: 16px !important;
+    width: 16px !important;
+    padding: 0 !important;
+    display: inline-block !important;
+  }
+</style>
+
 <% if @article.published? %>
   <div class="crayons-article-actions print-hidden">
     <div class="crayons-article-actions__inner">
 
       <%= render partial: "articles/multiple_reactions" %>
 
-      <%= favorite_control_tag(@article) %>
+      <div class="only-sidebar-menu-item community-leader-visible-block align-center">
+        <%= favorite_control_tag(@article) %>
+      </div>
 
-      <div class="only-sidebar-menu-item">
-        <div id="mod-actions-menu-btn-area" class="print-hidden trusted-visible-block align-center">
-          <% if user_signed_in? %>
-            <button class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn">
-              <svg width="24" height="24" class="crayons-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-labelledby="d6cd43ffbad3fe639e2e95c901ee88c8">
-                <title id="d6cd43ffbad3fe639e2e95c901ee88c8">Moderation</title>
-                <path d="M3.783 2.826L12 1l8.217 1.826a1 1 0 01.783.976v9.987a6 6 0 01-2.672 4.992L12 23l-6.328-4.219A6 6 0 013 13.79V3.802a1 1 0 01.783-.976zM5 4.604v9.185a4 4 0 001.781 3.328L12 20.597l5.219-3.48A4 4 0 0019 13.79V4.604L12 3.05 5 4.604zM13 10h3l-5 7v-5H8l5-7v5z" />
-              </svg>
-            </button>
-          <% end %>
-        </div>
+      <div id="mod-actions-menu-btn-area" class="only-sidebar-menu-item trusted-visible-block align-center">
+        <% if user_signed_in? %>
+          <button class="crayons-btn crayons-btn--ghost crayons-btn--icon-rounded mod-actions-menu-btn">
+            <svg width="24" height="24" class="crayons-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-labelledby="d6cd43ffbad3fe639e2e95c901ee88c8">
+              <title id="d6cd43ffbad3fe639e2e95c901ee88c8">Moderation</title>
+              <path d="M3.783 2.826L12 1l8.217 1.826a1 1 0 01.783.976v9.987a6 6 0 01-2.672 4.992L12 23l-6.328-4.219A6 6 0 013 13.79V3.802a1 1 0 01.783-.976zM5 4.604v9.185a4 4 0 001.781 3.328L12 20.597l5.219-3.48A4 4 0 0019 13.79V4.604L12 3.05 5 4.604zM13 10h3l-5 7v-5H8l5-7v5z" />
+            </svg>
+          </button>
+        <% end %>
       </div>
       <div class="align-center m:relative">
         <button id="article-show-more-button" aria-controls="article-show-more-dropdown" aria-expanded="false" aria-haspopup="true" class="dropbtn crayons-btn crayons-btn--ghost-dimmed crayons-btn--icon-rounded" aria-label="<%= t("views.actions.more.aria_label") %>">
@@ -31,6 +87,9 @@
 
         <div id="article-show-more-dropdown" class="crayons-dropdown side-bar left-2 right-2 m:right-auto m:left-100 s:left-auto mb-1 m:mb-0 top-unset bottom-100 m:top-0 m:bottom-unset">
           <% if user_signed_in? %>
+            <div class="only-mobile-menu-item community-leader-visible-block">
+              <%= favorite_control_tag(@article, variant: :dropdown) %>
+            </div>
             <div class="only-mobile-menu-item trusted-visible-block">
               <button class="mod-actions-menu-btn crayons-link crayons-link--block w-100 bg-transparent border-0 fw-bold">
                 Moderate

--- a/app/views/articles/_multiple_reactions.html.erb
+++ b/app/views/articles/_multiple_reactions.html.erb
@@ -12,7 +12,7 @@
         <%= image_tag "heart-plus-active.svg", aria_hidden: true, height: 24, width: 24 %>
       </span>
       <span class="crayons-reaction__count" id="reaction_total_count">
-        <span class="bg-base-40 opacity-25 p-2 inline-block radius-default"></span>
+        <span class="bg-base-40 opacity-25 inline-block radius-default" style="height: 16px; width: 16px;"></span>
       </span>
       <span class="crayons-tooltip__content">
         <%= t("views.reactions.drawer_button") %>
@@ -45,7 +45,7 @@
       <%= crayons_icon_tag("comment.svg", aria_hidden: true) %>
     </span>
     <span class="crayons-reaction__count" id="reaction-number-comment" data-count="<%= @comments_count %>">
-      <span class="bg-base-40 opacity-25 p-2 inline-block radius-default"></span>
+      <span class="bg-base-40 opacity-25 inline-block radius-default" style="height: 16px; width: 16px;"></span>
     </span>
 
     <span data-testid="tooltip" class="crayons-tooltip__content">

--- a/app/views/articles/_reaction_button.html.erb
+++ b/app/views/articles/_reaction_button.html.erb
@@ -12,7 +12,7 @@
         <%= crayons_icon_tag(image_active_path, aria_hidden: true) %>
       </span>
     <% end %>
-    <span class="crayons-reaction__count" id="reaction-number-<%= category %>"><span class="bg-base-40 opacity-25 p-2 inline-block radius-default"></span></span>
+    <span class="crayons-reaction__count" id="reaction-number-<%= category %>"><span class="bg-base-40 opacity-25 inline-block radius-default" style="height: 16px; width: 16px;"></span></span>
 
     <span data-testid="tooltip" class="crayons-tooltip__content">
       <%= description %>

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -76,7 +76,7 @@
                   <div class="print-hidden">
                     <button
                       class="crayons-btn follow-action-button whitespace-nowrap follow-user w-100"
-                      data-info='<%= story.user_data_info_to_json %>'>
+                      data-info='<%= story.respond_to?(:user_data_info_to_json) ? story.user_data_info_to_json : story.decorate.user_data_info_to_json %>'>
                       <%= t("views.users.follow") %>
                     </button>
                   </div>
@@ -97,6 +97,18 @@
             <% end %>
           </div>
           <a href="<%= URL.article(story) %>" class="crayons-story__tertiary fs-xs"><time datetime="<%= story.published_timestamp %>"><%= story.readable_publish_date %></time><span class="time-ago-indicator-initial-placeholder" data-seconds="<%= story.published_at_int %>"></span></a>
+          <% if local_assigns[:curation_view] && story.favorited_by_user_id.present? %>
+            <span class="inline-flex items-center fs-xs fw-medium ml-2" style="color: var(--reaction-favorite-color);">
+              <%= crayons_icon_tag("favorite-checked", native: true, width: 14, height: 14, class: "mr-1") %>
+              <% if user_signed_in? && story.favorited_by_user_id == current_user.id %>
+                <%= t("views.leadership.cards.picked_by_you") %>
+              <% elsif story.favorited_by_user.present? %>
+                <%= t("views.leadership.cards.picked_by_user", username: story.favorited_by_user.username) %>
+              <% else %>
+                <%= t("favorites.favorited") %>
+              <% end %>
+            </span>
+          <% end %>
         </div>
       </div>
 
@@ -154,7 +166,7 @@
             </div>
           </a>
           <% end %>
-          <% if should_render_favorited_marker?(story) %>
+          <% if should_render_favorited_marker?(story) && !local_assigns[:curation_view] %>
             <span
               class="crayons-story__favorited"
               data-favorited-marker
@@ -169,7 +181,31 @@
               </span>
             </span>
           <% end %>
-          <% if story.comments_count > 0 %>
+          <% if local_assigns[:curation_view] %>
+            <% if story.comments_count == 0 %>
+              <a href="<%= URL.article(story) %>#comments" class="crayons-btn crayons-btn--s crayons-btn--danger fs-xs fw-bold flex items-center" aria-label="<%= t("views.leadership.cards.start_discussion") %>">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" class="crayons-icon mr-1 shrink-0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+                </svg>
+                <%= t("views.leadership.cards.start_discussion") %>
+              </a>
+            <% elsif story.comments_count < 3 %>
+              <a href="<%= URL.article(story) %>#comments" class="crayons-btn crayons-btn--s crayons-btn--danger fs-xs fw-bold flex items-center" aria-label="<%= t("views.leadership.cards.further_discussion") %>">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" class="crayons-icon mr-1 shrink-0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+                </svg>
+                <%= t("views.leadership.cards.further_discussion") %> (<%= t("views.leadership.cards.comments_count", count: story.comments_count) %>)
+              </a>
+            <% else %>
+              <a href="<%= URL.article(story) %>#comments" class="crayons-btn crayons-btn--s crayons-btn--ghost crayons-btn--icon-left flex items-center" aria-label="<%= t("views.articles.comments.aria_label", title: story.type_of == "status" && story.title_finalized ? story.title_finalized : story.title) %>">
+                <%= crayons_icon_tag("small-comment", title: t("views.comments.summary.title")) %>
+                <%= t("views.comments.summary.count_html",
+                      count: story.comments_count,
+                      start: tag("span", { class: %w[hidden s:inline] }, true),
+                      end: "</span>".html_safe) %>
+              </a>
+            <% end %>
+          <% elsif story.comments_count > 0 %>
             <a href="<%= URL.article(story) %>#comments" class="crayons-btn crayons-btn--s crayons-btn--ghost crayons-btn--icon-left flex items-center" aria-label="<%= t("views.articles.comments.aria_label", title: story.type_of == "status" && story.title_finalized ? story.title_finalized : story.title) %>">
               <%= crayons_icon_tag("small-comment", title: t("views.comments.summary.title")) %>
               <%= t("views.comments.summary.count_html",

--- a/app/views/leadership_dashboards/_favorited_row.html.erb
+++ b/app/views/leadership_dashboards/_favorited_row.html.erb
@@ -1,28 +1,56 @@
-<article class="flex p-4 m:p-6 pb-0 m:pb-2 pr-2 m:pr-6">
-  <a href="/<%= favoritable.user.username %>" class="crayons-avatar crayons-avatar--l shrink-0">
-    <img src="<%= favoritable.user.profile_image_90 %>" alt="<%= favoritable.user.name %> profile" class="crayons-avatar__image" loading="lazy" />
-  </a>
+<% if favoritable.is_a?(Article) %>
+  <%= render partial: "articles/single_story", locals: { story: favoritable.decorate, curation_view: true, featured: false } %>
+<% elsif favoritable.is_a?(Comment) %>
+  <%
+    picker = favoritable.favorited_by_user
+    picked_by_current_user = favoritable.favorited_by_user_id == current_user.id
+  %>
+  <div class="crayons-story">
+    <div class="crayons-story__body">
+      <div class="crayons-story__top">
+        <div class="crayons-story__meta">
+          <div class="crayons-story__author-pic">
+            <a href="/<%= favoritable.user.username %>" class="crayons-avatar crayons-avatar--l">
+              <img src="<%= favoritable.user.profile_image_90 %>" alt="<%= favoritable.user.username %> profile" class="crayons-avatar__image" loading="lazy" />
+            </a>
+          </div>
+          <div>
+            <div>
+              <a href="/<%= favoritable.user.username %>" class="crayons-story__secondary fw-medium">
+                <%= favoritable.user.name %>
+              </a>
+            </div>
+            <a href="<%= favoritable.path %>" class="crayons-story__tertiary fs-xs">
+              <time datetime="<%= favoritable.created_at.iso8601 %>"><%= favoritable.readable_publish_date %></time>
+            </a>
+            <span class="inline-flex items-center fs-xs fw-medium ml-2" style="color: var(--reaction-favorite-color);">
+              <%= crayons_icon_tag("favorite-checked", native: true, width: 14, height: 14, class: "mr-1") %>
+              <% if picked_by_current_user %>
+                <%= t("views.leadership.cards.picked_by_you") %>
+              <% elsif picker.present? %>
+                <%= t("views.leadership.cards.picked_by_user", username: picker.username) %>
+              <% else %>
+                <%= t("favorites.favorited") %>
+              <% end %>
+            </span>
+          </div>
+        </div>
+      </div>
 
-  <div class="flex-1 pl-2 m:pl-4">
-    <a href="<%= favoritable.path %>" class="flex crayons-link">
-      <h2 class="fs-base lh-tight m:fs-l fw-bold break-word">
-        <% if favoritable.is_a?(Comment) %>
-          <%= t("views.leadership.curation.comment_on", title: favoritable.commentable&.title) %>
-        <% else %>
-          <%= favoritable.title %>
-        <% end %>
-      </h2>
-    </a>
-    <p class="fs-s">
-      <a href="/<%= favoritable.user.username %>" class="crayons-link fw-medium"><%= favoritable.user.name %></a>
-      <span class="color-base-30"> • </span>
-      <span class="color-base-60"><%= favoritable.readable_publish_date %></span>
-    </p>
+      <div class="crayons-story__indention">
+        <h2 class="crayons-story__title">
+          <a href="<%= favoritable.path %>">
+            <%= t("views.leadership.cards.comment_on", title: favoritable.commentable&.title) %>
+          </a>
+        </h2>
+        <div class="crayons-story__bottom mt-2">
+          <div class="crayons-story__details">
+            <a href="<%= favoritable.path %>" class="crayons-link color-base-70 fs-xs inline-flex items-center">
+              <%= t("views.leadership.cards.view_discussion") %> &rarr;
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
-
-  <%# The icon keeps its own colours (native), and its gem is drawn in
-      currentColor, so the favorite colour is set here. %>
-  <div class="m:self-center" style="color: var(--reaction-favorite-color);">
-    <%= crayons_icon_tag("favorite-checked", native: true, title: t("favorites.favorited_by_you")) %>
-  </div>
-</article>
+<% end %>

--- a/app/views/leadership_dashboards/_feed.html.erb
+++ b/app/views/leadership_dashboards/_feed.html.erb
@@ -1,0 +1,20 @@
+<%= render "nav_menu" %>
+
+<div class="substories" id="substories">
+  <% if @favorited.any? %>
+    <%= render partial: "favorited_row", collection: @favorited, as: :favoritable %>
+
+    <div class="p-4 m:p-6 pt-4 m:pt-4 pb-0 m:pb-0">
+      <%= paginate @favorited %>
+    </div>
+  <% else %>
+    <div class="crayons-card p-6 m:p-8 text-center">
+      <div class="mb-3" style="color: var(--reaction-favorite-color);">
+        <%= crayons_icon_tag("favorite-checked", native: true, width: 36, height: 36) %>
+      </div>
+      <p class="color-base-70 fs-base m-0 max-w-md mx-auto">
+        <%= t("views.leadership.sections.#{@section}_empty") %>
+      </p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/leadership_dashboards/_nav_menu.html.erb
+++ b/app/views/leadership_dashboards/_nav_menu.html.erb
@@ -1,30 +1,23 @@
-<% sections = [
-     ["curation", leadership_path],
-     ["discussion", leadership_section_path(:discussion)],
-   ] %>
+<%
+  base_path = request.path.start_with?("/curation") ? "/curation" : "/leadership"
+  sections = [
+    ["community", base_path, t("views.leadership.nav.community")],
+    ["yours", "#{base_path}/yours", t("views.leadership.nav.yours")],
+  ]
+%>
 
-<nav class="hidden m:block" aria-label="<%= t("views.leadership.nav.aria_label") %>">
-  <% sections.each do |section, path| %>
-    <a
-      class="crayons-link crayons-link--block <%= "crayons-link--current" if @section == section %>"
-      href="<%= path %>"
-      aria-current="<%= "page" if @section == section %>">
-      <%= t("views.leadership.#{section}.heading") %>
-    </a>
-  <% end %>
-</nav>
-
-<nav class="block m:hidden px-3" aria-label="<%= t("views.leadership.nav.aria_label") %>">
-  <div class="crayons-tabs">
-    <ul class="crayons-tabs__list">
-      <% sections.each do |section, path| %>
-        <li>
+<nav class="mb-4" aria-label="<%= t("views.leadership.nav.aria_label") %>">
+  <div class="crayons-tabs crayons-tabs--wrapped">
+    <ul class="crayons-tabs__list inline-flex gap-2" style="width: auto;">
+      <% sections.each do |section, path, label| %>
+        <li style="width: auto;">
           <a
-            data-text="<%= t("views.leadership.#{section}.heading") %>"
+            data-text="<%= label %>"
             class="crayons-tabs__item <%= "crayons-tabs__item--current" if @section == section %>"
             href="<%= path %>"
-            aria-current="<%= "page" if @section == section %>">
-            <%= t("views.leadership.#{section}.heading") %>
+            aria-current="<%= "page" if @section == section %>"
+            style="width: auto;">
+            <%= label %>
           </a>
         </li>
       <% end %>

--- a/app/views/leadership_dashboards/_sidebar.html.erb
+++ b/app/views/leadership_dashboards/_sidebar.html.erb
@@ -1,0 +1,37 @@
+<div class="space-y-4">
+  <%# Gem Allowance Card %>
+  <div class="crayons-card p-4">
+    <div class="flex items-center mb-2">
+      <span class="mr-2 inline-flex items-center" style="color: var(--reaction-favorite-color);">
+        <%= crayons_icon_tag("favorite-checked", native: true, title: t("views.leadership.icon.leader_alt")) %>
+      </span>
+      <h2 class="fs-base fw-bold m-0"><%= t("views.leadership.icon.leader_alt") %></h2>
+    </div>
+    <p class="fs-s mb-2">
+      <%= t("views.leadership.allowance.remaining_html", count: @favorite_allowance).html_safe %>
+    </p>
+    <p class="fs-xs color-base-60 m-0">
+      <%= t("views.leadership.allowance.replenish_note") %>
+    </p>
+  </div>
+
+  <%# Mission & Curation Explainer Card %>
+  <div class="crayons-card p-4">
+    <h2 class="fs-base fw-bold mb-3"><%= t("views.leadership.explainer.heading") %></h2>
+
+    <div class="mb-3">
+      <h3 class="fs-s fw-bold mb-1"><%= t("views.leadership.explainer.human_touch_title") %></h3>
+      <p class="fs-xs color-base-70 m-0"><%= t("views.leadership.explainer.human_touch_body") %></p>
+    </div>
+
+    <div class="mb-3">
+      <h3 class="fs-s fw-bold mb-1"><%= t("views.leadership.explainer.spark_discussions_title") %></h3>
+      <p class="fs-xs color-base-70 m-0"><%= t("views.leadership.explainer.spark_discussions_body") %></p>
+    </div>
+
+    <div>
+      <h3 class="fs-s fw-bold mb-1"><%= t("views.leadership.explainer.principles_title") %></h3>
+      <p class="fs-xs color-base-70 m-0"><%= t("views.leadership.explainer.principles_body") %></p>
+    </div>
+  </div>
+</div>

--- a/app/views/leadership_dashboards/show.html.erb
+++ b/app/views/leadership_dashboards/show.html.erb
@@ -2,15 +2,18 @@
 <main id="main-content">
   <div class="crayons-layout crayons-layout--header-inside crayons-layout--limited-l crayons-layout--2-cols">
     <header class="crayons-page-header">
-      <h1 class="crayons-title"><%= t("views.leadership.heading") %></h1>
+      <div>
+        <h1 class="crayons-title"><%= t("views.leadership.heading") %></h1>
+        <p class="color-base-70 fs-s mt-1 mb-0"><%= t("views.leadership.subtitle") %></p>
+      </div>
     </header>
 
     <div class="crayons-layout__sidebar-left">
-      <%= render "nav_menu" %>
+      <%= render "sidebar" %>
     </div>
 
     <div class="crayons-layout__content">
-      <%= render partial: @section %>
+      <%= render "feed" %>
     </div>
   </div>
 </main>

--- a/config/locales/controllers/admin/en.yml
+++ b/config/locales/controllers/admin/en.yml
@@ -40,9 +40,9 @@ en:
       saved: Article saved!
       pinned: Article Pinned!
       unpinned: Article Unpinned!
-      favorite_removed: Favorite removed.
+      favorite_removed: Gem removed.
     comments_controller:
-      favorite_removed: Favorite removed.
+      favorite_removed: Gem removed.
     badge_achievements_controller:
       deleted: Badge achievement has been deleted!
       rewarded: Badges are being rewarded. The task will finish shortly.

--- a/config/locales/controllers/admin/fr.yml
+++ b/config/locales/controllers/admin/fr.yml
@@ -40,9 +40,9 @@ fr:
       saved: Article sauvegardé !
       pinned: Article épinglé !
       unpinned: Article désépinglé !
-      favorite_removed: Favori supprimé.
+      favorite_removed: Pépite retirée.
     comments_controller:
-      favorite_removed: Favori supprimé.
+      favorite_removed: Pépite retirée.
     badge_achievements_controller:
       deleted: La réalisation du badge a été supprimée !
       rewarded: Les badges sont en train d'être récompensés. La tâche sera bientôt terminée.

--- a/config/locales/controllers/admin/pt.yml
+++ b/config/locales/controllers/admin/pt.yml
@@ -5,9 +5,9 @@ pt:
       saved: Artigo salvo!
       pinned: Artigo Fixado!
       unpinned: Artigo Desfixado!
-      favorite_removed: Favorito removido.
+      favorite_removed: Joia removida.
     comments_controller:
-      favorite_removed: Favorito removido.
+      favorite_removed: Joia removida.
     badge_achievements_controller:
       deleted: Conquista de badge foi excluída!
       rewarded: Badges estão sendo recompensados. A tarefa terminará em breve.

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -43,9 +43,9 @@ en:
     newsletter: newsletter
   favorites_controller:
     create:
-      already_favorited: This has already been made a favorite.
-      no_allowance: You have used up your favorite allowance.
-      cannot_favorite: Unable to make this a favorite.
+      already_favorited: This has already been picked as a gem.
+      no_allowance: You have used up your gem allowance.
+      cannot_favorite: Unable to pick this as a gem.
   feeds:
     sources:
       created: Your feed source has been added and an import has been triggered.

--- a/config/locales/controllers/fr.yml
+++ b/config/locales/controllers/fr.yml
@@ -43,9 +43,9 @@ fr:
     newsletter: bulletin d'information
   favorites_controller:
     create:
-      already_favorited: Ceci a déjà été mis en favori.
-      no_allowance: Vous avez épuisé votre quota de favoris.
-      cannot_favorite: Impossible de mettre ceci en favori.
+      already_favorited: Ceci a déjà été choisi comme pépite.
+      no_allowance: Vous avez épuisé votre quota de pépites.
+      cannot_favorite: Impossible de choisir ceci comme pépite.
   feeds:
     sources:
       created: Votre source de flux a été ajoutée et un import a été déclenché.

--- a/config/locales/controllers/pt.yml
+++ b/config/locales/controllers/pt.yml
@@ -43,9 +43,9 @@ pt:
     newsletter: newsletter
   favorites_controller:
     create:
-      already_favorited: Isto já foi adicionado aos favoritos.
-      no_allowance: Você esgotou sua cota de favoritos.
-      cannot_favorite: Não foi possível adicionar isto aos favoritos.
+      already_favorited: Isto já foi escolhido como joia.
+      no_allowance: Você esgotou sua cota de joias.
+      cannot_favorite: Não foi possível escolher isto como joia.
   feeds:
     sources:
       created: Sua fonte de feed foi adicionada e uma importação foi iniciada.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,9 +8,9 @@ en:
     if_continued_trouble_html: <a href="/contact">Contact us</a> if you continue having trouble.
     if_we_can_help_html: <a href="/contact">Contact us</a> if there is anything we can help with.
   favorites:
-    favorite: Favorite
-    favorited: Favorited
-    favorited_by_you: Favorited by you
+    favorite: Pick as gem
+    favorited: Picked as gem
+    favorited_by_you: Picked as gem by you
   core:
     add_comment: Add comment
     beta: beta

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -8,9 +8,9 @@ fr:
     if_continued_trouble_html: <a href="/contact">Contactez-nous</a> si vous continuez à avoir des problèmes.
     if_we_can_help_html: <a href="/contact">Contactez-nous</a> si nous pouvons vous aider.
   favorites:
-    favorite: Mettre en favori
-    favorited: Mis en favori
-    favorited_by_you: Vous avez mis ceci en favori
+    favorite: Choisir comme pépite
+    favorited: Choisi comme pépite
+    favorited_by_you: Choisi comme pépite par vous
   core:
     add_comment: Ajouter un commentaire
     beta: bêta

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -8,9 +8,9 @@ pt:
     if_continued_trouble_html: <a href="/contact">Entre em contato conosco</a> se você continuar tendo problemas.
     if_we_can_help_html: <a href="/contact">Entre em contato conosco</a> se houver algo que possamos ajudar.
   favorites:
-    favorite: Favoritar
-    favorited: Favoritado
-    favorited_by_you: Você favoritou isto
+    favorite: Escolher como joia
+    favorited: Escolhido como joia
+    favorited_by_you: Escolhido como joia por você
   core:
     add_comment: Adicionar comentário
     beta: beta

--- a/config/locales/services/en.yml
+++ b/config/locales/services/en.yml
@@ -15,8 +15,8 @@ en:
         not_enabled: Provider %{name} is not enabled!
     badges:
       award_community_favorite:
-        article_message: "Well done! [Your post](%{url}) is a community favorite!"
-        comment_message: "Well done! [Your comment](%{url}) is a community favorite!"
+        article_message: "Well done! [Your post](%{url}) was picked as a community gem!"
+        comment_message: "Well done! [Your comment](%{url}) was picked as a community gem!"
       award_beloved_comment:
         message: "You're famous! [This is the comment](%{comment}) for which you're being recognized. 😄"
       award_streak:

--- a/config/locales/services/fr.yml
+++ b/config/locales/services/fr.yml
@@ -15,8 +15,8 @@ fr:
         not_enabled: Le fournisseur %{name} n'est pas activé !
     badges:
       award_community_favorite:
-        article_message: "Bravo ! [Votre publication](%{url}) est un favori de la communauté !"
-        comment_message: "Bravo ! [Votre commentaire](%{url}) est un favori de la communauté !"
+        article_message: "Bravo ! [Votre publication](%{url}) a été choisie comme pépite de la communauté !"
+        comment_message: "Bravo ! [Votre commentaire](%{url}) a été choisi comme pépite de la communauté !"
       award_beloved_comment:
         message: "Vous êtes célèbre ! [C'est le commentaire](%{comment}) pour lequel vous êtes reconnu. 😄"
       award_streak:

--- a/config/locales/services/pt.yml
+++ b/config/locales/services/pt.yml
@@ -15,8 +15,8 @@ pt:
         not_enabled: Provedor %{name} não está habilitado!
     badges:
       award_community_favorite:
-        article_message: "Muito bem! [A sua publicação](%{url}) é um favorito da comunidade!"
-        comment_message: "Muito bem! [O seu comentário](%{url}) é um favorito da comunidade!"
+        article_message: "Muito bem! [A sua publicação](%{url}) foi escolhida como uma joia da comunidade!"
+        comment_message: "Muito bem! [O seu comentário](%{url}) foi escolhido como uma joia da comunidade!"
       award_beloved_comment:
         message: "Você é famoso! [Este é o comentário](%{comment}) pelo qual você está sendo reconhecido. 😄"
       award_streak:

--- a/config/locales/views/admin/en.yml
+++ b/config/locales/views/admin/en.yml
@@ -516,8 +516,8 @@ en:
           "Resource Admin: ProfileField": "Resource Admin: ProfileField"
           "Resource Admin: ProfileFieldGroup": "Resource Admin: ProfileFieldGroup"
           Super Moderator: Super Moderator
-          Community Leader Level 1: Community Leader Level 1
-          Community Leader Level 2: Community Leader Level 2
+          Community Leader Level 1: Community Curator Level 1
+          Community Leader Level 2: Community Curator Level 2
         statuses:
           Warned: Warned
           Comment Suspended: Comment Suspended
@@ -661,11 +661,11 @@ en:
       favorites:
         leaderboard:
           heading: Impact Leaderboard
-          description: User ranking by downstream engagement of their favorite content.
-          empty: No favorite content yet.
+          description: User ranking by downstream engagement of their gem content.
+          empty: No gem content yet.
           rank: Rank
-          leader: Leader
-          favorites: Favorites
+          leader: Curator
+          favorites: Gems
           articles: Articles
           comments: Comments
           impact: Impact

--- a/config/locales/views/admin/fr.yml
+++ b/config/locales/views/admin/fr.yml
@@ -507,8 +507,8 @@ fr:
           "Resource Admin: ProfileField": "Resource Admin: ProfileField"
           "Resource Admin: ProfileFieldGroup": "Resource Admin: ProfileFieldGroup"
           Super Moderator: Super Moderator
-          Community Leader Level 1: Community Leader Level 1
-          Community Leader Level 2: Community Leader Level 2
+          Community Leader Level 1: Curateur communautaire niveau 1
+          Community Leader Level 2: Curateur communautaire niveau 2
         statuses:
           Warned: Warned
           Comment Suspended: Comment Suspended
@@ -652,11 +652,11 @@ fr:
       favorites:
         leaderboard:
           heading: Classement d'impact
-          description: Classement des utilisateurs selon l'engagement généré par leurs contenus mis en favori.
-          empty: Aucun contenu en favori pour le moment.
+          description: Classement des utilisateurs selon l'engagement généré par leurs pépites.
+          empty: Aucune pépite pour le moment.
           rank: Rang
-          leader: Leader
-          favorites: Favoris
+          leader: Curateur
+          favorites: Pépites
           articles: Articles
           comments: Commentaires
           impact: Impact

--- a/config/locales/views/admin/pt.yml
+++ b/config/locales/views/admin/pt.yml
@@ -47,8 +47,8 @@ pt:
           "Resource Admin: Space": "Resource Admin: Space"
           "Resource Admin: ProfileField": "Resource Admin: ProfileField"
           "Resource Admin: ProfileFieldGroup": "Resource Admin: ProfileFieldGroup"
-          Community Leader Level 1: Community Leader Level 1
-          Community Leader Level 2: Community Leader Level 2
+          Community Leader Level 1: Curador Comunitário Nível 1
+          Community Leader Level 2: Curador Comunitário Nível 2
         title: Gerenciar Usuários
         search: Pesquisar usuários
         filter: Filtrar
@@ -557,11 +557,11 @@ pt:
       favorites:
         leaderboard:
           heading: Ranking de impacto
-          description: Classificação de usuários pelo engajamento gerado por seus conteúdos favoritados.
-          empty: Nenhum conteúdo favoritado ainda.
+          description: Classificação de usuários pelo engajamento gerado por suas joias.
+          empty: Nenhuma joia ainda.
           rank: Posição
-          leader: Líder
-          favorites: Favoritos
+          leader: Curador
+          favorites: Joias
           articles: Artigos
           comments: Comentários
           impact: Impacto

--- a/config/locales/views/leadership/en.yml
+++ b/config/locales/views/leadership/en.yml
@@ -1,19 +1,37 @@
----
 en:
   views:
     leadership:
-      heading: Community Leadership
+      heading: Community Curation
+      subtitle: Curating quality content, elevating outstanding contributors, and sparking meaningful discussions.
       icon:
-        leader_alt: Community Leader
+        leader_alt: Community Curator
       nav:
         aria_label: Sections
-      curation:
-        heading: Curation
-        allowance: "You have %{remaining} favorites remaining."
-        comment_on: Comment on “%{title}”
-        empty: You haven't favorited any content yet.
-      discussion:
-        heading: Further the Discussion
-        subtitle: Spark engagement by joining the discussion.
-        cta: Comment
-        empty: No posts to recommend.
+        community: Community Picks (24h)
+        yours: Your Picks
+      allowance:
+        remaining_html: "You have <strong class=\"color-base-100\">%{count}</strong> gem picks remaining."
+        replenish_note: "Gems replenish as your picks generate community impact and meaningful discussions."
+      explainer:
+        heading: How Curation Works
+        human_touch_title: The Power of Human Curation
+        human_touch_body: "Algorithms measure clicks, but only human readers recognize genuine insight, craftsmanship, and utility. As a Community Curator, your picks highlight high-value posts and help them bubble up across the platform."
+        spark_discussions_title: Spark the Discussion
+        spark_discussions_body: "Great writing often just needs a conversation starter. When you pick a post with few comments, leave a thoughtful response to get the dialogue rolling."
+        principles_title: Curator Guidelines
+        principles_body: "Focus on depth, usefulness, and constructive ideas. Look for promising new authors alongside established voices."
+      sections:
+        community_heading: Community Gems (Past 24 Hours)
+        community_empty: No gems have been picked in the past 24 hours. Be the first to pick one!
+        yours_heading: Gems Picked by You
+        yours_empty: You haven't picked any gems yet. Browse the community and pick articles or comments that deserve more spotlight.
+      cards:
+        picked_by_you: Picked by you
+        picked_by_user: "Picked by @%{username}"
+        comments_count:
+          one: "%{count} comment"
+          other: "%{count} comments"
+        start_discussion: Start the discussion
+        further_discussion: Further the discussion
+        view_discussion: View discussion
+        comment_on: "Comment on “%{title}”"

--- a/config/locales/views/leadership/fr.yml
+++ b/config/locales/views/leadership/fr.yml
@@ -1,19 +1,37 @@
----
 fr:
   views:
     leadership:
-      heading: Leadership communautaire
+      heading: Curation communautaire
+      subtitle: Sélectionner des contenus de qualité, valoriser les contributeurs remarquables et susciter des discussions enrichissantes.
       icon:
-        leader_alt: Leader communautaire
+        leader_alt: Curateur communautaire
       nav:
         aria_label: Sections
-      curation:
-        heading: Curation
-        allowance: "Il vous reste %{remaining} favoris."
-        comment_on: Commentaire sur « %{title} »
-        empty: Vous n'avez encore mis aucun contenu en favori.
-      discussion:
-        heading: Approfondir la discussion
-        subtitle: Suscitez l'engagement en participant à la discussion.
-        cta: Commenter
-        empty: Aucun article à recommander.
+        community: Pépites de la communauté (24h)
+        yours: Vos sélections
+      allowance:
+        remaining_html: "Il vous reste <strong class=\"color-base-100\">%{count}</strong> pépites à attribuer."
+        replenish_note: "Vos pépites se renouvellent au fur et à mesure que vos sélections génèrent de l'engagement et des échanges de qualité."
+      explainer:
+        heading: Comment fonctionne la curation
+        human_touch_title: L'importance de la curation humaine
+        human_touch_body: "Les algorithmes mesurent les clics, mais seuls les humains savent reconnaître la pertinence, l'originalité et le travail bien fait. En tant que curateur, vos sélections mettent en valeur les publications à forte valeur ajoutée."
+        spark_discussions_title: Initier les discussions
+        spark_discussions_body: "Un excellent article n'attend souvent qu'un premier commentaire pour lancer le débat. Si un contenu sélectionné a peu de réponses, laissez un commentaire constructif."
+        principles_title: Principes de curation
+        principles_body: "Privilégiez la profondeur, l'utilité et les idées constructives. Mettez en lumière de nouveaux auteurs ainsi que des contributeurs réguliers."
+      sections:
+        community_heading: Pépites de la communauté (dernières 24h)
+        community_empty: Aucune pépite sélectionnée au cours des dernières 24 heures. Soyez le premier à en choisir une !
+        yours_heading: Pépites choisies par vous
+        yours_empty: Vous n'avez encore choisi aucune pépite. Parcourez la communauté et valorisez les articles et commentaires qui le méritent.
+      cards:
+        picked_by_you: Choisi par vous
+        picked_by_user: "Choisi comme pépite par @%{username}"
+        comments_count:
+          one: "%{count} commentaire"
+          other: "%{count} commentaires"
+        start_discussion: Démarrer la discussion
+        further_discussion: Approfondir la discussion
+        view_discussion: Voir la discussion
+        comment_on: "Commentaire sur « %{title} »"

--- a/config/locales/views/leadership/pt.yml
+++ b/config/locales/views/leadership/pt.yml
@@ -2,18 +2,37 @@
 pt:
   views:
     leadership:
-      heading: Liderança Comunitária
+      heading: Curadoria Comunitária
+      subtitle: Curadoria de conteúdo de qualidade, valorização de contribuidores notáveis e incentivo a discussões significativas.
       icon:
-        leader_alt: Líder Comunitário
+        leader_alt: Curador Comunitário
       nav:
         aria_label: Seções
-      curation:
-        heading: Curadoria
-        allowance: "Você tem %{remaining} favoritos restantes."
-        comment_on: Comentário em “%{title}”
-        empty: Você ainda não favoritou nenhum conteúdo.
-      discussion:
-        heading: Aprofundar a Discussão
-        subtitle: Estimule o engajamento participando da discussão.
-        cta: Comentar
-        empty: Nenhum post para recomendar.
+        community: Escolhas da comunidade (24h)
+        yours: Suas escolhas
+      allowance:
+        remaining_html: "Você tem <strong class=\"color-base-100\">%{count}</strong> joias restantes para escolher."
+        replenish_note: "Suas joias se renovam conforme suas escolhas geram impacto e discussões de qualidade na comunidade."
+      explainer:
+        heading: Como funciona a curadoria
+        human_touch_title: O poder da curadoria humana
+        human_touch_body: "Algoritmos medem cliques, mas apenas pessoas reconhecem o verdadeiro valor, a originalidade e o cuidado na escrita. Como curador comunitário, suas escolhas destacam publicações de alto valor."
+        spark_discussions_title: Estimule a discussão
+        spark_discussions_body: "Um excelente conteúdo muitas vezes só precisa de um pontapé inicial. Quando escolher uma publicação com poucos comentários, participe e inicie a conversa."
+        principles_title: Diretrizes de curadoria
+        principles_body: "Foque em profundidade, utilidade e ideias construtivas. Destaque novos autores promissores e contribuidores constantes."
+      sections:
+        community_heading: Joias da comunidade (últimas 24h)
+        community_empty: Nenhuma joia foi escolhida nas últimas 24 horas. Seja o primeiro a escolher uma!
+        yours_heading: Joias escolhidas por você
+        yours_empty: Você ainda não escolheu nenhuma joia. Explore a comunidade e destaque os artigos e comentários merecedores.
+      cards:
+        picked_by_you: Escolhido por você
+        picked_by_user: "Escolhido como joia por @%{username}"
+        comments_count:
+          one: "%{count} comentário"
+          other: "%{count} comentários"
+        start_discussion: Iniciar a discussão
+        further_discussion: Aprofundar a discussão
+        view_discussion: Ver a discussão
+        comment_on: "Comentário em “%{title}”"

--- a/config/locales/views/main/en.yml
+++ b/config/locales/views/main/en.yml
@@ -33,7 +33,7 @@ en:
         placeholder: "..."
         list: Reading list
         moderator_center: Moderator Center
-        leadership: Community Leadership
+        leadership: Community Curation
         other: Other
         settings: Settings
         account: Account

--- a/config/locales/views/main/fr.yml
+++ b/config/locales/views/main/fr.yml
@@ -32,8 +32,8 @@ fr:
         placeholder: "..."
         list: Liste de lecture
         moderator_center: Centre de modération
-        leadership: Leadership communautaire
-        other: Other
+        leadership: Curation communautaire
+        other: Autre
         settings: Paramètres
         account: Compte
       nav_name:

--- a/config/locales/views/main/pt.yml
+++ b/config/locales/views/main/pt.yml
@@ -32,7 +32,7 @@ pt:
         placeholder: "..."
         list: Lista de leitura
         moderator_center: Centro de Moderação
-        leadership: Liderança Comunitária
+        leadership: Curadoria Comunitária
         other: Outros
         settings: Configurações
         account: Conta

--- a/config/locales/views/moderations/en.yml
+++ b/config/locales/views/moderations/en.yml
@@ -160,8 +160,8 @@ en:
         set_to_min_indexing: Set to min indexing
         edit: Edit
         featured: Featured
-        favorited_by: Favorited by
-        unfavorite: Unfavorite
+        favorited_by: Picked as gem by
+        unfavorite: Remove gem
         likes: likes
         notes:
           user_notes: user notes

--- a/config/locales/views/moderations/fr.yml
+++ b/config/locales/views/moderations/fr.yml
@@ -159,8 +159,8 @@ fr:
         set_to_min_indexing: Définir sur l'indexation minimale
         edit: Modifier
         featured: Mis en exergue
-        favorited_by: Mis en favori par
-        unfavorite: Retirer des favoris
+        favorited_by: Choisi comme pépite par
+        unfavorite: Retirer la pépite
         likes: aime
         notes:
           user_notes: notes d'utilisateur

--- a/config/locales/views/moderations/pt.yml
+++ b/config/locales/views/moderations/pt.yml
@@ -160,8 +160,8 @@ pt:
         set_to_min_indexing: Definir para a indexação mínima
         edit: Edit
         featured: Featured
-        favorited_by: Favoritado por
-        unfavorite: Desfavoritar
+        favorited_by: Escolhido como joia por
+        unfavorite: Remover joia
         likes: likes
         notes:
           user_notes: user notes

--- a/config/locales/views/subforems/en.yml
+++ b/config/locales/views/subforems/en.yml
@@ -181,7 +181,7 @@ en:
         community_bots:
           heading: Community Bots
           manage_button: Manage Bots
-          moderator_notice_html: "<strong>Note:</strong> Community bot management is currently only available to site admins. This feature will be coming to community leaders soon."
+          moderator_notice_html: "<strong>Note:</strong> Community bot management is currently only available to site admins. This feature will be coming to community curators soon."
           created_label: Created
           api_secrets_label: API Secrets
           view_button: View

--- a/config/locales/views/subforems/fr.yml
+++ b/config/locales/views/subforems/fr.yml
@@ -181,7 +181,7 @@ fr:
         community_bots:
           heading: Bots de la Communauté
           manage_button: Gérer les Bots
-          moderator_notice_html: "<strong>Note :</strong> La gestion des bots communautaires est actuellement disponible uniquement pour les administrateurs du site. Cette fonctionnalité sera bientôt disponible pour les leaders de communauté."
+          moderator_notice_html: "<strong>Note :</strong> La gestion des bots communautaires est actuellement disponible uniquement pour les administrateurs du site. Cette fonctionnalité sera bientôt disponible pour les curateurs de communauté."
           created_label: Créé
           api_secrets_label: Secrets API
           view_button: Voir

--- a/config/locales/views/subforems/pt.yml
+++ b/config/locales/views/subforems/pt.yml
@@ -181,7 +181,7 @@ pt:
         community_bots:
           heading: Bots da Comunidade
           manage_button: Gerenciar Bots
-          moderator_notice_html: "<strong>Nota:</strong> O gerenciamento de bots da comunidade está atualmente disponível apenas para administradores do site. Este recurso estará disponível para líderes da comunidade em breve."
+          moderator_notice_html: "<strong>Nota:</strong> O gerenciamento de bots da comunidade está atualmente disponível apenas para administradores do site. Este recurso estará disponível para curadores comunitários em breve."
           created_label: Criado
           api_secrets_label: Segredos de API
           view_button: Visualizar

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -521,6 +521,8 @@ Rails.application.routes.draw do
 
     get "/leadership", to: "leadership_dashboards#show", as: :leadership
     get "/leadership/:section", to: "leadership_dashboards#show", as: :leadership_section
+    get "/curation", to: "leadership_dashboards#show", as: :curation
+    get "/curation/:section", to: "leadership_dashboards#show", as: :curation_section
 
     unless Rails.env.production?
       get "/rails/mailers", to: "rails/mailers#index"

--- a/spec/requests/leadership_dashboards_spec.rb
+++ b/spec/requests/leadership_dashboards_spec.rb
@@ -1,83 +1,70 @@
 require "rails_helper"
 
-RSpec.describe "Leadership dashboard" do
+RSpec.describe "Curation dashboard" do
   let(:leader) { create(:user, :community_leader_level_1) }
 
-  describe "GET /leadership" do
+  describe "GET /curation" do
     context "when signed in as a community leader" do
       before { sign_in leader }
 
-      it "defaults to the curation section and shows both section links" do
-        get leadership_path
+      it "defaults to the community picks section and displays allowance and explainer" do
+        get curation_path
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include(I18n.t("views.leadership.curation.heading"))
-        expect(response.body).to include(I18n.t("views.leadership.discussion.heading"))
+        expect(response.body).to include(I18n.t("views.leadership.heading"))
+        expect(response.body).to include(I18n.t("views.leadership.nav.community"))
+        expect(response.body).to include(I18n.t("views.leadership.explainer.heading"))
       end
 
-      it "renders the section nav for both viewports and marks the current section" do
-        get leadership_section_path("discussion")
+      it "shows gems picked in the past 24 hours by any curator" do
+        other_curator = create(:user, :community_leader_level_1)
+        recent_gem = create(:article, title: "Recent Gem Post")
+        recent_gem.update_columns(favorited_by_user_id: other_curator.id, favorited_at: 2.hours.ago)
 
-        page = Capybara.string(response.body)
+        old_gem = create(:article, title: "Old Gem Post")
+        old_gem.update_columns(favorited_by_user_id: other_curator.id, favorited_at: 2.days.ago)
 
-        # Stacked links on wide viewports, tabs on narrow ones.
-        expect(page).to have_css("nav.m\\:block a.crayons-link--block", count: 2)
-        expect(page).to have_css("nav.m\\:hidden a.crayons-tabs__item", count: 2)
+        get curation_path
 
-        current = page.all("[aria-current='page']").map { |link| link.text.strip }.uniq
-        expect(current).to eq([I18n.t("views.leadership.discussion.heading")])
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Recent Gem Post")
+        expect(response.body).not_to include("Old Gem Post")
       end
 
-      it "shows the leader's favorited content in the curation section" do
-        favorited = create(:article)
-        favorited.update_columns(favorited_by_user_id: leader.id, favorited_at: Time.current)
+      it "shows 'Start the discussion' CTA when a curated post has 0 comments" do
+        gem_post = create(:article, comments_count: 0)
+        gem_post.update_columns(favorited_by_user_id: leader.id, favorited_at: 1.hour.ago)
 
-        get leadership_path
+        get curation_path
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include(favorited.title)
-        expect(response.body).to include(CGI.escapeHTML(favorited.user.name))
+        expect(response.body).to include(I18n.t("views.leadership.cards.start_discussion"))
       end
 
-      it "shows favorited comments alongside favorited posts" do
-        commented_on = create(:article)
-        comment = create(:comment, commentable: commented_on)
-        comment.update_columns(favorited_by_user_id: leader.id, favorited_at: Time.current)
+      it "shows 'Further the discussion' CTA when a curated post has 1 or 2 comments" do
+        gem_post = create(:article, comments_count: 2)
+        gem_post.update_columns(favorited_by_user_id: leader.id, favorited_at: 1.hour.ago)
 
-        get leadership_path
+        get curation_path
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include(CGI.escapeHTML(comment.user.name))
+        expect(response.body).to include(I18n.t("views.leadership.cards.further_discussion"))
       end
 
-      it "renders the suggested discussion feed" do
-        surfaced = create(:article, user: create(:user))
-        surfaced.update_columns(score: 100, comments_count: 0)
+      it "shows your gems in the 'yours' section" do
+        my_gem = create(:article, title: "My Curated Article")
+        my_gem.update_columns(favorited_by_user_id: leader.id, favorited_at: 3.days.ago)
 
-        get leadership_section_path("discussion")
+        other_leader = create(:user, :community_leader_level_1)
+        other_gem = create(:article, title: "Other Curated Article")
+        other_gem.update_columns(favorited_by_user_id: other_leader.id, favorited_at: 3.days.ago)
 
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to include(surfaced.title)
-        expect(response.body).to include(CGI.escapeHTML(surfaced.cached_user.name))
-        expect(response.body).to include(I18n.t("views.leadership.discussion.cta"))
-      end
-
-      it "excludes the leader's own posts from the discussion feed" do
-        own = create(:article, user: leader)
-        own.update_columns(score: 100, comments_count: 0)
-
-        get leadership_section_path("discussion")
+        get curation_section_path("yours")
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).not_to include(own.title)
-      end
-
-      it "accepts pagination params on each section" do
-        get leadership_path(page: 2)
-        expect(response).to have_http_status(:ok)
-
-        get leadership_section_path("discussion", page: 2)
-        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(I18n.t("views.leadership.nav.yours"))
+        expect(response.body).to include("My Curated Article")
+        expect(response.body).not_to include("Other Curated Article")
       end
     end
 
@@ -85,7 +72,7 @@ RSpec.describe "Leadership dashboard" do
       it "returns 404" do
         sign_in create(:user)
 
-        get leadership_path
+        get curation_path
 
         expect(response).to have_http_status(:not_found)
       end
@@ -93,9 +80,22 @@ RSpec.describe "Leadership dashboard" do
 
     context "when signed out" do
       it "does not render the dashboard" do
-        get leadership_path
+        get curation_path
 
         expect(response).not_to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe "GET /leadership" do
+    context "when signed in as a community leader" do
+      before { sign_in leader }
+
+      it "renders the curation dashboard identically" do
+        get leadership_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(I18n.t("views.leadership.heading"))
       end
     end
   end


### PR DESCRIPTION
## Summary

This PR overhauls the Community Curator dashboard and gem curation workflow:

1. **Terminology & Copy Update**:
   - Updates role terminology from 'Community Leader' to **'Community Curator'** / **'Curation'**.
   - Refines curation copy to refer to curated content as **'gems'** with the action **'pick'** / **'picked by @username'**.
   - Synchronized across all supported locales (`en`, `fr`, `pt`).

2. **Curation Dashboard Overhaul**:
   - Adds `/curation` and `/curation/:section` routes alongside `/leadership`.
   - Replaces the standalone 'further the discussion' section with:
     - **Community Picks (24h)**: Recent gems curated across the community in the past 24 hours.
     - **Your Picks**: Gems curated by the logged-in curator over time.
   - Left-aligned compact tab navigation above the story list.
   - Standard story card integration (`_single_story`) with curator badges and contextual discussion call-to-actions:
     - **0 comments**: Red prominent CTA to **'Start the discussion'**.
     - **1–2 comments**: Red CTA to **'Further the discussion (X comments)'**.
     - **3+ comments**: Standard active discussion indicator.
   - Sidebar with **Gem Allowance Counter** and comprehensive **Curation Principles & Guidance**.

3. **Layout Shift & Delayed Render Fixes**:
   - Server-side renders initial button/icon HTML for favorite/gem controls to eliminate layout pop-in for community leaders.
   - Removes empty grid space on non-leader screens by flattening direct grid items and ensuring robust CSS Grid behavior.
   - Locks reaction count placeholder dimensions to prevent vertical shifts during count hydration.

## Verification
- All 18 RSpec tests pass (`leadership_dashboards_spec.rb`, `favorites_spec.rb`).
- All 16 Jest unit tests pass (`FavoriteControl.test.jsx`).
- Tested and verified live on `forem-ai.exe.xyz`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790723592&installation_model_id=424141&pr_number=23787&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23787&signature=1824366ffd5259ffcba6d55c063870c540e2a6964349cdde8a0c2ecbb36431b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->