### PR TITLE
Allow admins to bulk add users to an organization by username

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -2,6 +2,7 @@ module Admin
   class OrganizationsController < Admin::ApplicationController
     layout "admin"
     PER_PAGE_MAX = 50
+    ORG_FEATURES = %w[org_readme org_lead_forms org_dofollow_links org_verification].freeze
 
     CREDIT_ACTIONS = {
       add: :add_to,
@@ -44,7 +45,7 @@ module Admin
       org = Organization.find(params[:id])
       old_status = org.fully_trusted?
       org.update!(fully_trusted: params[:fully_trusted] == "true")
-      
+
       if old_status != org.fully_trusted?
         Note.create(
           author_id: current_user.id,
@@ -70,7 +71,7 @@ module Admin
       org = Organization.find(params[:id])
       old_score = org.baseline_score
       new_score = params[:baseline_score].to_i
-      
+
       org.update!(baseline_score: new_score)
 
       if old_score != org.baseline_score
@@ -128,8 +129,6 @@ module Admin
       redirect_to admin_organization_path(org)
     end
 
-    ORG_FEATURES = %w[org_readme org_lead_forms org_dofollow_links org_verification].freeze
-
     def update_org_feature
       org = Organization.find(params[:id])
       feature = params[:feature]
@@ -171,6 +170,20 @@ module Admin
       redirect_to admin_organization_path(org)
     end
 
+    def bulk_add_users
+      org = Organization.find(params[:id])
+      result = Organizations::BulkAddUsers.call(
+        organization: org,
+        usernames: params[:usernames],
+        role: params[:role],
+      )
+
+      log_bulk_add_audit_and_notes(org, result)
+      set_bulk_add_flash_message(result)
+
+      redirect_to admin_organization_path(org)
+    end
+
     def destroy
       organization = Organization.find_by(id: params[:id])
       Organizations::DeleteWorker.perform_async(organization.id, current_user.id, false)
@@ -193,6 +206,64 @@ module Admin
         reason: "misc_note",
         content: params[:note],
       )
+    end
+
+    def log_bulk_add_audit_and_notes(org, result)
+      if result.added_users.any?
+        Note.create(
+          author_id: current_user.id,
+          noteable_id: org.id,
+          noteable_type: "Organization",
+          reason: "misc_note",
+          content: "Bulk added #{result.added_users.size} #{result.role} member(s): #{result.added_users.join(', ')}",
+        )
+      end
+
+      Audit::Logger.log(:moderator, current_user, {
+                          "action" => params[:action],
+                          "controller" => params[:controller],
+                          "target_organization_id" => org.id,
+                          "role" => result.role,
+                          "added_users" => result.added_users,
+                          "already_members" => result.already_members,
+                          "not_found" => result.not_found,
+                          "failed_users" => result.failed_users
+                        })
+    end
+
+    def set_bulk_add_flash_message(result)
+      if result.empty_input?
+        flash[:error] = I18n.t("admin.organizations_controller.bulk_add_users.empty_input")
+        return
+      end
+
+      messages = bulk_add_result_messages(result)
+      if result.added_users.any?
+        flash[:notice] = messages.join(" ")
+      else
+        flash[:error] = messages.join(" ")
+      end
+    end
+
+    def bulk_add_result_messages(result)
+      messages = []
+      if result.added_users.any?
+        messages << I18n.t("admin.organizations_controller.bulk_add_users.added",
+                           count: result.added_users.size, usernames: result.added_users.join(", "))
+      end
+      if result.already_members.any?
+        messages << I18n.t("admin.organizations_controller.bulk_add_users.already_members",
+                           count: result.already_members.size, usernames: result.already_members.join(", "))
+      end
+      if result.not_found.any?
+        messages << I18n.t("admin.organizations_controller.bulk_add_users.not_found",
+                           count: result.not_found.size, usernames: result.not_found.join(", "))
+      end
+      if result.failed_users.any?
+        messages << I18n.t("admin.organizations_controller.bulk_add_users.failed",
+                           count: result.failed_users.size, errors: result.failed_users.join(", "))
+      end
+      messages
     end
   end
 end

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -215,7 +215,7 @@ module Admin
           noteable_id: org.id,
           noteable_type: "Organization",
           reason: "misc_note",
-          content: "Bulk added #{result.added_users.size} #{result.role} member(s): #{result.added_users.join(', ')}",
+          content: "Bulk added #{result.added_users.size} user(s) as #{result.role}: #{result.added_users.join(', ')}",
         )
       end
 

--- a/app/services/organizations/bulk_add_users.rb
+++ b/app/services/organizations/bulk_add_users.rb
@@ -1,0 +1,96 @@
+module Organizations
+  class BulkAddUsers
+    ALLOWED_ROLES = %w[member admin].freeze
+    DEFAULT_ROLE = "member".freeze
+
+    Result = Struct.new(
+      :role,
+      :added_users,
+      :already_members,
+      :not_found,
+      :failed_users,
+      :empty_input,
+      keyword_init: true,
+    ) do
+      def empty_input?
+        !empty_input.nil? && empty_input != false
+      end
+    end
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def self.parse_usernames(raw_usernames)
+      return [] if raw_usernames.blank?
+
+      raw_usernames.to_s
+        .split(/[,\n]/)
+        .map { |u| u.strip.sub(/\A@+/, "").downcase }
+        .compact_blank
+        .uniq
+    end
+
+    def initialize(organization:, usernames:, role: DEFAULT_ROLE)
+      @organization = organization
+      @raw_usernames = usernames
+      @role = ALLOWED_ROLES.include?(role.to_s) ? role.to_s : DEFAULT_ROLE
+    end
+
+    def call
+      parsed_usernames = self.class.parse_usernames(raw_usernames)
+
+      if parsed_usernames.empty?
+        return Result.new(
+          role: role,
+          added_users: [],
+          already_members: [],
+          not_found: [],
+          failed_users: [],
+          empty_input: true,
+        )
+      end
+
+      users_by_username = User.where(username: parsed_usernames).index_by { |u| u.username.downcase }
+      existing_member_user_ids = organization.organization_memberships
+        .where(user_id: users_by_username.values.map(&:id))
+        .pluck(:user_id)
+        .to_set
+
+      added_users = []
+      already_members = []
+      not_found = []
+      failed_users = []
+
+      parsed_usernames.each do |username|
+        user = users_by_username[username]
+
+        if user.nil?
+          not_found << username
+        elsif existing_member_user_ids.include?(user.id)
+          already_members << user.username
+        else
+          membership = organization.organization_memberships.build(user: user, type_of_user: role)
+          if membership.save
+            added_users << user.username
+          else
+            failed_users << "#{user.username} (#{membership.errors_as_sentence})"
+          end
+        end
+      end
+
+      Result.new(
+        role: role,
+        added_users: added_users,
+        already_members: already_members,
+        not_found: not_found,
+        failed_users: failed_users,
+        empty_input: false,
+      )
+    end
+
+    private
+
+    attr_reader :organization, :raw_usernames, :role
+  end
+end

--- a/app/services/organizations/bulk_add_users.rb
+++ b/app/services/organizations/bulk_add_users.rb
@@ -71,10 +71,14 @@ module Organizations
           already_members << user.username
         else
           membership = organization.organization_memberships.build(user: user, type_of_user: role)
-          if membership.save
-            added_users << user.username
-          else
-            failed_users << "#{user.username} (#{membership.errors_as_sentence})"
+          begin
+            if membership.save
+              added_users << user.username
+            else
+              failed_users << "#{user.username} (#{membership.errors_as_sentence})"
+            end
+          rescue ActiveRecord::RecordNotUnique
+            already_members << user.username
           end
         end
       end

--- a/app/views/admin/organizations/show.html.erb
+++ b/app/views/admin/organizations/show.html.erb
@@ -243,6 +243,26 @@
     <%= number_field_tag :baseline_score, @organization.baseline_score, class: "crayons-textfield w-25", min: 0 %>
     <%= submit_tag "Update Score", class: "crayons-btn" %>
   <% end %>
+<div class="crayons-card p-6 mb-6">
+  <h3 class="crayons-subtitle-2 mb-4"><%= t("views.admin.organizations.bulk_add_users.heading") %></h3>
+  <p class="fs-s color-base-60 mb-4">
+    <%= t("views.admin.organizations.bulk_add_users.description") %>
+  </p>
+  <%= form_tag bulk_add_users_admin_organization_path(@organization), method: :post, class: "flex flex-col gap-4" do %>
+    <div class="crayons-field">
+      <%= label_tag :usernames, t("views.admin.organizations.bulk_add_users.usernames_label"), class: "crayons-field__label" %>
+      <%= text_area_tag :usernames, nil, placeholder: "username1, @username2, username3", required: true, rows: 3, class: "crayons-textfield w-100", aria: { label: t("views.admin.organizations.bulk_add_users.usernames_label") } %>
+    </div>
+    <div class="flex items-center gap-4 flex-wrap">
+      <div class="crayons-field mb-0">
+        <%= label_tag :role, t("views.admin.organizations.bulk_add_users.role_label"), class: "crayons-field__label" %>
+        <%= select_tag :role, options_for_select([[t("views.admin.organizations.bulk_add_users.roles.member"), "member"], [t("views.admin.organizations.bulk_add_users.roles.admin"), "admin"]], "member"), class: "crayons-select" %>
+      </div>
+      <div class="self-end">
+        <%= submit_tag t("views.admin.organizations.bulk_add_users.submit"), class: "crayons-btn crayons-btn--primary" %>
+      </div>
+    </div>
+  <% end %>
 </div>
 
 <%= render "activity" %>

--- a/app/views/admin/organizations/show.html.erb
+++ b/app/views/admin/organizations/show.html.erb
@@ -243,6 +243,8 @@
     <%= number_field_tag :baseline_score, @organization.baseline_score, class: "crayons-textfield w-25", min: 0 %>
     <%= submit_tag "Update Score", class: "crayons-btn" %>
   <% end %>
+</div>
+
 <div class="crayons-card p-6 mb-6">
   <h3 class="crayons-subtitle-2 mb-4"><%= t("views.admin.organizations.bulk_add_users.heading") %></h3>
   <p class="fs-s color-base-60 mb-4">
@@ -251,7 +253,7 @@
   <%= form_tag bulk_add_users_admin_organization_path(@organization), method: :post, class: "flex flex-col gap-4" do %>
     <div class="crayons-field">
       <%= label_tag :usernames, t("views.admin.organizations.bulk_add_users.usernames_label"), class: "crayons-field__label" %>
-      <%= text_area_tag :usernames, nil, placeholder: "username1, @username2, username3", required: true, rows: 3, class: "crayons-textfield w-100", aria: { label: t("views.admin.organizations.bulk_add_users.usernames_label") } %>
+      <%= text_area_tag :usernames, nil, placeholder: t("views.admin.organizations.bulk_add_users.usernames_placeholder"), required: true, rows: 3, class: "crayons-textfield w-100", aria: { label: t("views.admin.organizations.bulk_add_users.usernames_label") } %>
     </div>
     <div class="flex items-center gap-4 flex-wrap">
       <div class="crayons-field mb-0">

--- a/config/locales/controllers/admin/en.yml
+++ b/config/locales/controllers/admin/en.yml
@@ -127,6 +127,12 @@ en:
       org_feature_enabled: "%{feature} has been enabled for this organization."
       org_feature_disabled: "%{feature} has been disabled for this organization."
       org_feature_invalid: "Invalid org feature specified."
+      bulk_add_users:
+        added: "Successfully added %{count} user(s) (%{usernames}) to the organization."
+        already_members: "Already member(s): %{usernames}."
+        not_found: "User(s) not found: %{usernames}."
+        failed: "Failed to add %{count} user(s): %{errors}."
+        empty_input: "Please provide at least one username."
     org_features_controller:
       invalid_feature: "Invalid feature specified."
       global_enabled: "%{feature} has been enabled for all organizations."

--- a/config/locales/controllers/admin/fr.yml
+++ b/config/locales/controllers/admin/fr.yml
@@ -127,6 +127,12 @@ fr:
       org_feature_enabled: "%{feature} a été activé pour cette organisation."
       org_feature_disabled: "%{feature} a été désactivé pour cette organisation."
       org_feature_invalid: "Fonctionnalité d'organisation spécifiée invalide."
+      bulk_add_users:
+        added: "%{count} utilisateur(s) (%{usernames}) ont été ajoutés avec succès à l'organisation."
+        already_members: "Déjà membre(s) : %{usernames}."
+        not_found: "Utilisateur(s) non trouvé(s) : %{usernames}."
+        failed: "Échec de l'ajout de %{count} utilisateur(s) : %{errors}."
+        empty_input: "Veuillez fournir au moins un nom d'utilisateur."
     org_features_controller:
       invalid_feature: "Fonctionnalité spécifiée invalide."
       global_enabled: "%{feature} a été activé pour toutes les organisations."

--- a/config/locales/controllers/admin/pt.yml
+++ b/config/locales/controllers/admin/pt.yml
@@ -92,6 +92,12 @@ pt:
       org_feature_enabled: "%{feature} foi habilitado para esta organização."
       org_feature_disabled: "%{feature} foi desabilitado para esta organização."
       org_feature_invalid: "Funcionalidade de organização especificada inválida."
+      bulk_add_users:
+        added: "%{count} usuário(s) (%{usernames}) adicionado(s) com sucesso à organização."
+        already_members: "Já membro(s): %{usernames}."
+        not_found: "Usuário(s) não encontrado(s): %{usernames}."
+        failed: "Falha ao adicionar %{count} usuário(s): %{errors}."
+        empty_input: "Por favor, forneça pelo menos um nome de usuário."
     org_features_controller:
       invalid_feature: "Funcionalidade especificada inválida."
       global_enabled: "%{feature} foi habilitado para todas as organizações."

--- a/config/locales/views/admin/en.yml
+++ b/config/locales/views/admin/en.yml
@@ -562,6 +562,15 @@ en:
             enable: Enable Dofollow
             disable: Disable Dofollow
             enabled_notice: Dofollow links are enabled for this organization's readme page.
+        bulk_add_users:
+          heading: Bulk Add Members
+          description: "Add multiple users to this organization at once. Enter a comma-separated list of usernames (with or without @ and spaces). Existing members will be skipped."
+          usernames_label: Usernames
+          role_label: Role
+          roles:
+            member: Member
+            admin: Admin
+          submit: Bulk Add Members
       favorites:
         leaderboard:
           heading: Impact Leaderboard

--- a/config/locales/views/admin/en.yml
+++ b/config/locales/views/admin/en.yml
@@ -566,6 +566,7 @@ en:
           heading: Bulk Add Members
           description: "Add multiple users to this organization at once. Enter a comma-separated list of usernames (with or without @ and spaces). Existing members will be skipped."
           usernames_label: Usernames
+          usernames_placeholder: "username1, @username2, username3"
           role_label: Role
           roles:
             member: Member

--- a/config/locales/views/admin/fr.yml
+++ b/config/locales/views/admin/fr.yml
@@ -555,6 +555,7 @@ fr:
           heading: Ajouter des membres en bloc
           description: "Ajoutez plusieurs utilisateurs à cette organisation en une seule fois. Entrez une liste de noms d'utilisateur séparés par des virgules (avec ou sans @ et espaces). Les membres existants seront ignorés."
           usernames_label: Noms d'utilisateur
+          usernames_placeholder: "utilisateur1, @utilisateur2, utilisateur3"
           role_label: Rôle
           roles:
             member: Membre

--- a/config/locales/views/admin/fr.yml
+++ b/config/locales/views/admin/fr.yml
@@ -551,6 +551,15 @@ fr:
             enable: Activer Dofollow
             disable: Désactiver Dofollow
             enabled_notice: Les liens dofollow sont activés pour la page readme de cette organisation.
+        bulk_add_users:
+          heading: Ajouter des membres en bloc
+          description: "Ajoutez plusieurs utilisateurs à cette organisation en une seule fois. Entrez une liste de noms d'utilisateur séparés par des virgules (avec ou sans @ et espaces). Les membres existants seront ignorés."
+          usernames_label: Noms d'utilisateur
+          role_label: Rôle
+          roles:
+            member: Membre
+            admin: Administrateur
+          submit: Ajouter des membres en bloc
       favorites:
         leaderboard:
           heading: Classement d'impact

--- a/config/locales/views/admin/pt.yml
+++ b/config/locales/views/admin/pt.yml
@@ -452,6 +452,7 @@ pt:
           heading: Adicionar Membros em Massa
           description: "Adicione múltiplos usuários a esta organização de uma só vez. Digite uma lista de nomes de usuário separados por vírgula (com ou sem @ e espaços). Membros existentes serão ignorados."
           usernames_label: Nomes de Usuário
+          usernames_placeholder: "usuario1, @usuario2, usuario3"
           role_label: Função
           roles:
             member: Membro

--- a/config/locales/views/admin/pt.yml
+++ b/config/locales/views/admin/pt.yml
@@ -448,6 +448,15 @@ pt:
             enable: Habilitar Dofollow
             disable: Desabilitar Dofollow
             enabled_notice: Links dofollow estão habilitados para a página readme desta organização.
+        bulk_add_users:
+          heading: Adicionar Membros em Massa
+          description: "Adicione múltiplos usuários a esta organização de uma só vez. Digite uma lista de nomes de usuário separados por vírgula (com ou sem @ e espaços). Membros existentes serão ignorados."
+          usernames_label: Nomes de Usuário
+          role_label: Função
+          roles:
+            member: Membro
+            admin: Administrador
+          submit: Adicionar Membros em Massa
       favorites:
         leaderboard:
           heading: Ranking de impacto

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -120,6 +120,7 @@ namespace :admin do
         patch "update_baseline_score"
         patch "update_verified"
         patch "update_org_feature"
+        post "bulk_add_users"
       end
     end
     resources :emails

--- a/spec/requests/admin/organizations_bulk_add_users_spec.rb
+++ b/spec/requests/admin/organizations_bulk_add_users_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Admin Bulk Add Users to Organization" do
         note = Note.last
         expect(note.noteable).to eq(organization)
         expect(note.author_id).to eq(admin.id)
-        expect(note.content).to include("Bulk added 2 member member(s)")
+        expect(note.content).to include("Bulk added 2 user(s) as member: #{user1.username}, #{user2.username}")
       ensure
         Audit::Subscribe.forget :moderator
       end

--- a/spec/requests/admin/organizations_bulk_add_users_spec.rb
+++ b/spec/requests/admin/organizations_bulk_add_users_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.describe "Admin Bulk Add Users to Organization" do
+  let(:admin) { create(:user, :super_admin) }
+  let(:regular_user) { create(:user) }
+  let(:organization) { create(:organization) }
+  let(:user1) { create(:user, username: "dev_alice") }
+  let(:user2) { create(:user, username: "dev_bob") }
+
+  describe "POST /admin/content_manager/organizations/:id/bulk_add_users" do
+    it "denies access to non-admin users" do
+      sign_in(regular_user)
+      expect do
+        post bulk_add_users_admin_organization_path(organization), params: { usernames: user1.username }
+      end.to raise_error(Pundit::NotAuthorizedError)
+    end
+
+    context "when authorized as admin" do
+      before { sign_in(admin) }
+
+      it "successfully bulk adds users to the organization and redirects", :aggregate_failures do
+        expect do
+          post bulk_add_users_admin_organization_path(organization), params: {
+            usernames: "@#{user1.username},  #{user2.username} ",
+            role: "member"
+          }
+        end.to change { organization.organization_memberships.count }.by(2)
+
+        expect(response).to redirect_to(admin_organization_path(organization))
+        expect(flash[:notice]).to include(user1.username)
+        expect(flash[:notice]).to include(user2.username)
+
+        expect(organization.organization_memberships.pluck(:user_id)).to contain_exactly(user1.id, user2.id)
+      end
+
+      it "allows specifying admin role for new members", :aggregate_failures do
+        post bulk_add_users_admin_organization_path(organization), params: {
+          usernames: "@#{user1.username}",
+          role: "admin"
+        }
+
+        membership = organization.organization_memberships.find_by(user_id: user1.id)
+        expect(membership.type_of_user).to eq("admin")
+      end
+
+      it "handles empty input gracefully", :aggregate_failures do
+        expect do
+          post bulk_add_users_admin_organization_path(organization), params: { usernames: "  " }
+        end.not_to change { organization.organization_memberships.count }
+
+        expect(response).to redirect_to(admin_organization_path(organization))
+        expect(flash[:error]).to be_present
+      end
+
+      it "reports already-members and non-existent users", :aggregate_failures do
+        create(:organization_membership, organization: organization, user: user1, type_of_user: "member")
+
+        expect do
+          post bulk_add_users_admin_organization_path(organization), params: {
+            usernames: "@#{user1.username}, #{user2.username}, unknown_user_999",
+            role: "member"
+          }
+        end.to change { organization.organization_memberships.count }.by(1)
+
+        expect(response).to redirect_to(admin_organization_path(organization))
+        expect(flash[:notice]).to include(user2.username)
+        expect(flash[:notice]).to include(user1.username)
+        expect(flash[:notice]).to include("unknown_user_999")
+      end
+
+      it "creates an audit log and admin note on the organization", :aggregate_failures do
+        Audit::Subscribe.listen :moderator
+        expect do
+          post bulk_add_users_admin_organization_path(organization), params: {
+            usernames: "@#{user1.username}, #{user2.username}",
+            role: "member"
+          }
+        end.to change(AuditLog, :count).by(1)
+          .and change(Note, :count).by(1)
+
+        audit_log = AuditLog.last
+        expect(audit_log.category).to eq(AuditLog::MODERATOR_AUDIT_LOG_CATEGORY)
+        expect(audit_log.user_id).to eq(admin.id)
+        expect(audit_log.data["action"]).to eq("bulk_add_users")
+        expect(audit_log.data["target_organization_id"]).to eq(organization.id)
+        expect(audit_log.data["added_users"]).to contain_exactly(user1.username, user2.username)
+
+        note = Note.last
+        expect(note.noteable).to eq(organization)
+        expect(note.author_id).to eq(admin.id)
+        expect(note.content).to include("Bulk added 2 member member(s)")
+      ensure
+        Audit::Subscribe.forget :moderator
+      end
+    end
+  end
+end

--- a/spec/services/organizations/bulk_add_users_spec.rb
+++ b/spec/services/organizations/bulk_add_users_spec.rb
@@ -107,5 +107,16 @@ RSpec.describe Organizations::BulkAddUsers do
         expect(result.not_found).to eq(["unknown_dev"])
       end
     end
+
+    context "when a race condition raises RecordNotUnique on membership save" do
+      it "handles the error gracefully and marks the user as already member", :aggregate_failures do
+        allow_any_instance_of(OrganizationMembership).to receive(:save) # rubocop:disable RSpec/AnyInstance
+          .and_raise(ActiveRecord::RecordNotUnique)
+
+        result = described_class.call(organization: organization, usernames: user1.username)
+        expect(result.added_users).to be_empty
+        expect(result.already_members).to eq([user1.username])
+      end
+    end
   end
 end

--- a/spec/services/organizations/bulk_add_users_spec.rb
+++ b/spec/services/organizations/bulk_add_users_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+RSpec.describe Organizations::BulkAddUsers do
+  let(:organization) { create(:organization) }
+  let(:user1) { create(:user, username: "user_one") }
+  let(:user2) { create(:user, username: "user_two") }
+  let(:user3) { create(:user, username: "user_three") }
+
+  describe ".parse_usernames" do
+    it "handles comma-separated usernames with or without @ and spaces" do
+      input = " @user_one,  user_two , @user_three "
+      expect(described_class.parse_usernames(input)).to eq(%w[user_one user_two user_three])
+    end
+
+    it "handles newline-separated usernames" do
+      input = "@user_one\nuser_two\r\n@user_three"
+      expect(described_class.parse_usernames(input)).to eq(%w[user_one user_two user_three])
+    end
+
+    it "handles downcasing and deduplication" do
+      input = "User_One, @USER_ONE, user_two"
+      expect(described_class.parse_usernames(input)).to eq(%w[user_one user_two])
+    end
+
+    it "handles empty or whitespace-only inputs" do
+      expect(described_class.parse_usernames("")).to eq([])
+      expect(described_class.parse_usernames("   ")).to eq([])
+      expect(described_class.parse_usernames(", , ,")).to eq([])
+      expect(described_class.parse_usernames(nil)).to eq([])
+    end
+  end
+
+  describe "#call" do
+    context "when input is empty or invalid" do
+      it "returns empty_input result" do
+        result = described_class.call(organization: organization, usernames: "")
+        expect(result.empty_input?).to be true
+        expect(result.added_users).to be_empty
+        expect(result.already_members).to be_empty
+        expect(result.not_found).to be_empty
+      end
+    end
+
+    context "when adding new valid users" do
+      it "adds users as members by default", :aggregate_failures do
+        input = "@#{user1.username}, #{user2.username}"
+        result = described_class.call(organization: organization, usernames: input)
+
+        expect(result.empty_input?).to be false
+        expect(result.added_users).to contain_exactly(user1.username, user2.username)
+        expect(result.already_members).to be_empty
+        expect(result.not_found).to be_empty
+
+        membership1 = organization.organization_memberships.find_by(user_id: user1.id)
+        membership2 = organization.organization_memberships.find_by(user_id: user2.id)
+        expect(membership1.type_of_user).to eq("member")
+        expect(membership2.type_of_user).to eq("member")
+      end
+
+      it "adds users as admins when role is specified", :aggregate_failures do
+        input = user1.username
+        result = described_class.call(organization: organization, usernames: input, role: "admin")
+
+        expect(result.added_users).to eq([user1.username])
+        membership = organization.organization_memberships.find_by(user_id: user1.id)
+        expect(membership.type_of_user).to eq("admin")
+      end
+    end
+
+    context "when users do not exist" do
+      it "records not_found usernames", :aggregate_failures do
+        input = "@#{user1.username}, nonexistent_user_xyz"
+        result = described_class.call(organization: organization, usernames: input)
+
+        expect(result.added_users).to eq([user1.username])
+        expect(result.not_found).to eq(["nonexistent_user_xyz"])
+        expect(result.already_members).to be_empty
+      end
+    end
+
+    context "when users are already members of the organization" do
+      before do
+        create(:organization_membership, organization: organization, user: user1, type_of_user: "member")
+      end
+
+      it "records already_members and does not create duplicate memberships", :aggregate_failures do
+        input = "@#{user1.username}, #{user2.username}"
+        expect do
+          result = described_class.call(organization: organization, usernames: input)
+          expect(result.added_users).to eq([user2.username])
+          expect(result.already_members).to eq([user1.username])
+        end.to change { organization.organization_memberships.count }.by(1)
+      end
+    end
+
+    context "when handling mixed valid, existing, and non-existent usernames" do
+      before do
+        create(:organization_membership, organization: organization, user: user1, type_of_user: "member")
+      end
+
+      it "processes each category accurately", :aggregate_failures do
+        input = "@#{user1.username}, #{user2.username}, unknown_dev, @#{user3.username}"
+        result = described_class.call(organization: organization, usernames: input)
+
+        expect(result.added_users).to contain_exactly(user2.username, user3.username)
+        expect(result.already_members).to eq([user1.username])
+        expect(result.not_found).to eq(["unknown_dev"])
+      end
+    end
+  end
+end

--- a/spec/system/admin/admin_manages_organizations_spec.rb
+++ b/spec/system/admin/admin_manages_organizations_spec.rb
@@ -23,7 +23,24 @@ RSpec.describe "Admin manages organizations" do
 
     it "does not show the remove form when there are no credits" do
       expect(page).to have_button("Add Org Credits")
-      expect(page).not_to have_button("Remove Org Credits")
+      expect(page).to have_no_button("Remove Org Credits")
+    end
+  end
+
+  context "when bulk adding users to an organization" do
+    let!(:user1) { create(:user, username: "sys_alice") }
+    let!(:user2) { create(:user, username: "sys_bob") }
+
+    before { visit admin_organization_path(organization) }
+
+    it "adds users to the organization from the admin page", :aggregate_failures do
+      fill_in "Usernames", with: "@#{user1.username}, #{user2.username}"
+      select "Member", from: "Role"
+      click_on "Bulk Add Members"
+
+      expect(page).to have_content(user1.username)
+      expect(page).to have_content(user2.username)
+      expect(organization.organization_memberships.pluck(:user_id)).to contain_exactly(user1.id, user2.id)
     end
   end
 end

--- a/spec/system/admin/admin_manages_organizations_spec.rb
+++ b/spec/system/admin/admin_manages_organizations_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Admin manages organizations" do
 
       expect(page).to have_content(user1.username)
       expect(page).to have_content(user2.username)
-      expect(organization.organization_memberships.pluck(:user_id)).to contain_exactly(user1.id, user2.id)
+      expect(organization.reload.organization_memberships.pluck(:user_id)).to contain_exactly(user1.id, user2.id)
     end
   end
 end


### PR DESCRIPTION
## What does this PR do?

Adds a feature enabling administrators to bulk add users to an organization by pasting a list of comma-separated usernames (supporting optional `@` prefixes, spaces, newlines, and mixed casing) from the organization admin page.

### Features
- **Service Layer (`Organizations::BulkAddUsers`)**:
  - Parses and cleans username input (handling `@` prefixes, whitespace, newlines, casing, deduplication).
  - Performs batch queries to prevent N+1 query overhead.
  - Returns structured results categorizing added users, existing members, not found usernames, and any failed validations.
- **Admin UI & Controller (`Admin::OrganizationsController`)**:
  - Added "Bulk Add Members" Crayons card to the organization admin show page (`app/views/admin/organizations/show.html.erb`).
  - Added `post :bulk_add_users` member route in `config/routes/admin.rb`.
  - Creates admin `Note` on the organization and records moderator `AuditLog` on execution.
  - Sets informative flash messages with detailed breakdown of added, existing, and unknown usernames.
- **Internationalization (i18n)**:
  - Added translations across all supported locales (`en`, `fr`, `pt`).
- **Tests**:
  - Unit specs: `spec/services/organizations/bulk_add_users_spec.rb`
  - Request specs: `spec/requests/admin/organizations_bulk_add_users_spec.rb`
  - System specs: `spec/system/admin/admin_manages_organizations_spec.rb`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790784557&installation_model_id=424141&pr_number=23788&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23788&signature=5ddfff271c31d88948657598e9907ca15267629eeacb912ac422126a2c81df9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->