### PR TITLE
Redirect authorized users to preview parameter on unpublished articles

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -421,9 +421,12 @@ class StoriesController < ApplicationController
 
   def assign_article_show_variables
     if permission_denied?
-      if can_edit_article?
-        redirect_to_preview
-        return
+      if user_signed_in?
+        unset_cache_control_headers
+        if can_edit_article?
+          redirect_to_preview
+          return
+        end
       end
       not_found
     end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -374,8 +374,18 @@ class StoriesController < ApplicationController
 
   def handle_article_show
     assign_article_show_variables
-    user_keys = @article.user&.profile_identity_cache_keys
-    set_surrogate_key_header(*[@article.record_key, *user_keys].compact)
+    return if performed?
+
+    if !@article.published || @article.scheduled?
+      unset_cache_control_headers
+      response.headers["Cache-Control"] = "private, no-cache, no-store, must-revalidate"
+      response.headers["Pragma"] = "no-cache"
+      response.headers["Expires"] = "0"
+    else
+      user_keys = @article.user&.profile_identity_cache_keys
+      set_surrogate_key_header(*[@article.record_key, *user_keys].compact)
+    end
+
     redirect_if_appropriate
     return if performed?
 
@@ -410,7 +420,14 @@ class StoriesController < ApplicationController
   end
 
   def assign_article_show_variables
-    not_found if permission_denied?
+    if permission_denied?
+      if can_edit_article?
+        redirect_to_preview
+        return
+      end
+      not_found
+    end
+
     not_found unless @article.user
 
     check_admin_access if @article.user.spam?
@@ -444,6 +461,25 @@ class StoriesController < ApplicationController
     assign_co_authors
     @comment = Comment.new(body_markdown: @article&.comment_template)
     @context_note = @article.context_notes.first
+  end
+
+  def redirect_to_preview
+    unset_cache_control_headers
+    response.headers["Cache-Control"] = "private, no-cache, no-store, must-revalidate"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
+
+    params_hash = request.query_parameters.merge("preview" => @article.password)
+    redirect_to "#{request.path}?#{params_hash.to_query}", status: :found
+  end
+
+  def can_edit_article?
+    return false unless user_signed_in?
+
+    record = @article.respond_to?(:to_model) ? @article.to_model : @article
+    policy(record).edit?
+  rescue Pundit::NotAuthorizedError, Pundit::NotDefinedError
+    false
   end
 
   def permission_denied?

--- a/spec/requests/stories_show_spec.rb
+++ b/spec/requests/stories_show_spec.rb
@@ -287,6 +287,144 @@ RSpec.describe "StoriesShow" do
     end
   end
 
+  describe "GET /:username/:slug (unpublished or scheduled preview redirect)" do
+    let(:unpublished_article) { create(:article, user: user, published: false) }
+    let(:scheduled_article) { create(:article, user: user, published: true, published_at: 1.day.from_now) }
+    let(:other_user) { create(:user) }
+    let(:admin_user) { create(:user, :admin) }
+
+    context "when user is not signed in" do
+      it "raises 404 for unpublished article without preview param" do
+        expect { get unpublished_article.path }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "raises 404 for unpublished article with invalid preview param" do
+        expect { get "#{unpublished_article.path}?preview=invalid" }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "raises 404 for scheduled article without preview param" do
+        expect { get scheduled_article.path }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "allows viewing unpublished article with valid preview param without edge caching headers" do
+        get "#{unpublished_article.path}?preview=#{unpublished_article.password}"
+        expect(response).to have_http_status(:ok)
+        expect(response.headers["Surrogate-Control"]).to be_nil
+        expect(response.headers["Cache-Control"]).to include("private")
+      end
+    end
+
+    context "when user is signed in without edit permissions" do
+      before { sign_in other_user }
+
+      it "raises 404 for unpublished article without preview param" do
+        expect { get unpublished_article.path }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "raises 404 for unpublished article with invalid preview param" do
+        expect { get "#{unpublished_article.path}?preview=invalid" }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "raises 404 for scheduled article without preview param" do
+        expect { get scheduled_article.path }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when user is signed in as the author" do
+      before { sign_in user }
+
+      it "redirects unpublished article without preview param to the preview URL with 302 Found" do
+        get unpublished_article.path
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to("#{unpublished_article.path}?preview=#{unpublished_article.password}")
+        expect(response.headers["Surrogate-Control"]).to be_nil
+        expect(response.headers["Cache-Control"]).to include("private")
+      end
+
+      it "redirects unpublished article with invalid preview param to the correct preview URL" do
+        get "#{unpublished_article.path}?preview=wrong_token"
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to("#{unpublished_article.path}?preview=#{unpublished_article.password}")
+        expect(response.headers["Surrogate-Control"]).to be_nil
+        expect(response.headers["Cache-Control"]).to include("private")
+      end
+
+      it "preserves additional query parameters on redirect" do
+        get "#{unpublished_article.path}?i=i"
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to("#{unpublished_article.path}?i=i&preview=#{unpublished_article.password}")
+      end
+
+      it "redirects scheduled article without preview param to the preview URL" do
+        get scheduled_article.path
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to("#{scheduled_article.path}?preview=#{scheduled_article.password}")
+        expect(response.headers["Surrogate-Control"]).to be_nil
+        expect(response.headers["Cache-Control"]).to include("private")
+      end
+    end
+
+    context "when user is signed in as an admin" do
+      before { sign_in admin_user }
+
+      it "redirects unpublished article without preview param to preview URL" do
+        get unpublished_article.path
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to("#{unpublished_article.path}?preview=#{unpublished_article.password}")
+        expect(response.headers["Surrogate-Control"]).to be_nil
+        expect(response.headers["Cache-Control"]).to include("private")
+      end
+    end
+
+    context "when user is an organization admin for an org unpublished article" do
+      let(:org_admin) { create(:user) }
+      let(:org_unpublished_article) { create(:article, user: user, organization: org, published: false) }
+
+      before do
+        create(:organization_membership, user: org_admin, organization: org, type_of_user: :admin)
+        sign_in org_admin
+      end
+
+      it "redirects unpublished article to preview URL" do
+        get org_unpublished_article.path
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to("#{org_unpublished_article.path}?preview=#{org_unpublished_article.password}")
+        expect(response.headers["Surrogate-Control"]).to be_nil
+        expect(response.headers["Cache-Control"]).to include("private")
+      end
+    end
+
+    context "when author is suspended" do
+      before do
+        user.add_role(:suspended)
+        sign_in user
+      end
+
+      it "raises 404 for unpublished article without preview param" do
+        expect { get unpublished_article.path }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when on a custom domain" do
+      let(:custom_org) { create(:organization, custom_domain: "custom.example.com") }
+      let(:custom_article) { create(:article, user: user, organization: custom_org, published: false) }
+
+      before do
+        sign_in user
+      end
+
+      it "redirects to custom domain preview URL for authorized user" do
+        get "/#{custom_article.slug}",
+            headers: { "Host" => "custom.example.com" },
+            env: { "forem.custom_domain_org" => custom_org }
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to("/#{custom_article.slug}?preview=#{custom_article.password}")
+        expect(response.headers["Surrogate-Control"]).to be_nil
+        expect(response.headers["Cache-Control"]).to include("private")
+      end
+    end
+  end
+
   describe "GET /:username (org)" do
     it "redirects to the appropriate page if given an organization's old slug" do
       original_slug = org.slug

--- a/spec/system/articles/user_visits_an_article_spec.rb
+++ b/spec/system/articles/user_visits_an_article_spec.rb
@@ -217,7 +217,19 @@ RSpec.describe "Views an article" do
       let(:query_params) { "" }
       let(:article_user) { user }
 
-      it "raises ActiveRecord::RecordNotFound" do
+      it "redirects the authorized author to the preview URL" do
+        visit article_path
+        expect(page).to have_current_path(article.path + "?preview=#{article.password}")
+      end
+
+      it "raises ActiveRecord::RecordNotFound when the user is not logged in" do
+        sign_out user
+        expect { visit article_path }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "raises ActiveRecord::RecordNotFound when the user is not authorized to edit" do
+        sign_out user
+        sign_in create(:user)
         expect { visit article_path }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end


### PR DESCRIPTION
## What does this PR do?

When a signed-in user with authorization to edit an article (the author, a site administrator, or an organization administrator) visits an unpublished or scheduled article without the proper `preview` query parameter (or with an invalid/missing parameter), this PR redirects them via HTTP 302 Found to the proper preview URL (`?preview=<password>`) rather than rendering a 404.

### Key Highlights & Security/Cache Isolation:
1. **Zero Overhead for Anonymous Traffic**:
   - Short-circuits immediately if `!user_signed_in?` so public users, bots, and crawlers 404 without evaluating Pundit policies or extra database lookups.
2. **Proper 404 for Unauthorized Users**:
   - Other signed-in users who do not have edit rights, as well as suspended authors, continue to receive a 404.
3. **Edge & Client Cache Isolation**:
   - Explicitly calls `unset_cache_control_headers` to strip `Surrogate-Control`, `Surrogate-Key`, and `X-Accel-Expires`.
   - Sets `Cache-Control: private, no-cache, no-store, must-revalidate`, `Pragma: no-cache`, and `Expires: 0` on both the 302 redirect and the preview rendering to guarantee Fastly and intermediate CDNs never cache the redirect or the preview content.
4. **Preserves Existing Query Parameters**:
   - Merges existing request query parameters with `preview=<password>` upon redirect.
5. **Custom Domain Support**:
   - Fully compatible with custom domain article previews.

## How was this tested?
- Added comprehensive request specs in `spec/requests/stories_show_spec.rb` covering:
  - Unauthenticated 404s on unpublished/scheduled articles.
  - Unauthorized signed-in 404s.
  - Suspended author 404s.
  - Authorized author, admin, and org-admin 302 preview redirects.
  - Query parameter preservation on redirect.
  - Custom domain preview redirects.
  - Private cache-control header verification.
- Ran test suite (`spec/requests/stories_show_spec.rb` and `spec/requests/articles/articles_show_spec.rb`) with 100% passing tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790798907&installation_model_id=424141&pr_number=23792&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23792&signature=e1dfa4a0d64ee8126466b731f839c7e0c162f9a91981a325750a9e003f79805f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->