### PR TITLE
Replace client-side stylesheet swapping with fingerprinted internal navigation

### DIFF
--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -50,6 +50,7 @@ var instantClick
 
 
   function getInternalUrl(url) {
+    url = removeHash(url)
     var param = $styleFingerprint ? "i=" + $styleFingerprint : "i=i"
     if (url.indexOf("?") == -1) {
       return url + "?" + param

--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -20,6 +20,7 @@ var instantClick
     , $urlToPreload
     , $preloadTimer
     , $lastTouchTimestamp
+    , $styleFingerprint = false
 
   // Preloading-related variables
     , $history = {}
@@ -47,6 +48,16 @@ var instantClick
 
   ////////// HELPERS //////////
 
+
+  function getInternalUrl(url) {
+    var param = $styleFingerprint ? "i=" + $styleFingerprint : "i=i"
+    if (url.indexOf("?") == -1) {
+      return url + "?" + param
+    }
+    else {
+      return url + "&" + param
+    }
+  }
 
   function removeHash(url) {
     var index = url.indexOf('#')
@@ -490,12 +501,7 @@ var instantClick
     $timing = {
       start: +new Date
     }
-    if (url.indexOf("?") == -1) {
-      var internalUrl = url+"?i=i"
-    }
-    else {
-      var internalUrl = url+"&i=i"
-    }
+    var internalUrl = getInternalUrl(url)
     removeExpiredKeys()
     triggerPageEvent('fetch')
     if (!$fetchedBodies[url]){
@@ -521,12 +527,7 @@ var instantClick
 
   function getURLInfo(url, callback) {
     var xhr = new XMLHttpRequest();
-    if (url.indexOf("?") == -1) {
-      var internalUrl = url+"?i=i"
-    }
-    else {
-      var internalUrl = url+"&i=i"
-    }
+    var internalUrl = getInternalUrl(url)
     xhr.open (
       "GET",
       internalUrl,
@@ -649,6 +650,7 @@ var instantClick
     else if (typeof preloadingMode == 'number') {
       $delayBeforePreload = preloadingMode
     }
+    $styleFingerprint = (document.body && document.body.dataset && document.body.dataset.styleFingerprint) || false
     $currentLocationWithoutHash = removeHash(location.href)
     $history[$currentLocationWithoutHash] = {
       body: document.getElementById("page-content"),

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -325,7 +325,7 @@ class ApplicationController < ActionController::Base
   end
 
   def internal_navigation?
-    params[:i] == "i"
+    params[:i] == "i" || params[:i].to_s.match?(/\A[a-f0-9]{8,12}\z/)
   end
   helper_method :internal_navigation?
 
@@ -609,9 +609,9 @@ class ApplicationController < ActionController::Base
   end
 
   def internal_nav_param
-    return "" unless params[:i] == "i"
+    return "" unless internal_navigation?
 
-    "?i=i"
+    "?i=#{params[:i]}"
   end
 
   def clear_request_store

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -573,5 +573,16 @@ module ApplicationHelper
 
     URL.url("#{main_path}#{query}")
   end
+
+  def main_stylesheets_fingerprint
+    @main_stylesheets_fingerprint ||= begin
+      combined = [
+        stylesheet_path("minimal"),
+        stylesheet_path("views"),
+        stylesheet_path("crayons")
+      ].join
+      Digest::MD5.hexdigest(combined)[0..9]
+    end
+  end
 end
 

--- a/app/lib/org_custom_domain_constraint.rb
+++ b/app/lib/org_custom_domain_constraint.rb
@@ -39,7 +39,7 @@ class OrgCustomDomainConstraint
     path = request.path.to_s
     first_segment = path.split("/")[1]
 
-    if platform_path?(first_segment, path) && request.params[:i] != "i"
+    if platform_path?(first_segment, path) && (request.params[:i] != "i" && !request.params[:i].to_s.match?(/\A[a-f0-9]{8,12}\z/))
       return nil
     end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -87,7 +87,8 @@
       data-algolia-display="<%= j(Settings::General.display_algolia_branding) %>"
       data-dynamic-url-component="<%= ENV.fetch("BILLBOARD_URL_COMPONENT", "bb") %>"
       data-ga4-tracking-id="<%= j(Settings::General.ga_analytics_4_id) %>"
-      data-global-feature-flags-enabled="<%= j(enabled_global_feature_flags) %>">
+      data-global-feature-flags-enabled="<%= j(enabled_global_feature_flags) %>"
+      data-style-fingerprint="<%= main_stylesheets_fingerprint %>">
       <%# Repeat of stylesheets in <head> to fix rendering glitch: https://github.com/forem/forem/issues/12377 %>
       
       <%# First script to run no matter what %>
@@ -158,63 +159,6 @@
     <%= yield %>
     <div id="runtime-banner-container"></div>
     <div id="i18n-translations" data-translations="<%= i18n_translations_for_javascript.to_json %>"></div>
-    <% if internal_navigation? %>
-      <script>
-        (function() {
-          var expectedStyles = {
-            "minimal": "<%= stylesheet_path('minimal') %>",
-            "views": "<%= stylesheet_path('views') %>",
-            "crayons": "<%= stylesheet_path('crayons') %>"
-          };
-          var qualifiers = ["main", "secondary"];
-          Object.keys(expectedStyles).forEach(function(name) {
-            var expectedHref = expectedStyles[name];
-            for (var i = 0; i < qualifiers.length; i++) {
-              var id = qualifiers[i] + "-" + name + "-stylesheet";
-              var link = document.getElementById(id);
-              if (link) {
-                var currentHref = link.getAttribute('href');
-                if (currentHref && currentHref !== expectedHref && link.dataset.pendingHref !== expectedHref) {
-                  link.dataset.pendingHref = expectedHref;
-                  var newLink = document.createElement('link');
-                  newLink.rel = 'stylesheet';
-                  newLink.media = link.media || 'all';
-                  newLink.href = expectedHref;
-                  newLink.onload = (function(targetId, expectedUrl, replacementLink) {
-                    return function() {
-                      var currentTarget = document.getElementById(targetId);
-                      if (currentTarget && currentTarget.dataset.pendingHref === expectedUrl) {
-                        replacementLink.id = targetId;
-                        delete currentTarget.dataset.pendingHref;
-                        if (currentTarget.parentNode) {
-                          currentTarget.parentNode.replaceChild(replacementLink, currentTarget);
-                          return;
-                        }
-                      }
-                      if (replacementLink.parentNode) {
-                        replacementLink.parentNode.removeChild(replacementLink);
-                      }
-                    };
-                  })(id, expectedHref, newLink);
-                  newLink.onerror = (function(targetId, expectedUrl, replacementLink) {
-                    return function() {
-                      var currentTarget = document.getElementById(targetId);
-                      if (currentTarget && currentTarget.dataset.pendingHref === expectedUrl) {
-                        delete currentTarget.dataset.pendingHref;
-                      }
-                      if (replacementLink.parentNode) {
-                        replacementLink.parentNode.removeChild(replacementLink);
-                      }
-                    };
-                  })(id, expectedHref, newLink);
-                  document.head.appendChild(newLink);
-                }
-              }
-            }
-          });
-        })();
-      </script>
-    <% end %>
   </div>
 </div>
 <% unless internal_navigation? %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -703,4 +703,13 @@ RSpec.describe ApplicationHelper do
       expect(helper.custom_domain_main_app_url(organization)).to eq("http://forem.com/myorg/my-article")
     end
   end
+
+  describe "#main_stylesheets_fingerprint" do
+    it "returns a deterministic hash based on minimal, views, and crayons stylesheet paths" do
+      fingerprint = helper.main_stylesheets_fingerprint
+      expect(fingerprint).to be_a(String)
+      expect(fingerprint.length).to eq(10)
+      expect(fingerprint).to eq(helper.main_stylesheets_fingerprint)
+    end
+  end
 end

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -633,28 +633,29 @@ RSpec.describe "StoriesIndex" do
     end
   end
 
-  describe "InstantClick stylesheet alignment" do
-    it "does not render the alignment script under normal navigation" do
+  describe "InstantClick stylesheet fingerprinting and layout behavior" do
+    it "renders data-style-fingerprint and outer shell link tags under normal navigation" do
       get "/"
       expect(response).to have_http_status(:ok)
+      expect(response.body).to include("data-style-fingerprint=")
       expect(response.body).not_to include("expectedStyles")
       # Expect outer shell link tags
       expect(response.body).to include('id="main-minimal-stylesheet"')
     end
 
-    it "renders the alignment script with correct asset paths under internal navigation" do
+    it "renders internal navigation fragment without alignment script or outer shell links" do
       get "/", params: { i: "i" }
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("expectedStyles")
-      expected_minimal = ActionController::Base.helpers.stylesheet_path("minimal")
-      expected_views = ActionController::Base.helpers.stylesheet_path("views")
-      expected_crayons = ActionController::Base.helpers.stylesheet_path("crayons")
-      expect(response.body).to include(%("minimal": "#{expected_minimal}"))
-      expect(response.body).to include(%("views": "#{expected_views}"))
-      expect(response.body).to include(%("crayons": "#{expected_crayons}"))
-      expect(response.body).to include("pendingHref")
-      expect(response.body).to include("replaceChild")
+      expect(response.body).not_to include("expectedStyles")
+      expect(response.body).not_to include("pendingHref")
       # Internal navigation excludes the outer layout, so the outer shell links should not be rendered
+      expect(response.body).not_to include('id="main-minimal-stylesheet"')
+    end
+
+    it "supports fingerprinted internal navigation params" do
+      get "/", params: { i: "cc9ed033eb" }
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("expectedStyles")
       expect(response.body).not_to include('id="main-minimal-stylesheet"')
     end
   end


### PR DESCRIPTION
### Summary
This PR fixes the issue where navigating from an updated page to an older cached page (e.g. an edge-cached article) would trigger client-side stylesheet swapping and involuntarily downgrade DOM stylesheets to obsolete/stale versions or cause 404s and CSS cascade race conditions.

### Changes
- **Fingerprinted Internal Navigation:** InstantClick reads the current page's stylesheet fingerprint (`data-style-fingerprint` on `<body>`, computed via `ApplicationHelper#main_stylesheets_fingerprint`) and appends it to internal navigation requests (`?i=FINGERPRINT`).
- **Graceful Fallback:** If `data-style-fingerprint` is absent (e.g. older sessions during deploy cutover), InstantClick falls back to `?i=i`.
- **Removed Client-Side Swapping Script:** Removed the inline `expectedStyles` and DOM `replaceChild` logic from `app/views/layouts/application.html.erb`.
- **Controller & Constraint Support:** Updated `ApplicationController` (`internal_navigation?`, `internal_nav_param`) and `OrgCustomDomainConstraint` to recognize fingerprinted internal nav parameters and retain them across permanent redirects.
- **Specs:** Updated helper and request specs to test fingerprint generation, absence of swapping script, and fingerprinted internal navigation params.

### Verification
- Ran `rspec spec/helpers/application_helper_spec.rb:705 spec/requests/stories_index_spec.rb:635` (Passed)
- Ran `rspec spec/requests/stories_show_spec.rb spec/requests/articles/articles_show_spec.rb` (Passed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790791322&installation_model_id=424141&pr_number=23789&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23789&signature=febc37eef1872ace67e1f2efa8ed2498266426a54c671bcf7b1d33116f812ac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->