### PR TITLE
Add favorited_weight to FeedConfig to boost favorited articles in feed

### DIFF
--- a/app/controllers/admin/feed_configs_controller.rb
+++ b/app/controllers/admin/feed_configs_controller.rb
@@ -65,6 +65,7 @@ module Admin
         :comment_recency_weight,
         :comment_score_weight,
         :compellingness_score_weight,
+        :favorited_weight,
         :featured_weight,
         :feed_success_weight,
         :follow_status_weight,

--- a/app/models/feed_config.rb
+++ b/app/models/feed_config.rb
@@ -169,6 +169,7 @@ class FeedConfig < ApplicationRecord
     end
 
     terms << "(CASE WHEN articles.featured = TRUE THEN #{featured_weight} ELSE 0 END)" if featured_weight.positive?
+    terms << "(CASE WHEN articles.favorited_by_user_id IS NOT NULL THEN #{favorited_weight} ELSE 0 END)" if favorited_weight.positive?
     terms << "(CASE WHEN articles.type_of = 1 THEN #{status_weight} ELSE 0 END)" if status_weight.positive?
     terms << "(- (articles.clickbait_score * #{clickbait_score_weight}))" if clickbait_score_weight.positive?
     terms << "(articles.compellingness_score * #{compellingness_score_weight})" if compellingness_score_weight.positive?
@@ -205,6 +206,7 @@ class FeedConfig < ApplicationRecord
     clone.general_past_day_bonus_weight = general_past_day_bonus_weight * rand(0.9..1.1)
     clone.recently_active_past_day_bonus_weight = recently_active_past_day_bonus_weight * rand(0.9..1.1)
     clone.featured_weight = featured_weight * rand(0.9..1.1)
+    clone.favorited_weight = favorited_weight * rand(0.9..1.1)
     clone.status_weight = status_weight * rand(0.9..1.1)
     clone.follow_status_weight = follow_status_weight * rand(0.9..1.1)
     clone.clickbait_score_weight = clickbait_score_weight * rand(0.9..1.1)

--- a/app/views/admin/feed_configs/_form.html.erb
+++ b/app/views/admin/feed_configs/_form.html.erb
@@ -74,6 +74,11 @@
         <%= f.number_field :featured_weight, step: "any", class: "crayons-textfield" %>
       </div>
       <div class="crayons-field">
+        <%= f.label :favorited_weight, "Favorited (Gem) Weight", class: "crayons-field__label" %>
+        <p class="fs-xs color-base-60 mb-1">Boost given to articles marked as a community favorite / gem.</p>
+        <%= f.number_field :favorited_weight, step: "any", class: "crayons-textfield" %>
+      </div>
+      <div class="crayons-field">
         <%= f.label :compellingness_score_weight, "Compellingness Score Weight", class: "crayons-field__label" %>
         <%= f.number_field :compellingness_score_weight, step: "any", class: "crayons-textfield" %>
       </div>

--- a/db/migrate/20260901140000_add_favorited_weight_to_feed_configs.rb
+++ b/db/migrate/20260901140000_add_favorited_weight_to_feed_configs.rb
@@ -1,0 +1,5 @@
+class AddFavoritedWeightToFeedConfigs < ActiveRecord::Migration[8.0]
+  def change
+    add_column :feed_configs, :favorited_weight, :float, default: 0.0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_25_100500) do
+ActiveRecord::Schema[8.0].define(version: 2026_09_01_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -817,6 +817,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_25_100500) do
     t.float "comment_score_weight", default: 1.0
     t.float "compellingness_score_weight", default: 0.0, null: false
     t.datetime "created_at", null: false
+    t.float "favorited_weight", default: 0.0, null: false
     t.float "featured_weight", default: 0.0, null: false
     t.bigint "feed_impressions_count", default: 0
     t.float "feed_success_score", default: 0.0

--- a/spec/models/feed_config_spec.rb
+++ b/spec/models/feed_config_spec.rb
@@ -236,6 +236,7 @@ RSpec.describe FeedConfig, type: :model do
         feed_config.recent_article_suppression_rate = 2.0
         feed_config.published_today_weight         = 3.0
         feed_config.featured_weight                = 4.0
+        feed_config.favorited_weight               = 4.5
         feed_config.clickbait_score_weight         = 5.0
         feed_config.compellingness_score_weight    = 6.0
         feed_config.language_match_weight          = 7.0
@@ -277,6 +278,11 @@ RSpec.describe FeedConfig, type: :model do
       it "includes the featured weight" do
         sql = feed_config.score_sql(user)
         expect(sql).to include("CASE WHEN articles.featured = TRUE THEN 4.0")
+      end
+
+      it "includes the favorited weight" do
+        sql = feed_config.score_sql(user)
+        expect(sql).to include("CASE WHEN articles.favorited_by_user_id IS NOT NULL THEN 4.5")
       end
 
       it "includes the status weight" do
@@ -369,6 +375,7 @@ RSpec.describe FeedConfig, type: :model do
       feed_config.recent_article_suppression_rate = 13.0
       feed_config.published_today_weight         = 14.0
       feed_config.featured_weight                = 15.0
+      feed_config.favorited_weight               = 15.2
       feed_config.status_weight                  = 15.5
       feed_config.clickbait_score_weight         = 16.0
       feed_config.compellingness_score_weight    = 17.0
@@ -411,6 +418,7 @@ RSpec.describe FeedConfig, type: :model do
       expect(clone.recent_article_suppression_rate).to eq(13.0 * 1.1)
       expect(clone.published_today_weight).to eq(14.0 * 1.1)
       expect(clone.featured_weight).to eq(15.0 * 1.1)
+      expect(clone.favorited_weight).to eq(15.2 * 1.1)
       expect(clone.status_weight).to eq(15.5 * 1.1)
       expect(clone.clickbait_score_weight).to eq(16.0 * 1.1)
       expect(clone.compellingness_score_weight).to eq(17.0 * 1.1)
@@ -443,6 +451,7 @@ RSpec.describe FeedConfig, type: :model do
         "general_past_day_bonus_weight",
         "recently_active_past_day_bonus_weight",
         "featured_weight",
+        "favorited_weight",
         "status_weight",
         "clickbait_score_weight",
         "compellingness_score_weight",

--- a/spec/requests/admin/feed_configs_spec.rb
+++ b/spec/requests/admin/feed_configs_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "/admin/advanced/feed_configs" do
       feed_config: {
         ai_disclosure_matching_weight: 15.0,
         autonomous_ai_penalty_weight: 25.0,
+        favorited_weight: 8.5,
         user_follow_weight: 2.0,
         tag_follow_weight: 3.0,
         score_weight: 1.5
@@ -84,6 +85,7 @@ RSpec.describe "/admin/advanced/feed_configs" do
         new_config = FeedConfig.last
         expect(new_config.ai_disclosure_matching_weight).to eq(15.0)
         expect(new_config.autonomous_ai_penalty_weight).to eq(25.0)
+        expect(new_config.favorited_weight).to eq(8.5)
         expect(new_config.user_follow_weight).to eq(2.0)
         expect(response).to redirect_to(admin_feed_config_path(new_config))
       end


### PR DESCRIPTION
## Summary
Adds a configurable `favorited_weight` to `FeedConfig` to allow community favorite / gem articles to receive an algorithmic score boost in the home feed.

## Changes
- **Migration & Schema**: Added `favorited_weight` (`float`, default `0.0`, `null: false`) to `feed_configs` table.
- **Feed Algorithm**: In `FeedConfig#score_sql`, added term `(CASE WHEN articles.favorited_by_user_id IS NOT NULL THEN #{favorited_weight} ELSE 0 END)` when `favorited_weight.positive?`. Also included it in `FeedConfig#create_slightly_modified_clone!` for feed config mutation experiments.
- **Admin Interface**: Permitted `:favorited_weight` parameter in `Admin::FeedConfigsController` and added form input with help text in `app/views/admin/feed_configs/_form.html.erb`.
- **Tests**: Added unit tests in `spec/models/feed_config_spec.rb` and controller request specs in `spec/requests/admin/feed_configs_spec.rb`.

## Verification
- Ran `bin/rspec spec/models/feed_config_spec.rb` (30 examples, 0 failures)
- Ran `bin/rspec spec/requests/admin/feed_configs_spec.rb` (9 examples, 0 failures)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790863026&installation_model_id=424141&pr_number=23793&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23793&signature=b88c153403db39f444524e24d0765d1a09c1cc06cb83f6b36e65e225412a5684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->