### PR TITLE
Enhance Community Favorite badge notifications and add Gem Picked modal

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -18,7 +18,11 @@ class FavoritesController < ApplicationController
     result = Favorites::Create.call(favoritable: favoritable, user: current_user)
 
     if result.success?
-      head :ok
+      current_user.reload
+      render json: {
+        success: true,
+        remaining_allowance: current_user.favorite_allowance
+      }, status: :ok
     else
       render_favorite_error(result.error)
     end

--- a/app/helpers/favorites_helper.rb
+++ b/app/helpers/favorites_helper.rb
@@ -12,11 +12,15 @@ module FavoritesHelper
                     when :article
                       if favorited
                         tag.span(
-                          class: "favorite-reaction favorite-control favorite-control--favorited crayons-tooltip__activator relative",
+                          class: "favorite-reaction favorite-control favorite-control--favorited " \
+                                 "crayons-tooltip__activator relative",
                           role: "img",
                           aria: { label: label },
                         ) do
-                          concat tag.span(crayons_icon_tag("favorite-filled", native: true), class: "crayons-reaction__icon crayons-reaction__icon--borderless")
+                          concat tag.span(
+                            crayons_icon_tag("favorite-filled", native: true),
+                            class: "crayons-reaction__icon crayons-reaction__icon--borderless",
+                          )
                           concat tag.span(label, data: { testid: "tooltip" }, class: "crayons-tooltip__content")
                         end
                       else
@@ -25,14 +29,18 @@ module FavoritesHelper
                           class: "favorite-reaction favorite-control crayons-tooltip__activator relative",
                           aria: { label: label },
                         ) do
-                          concat tag.span(crayons_icon_tag("favorite", native: true), class: "crayons-reaction__icon crayons-reaction__icon--borderless")
+                          concat tag.span(
+                            crayons_icon_tag("favorite", native: true),
+                            class: "crayons-reaction__icon crayons-reaction__icon--borderless",
+                          )
                           concat tag.span(label, data: { testid: "tooltip" }, class: "crayons-tooltip__content")
                         end
                       end
                     when :dropdown
                       if favorited
                         tag.span(
-                          class: "flex justify-between crayons-link crayons-link--block w-100 bg-transparent border-0 favorite-control favorite-control--favorited",
+                          class: "flex justify-between crayons-link crayons-link--block w-100 bg-transparent " \
+                                 "border-0 favorite-control favorite-control--favorited",
                           role: "img",
                           aria: { label: label },
                         ) do
@@ -42,7 +50,8 @@ module FavoritesHelper
                       else
                         tag.button(
                           type: "button",
-                          class: "flex justify-between crayons-link crayons-link--block w-100 bg-transparent border-0 favorite-control",
+                          class: "flex justify-between crayons-link crayons-link--block w-100 bg-transparent " \
+                                 "border-0 favorite-control",
                           aria: { label: label },
                         ) do
                           concat tag.span(label, class: "fw-bold")
@@ -52,7 +61,8 @@ module FavoritesHelper
                     when :comment
                       if favorited
                         tag.span(
-                          class: "crayons-btn crayons-btn--ghost crayons-btn--s crayons-btn--icon favorite-control favorite-control--favorited crayons-tooltip__activator relative",
+                          class: "crayons-btn crayons-btn--ghost crayons-btn--s crayons-btn--icon " \
+                                 "favorite-control favorite-control--favorited crayons-tooltip__activator relative",
                           role: "img",
                           aria: { label: label },
                         ) do
@@ -74,7 +84,13 @@ module FavoritesHelper
         favorited_by_user_id: favoritable.favorited_by_user_id,
         label_favorite: t("favorites.favorite"),
         label_favorited: t("favorites.favorited"),
-        label_favorited_by_you: t("favorites.favorited_by_you")
+        label_favorited_by_you: t("favorites.favorited_by_you"),
+        modal_title: t("favorites.modal.title"),
+        modal_body: t("favorites.modal.body"),
+        modal_remaining_zero: t("favorites.modal.remaining_zero"),
+        modal_remaining_one: t("favorites.modal.remaining_one"),
+        modal_remaining_other: t("favorites.modal.remaining_other"),
+        modal_close: t("favorites.modal.close")
       },
     ) do
       inner_content

--- a/app/helpers/favorites_helper.rb
+++ b/app/helpers/favorites_helper.rb
@@ -90,7 +90,10 @@ module FavoritesHelper
         modal_remaining_zero: t("favorites.modal.remaining_zero"),
         modal_remaining_one: t("favorites.modal.remaining_one"),
         modal_remaining_other: t("favorites.modal.remaining_other"),
-        modal_close: t("favorites.modal.close")
+        modal_close: t("favorites.modal.close"),
+        modal_exhausted_title: t("favorites.modal_exhausted.title"),
+        modal_exhausted_body: t("favorites.modal_exhausted.body"),
+        modal_exhausted_close: t("favorites.modal_exhausted.close")
       },
     ) do
       inner_content

--- a/app/javascript/favoriteControl/FavoriteControl.jsx
+++ b/app/javascript/favoriteControl/FavoriteControl.jsx
@@ -98,6 +98,9 @@ export const FavoriteControl = ({
   modalRemainingOne = 'You have 1 more gem left to give out today.',
   modalRemainingOther = 'You have %{count} more gems left to give out today.',
   modalClose = 'Got it',
+  modalExhaustedTitle = 'Out of Gems',
+  modalExhaustedBody = 'You have no more gems left to give out today. Your allowance will refresh soon!',
+  modalExhaustedClose = 'Got it',
 }) => {
   const [favorited, setFavorited] = useState(
     initialFavorited === 'true' || initialFavorited === true,
@@ -106,15 +109,16 @@ export const FavoriteControl = ({
     initialFavoritedByUserId ? Number(initialFavoritedByUserId) : null,
   );
   const [submitting, setSubmitting] = useState(false);
-  const [showModal, setShowModal] = useState(false);
+  const [showSuccessModal, setShowSuccessModal] = useState(false);
+  const [showExhaustedModal, setShowExhaustedModal] = useState(false);
   const [remainingAllowance, setRemainingAllowance] = useState(null);
 
   const userId = currentUser?.id ?? null;
   const favoritedByCurrentUser =
     favorited && userId != null && favoritedById === userId;
 
-  const renderModal = () => {
-    if (!showModal) {
+  const renderSuccessModal = () => {
+    if (!showSuccessModal) {
       return null;
     }
 
@@ -131,7 +135,7 @@ export const FavoriteControl = ({
     return (
       <Modal
         title={modalTitle}
-        onClose={() => setShowModal(false)}
+        onClose={() => setShowSuccessModal(false)}
         backdropDismissible
         size="small"
       >
@@ -158,9 +162,53 @@ export const FavoriteControl = ({
             <Button
               variant="primary"
               size="large"
-              onClick={() => setShowModal(false)}
+              onClick={() => setShowSuccessModal(false)}
             >
               {modalClose}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    );
+  };
+
+  const renderExhaustedModal = () => {
+    if (!showExhaustedModal) {
+      return null;
+    }
+
+    return (
+      <Modal
+        title={modalExhaustedTitle}
+        onClose={() => setShowExhaustedModal(false)}
+        backdropDismissible
+        size="small"
+      >
+        <div class="p-6 text-center grid gap-4" data-testid="gem-exhausted-modal-content">
+          <div
+            class="mx-auto flex items-center justify-center"
+            style={{
+              width: '96px',
+              height: '96px',
+              color: 'var(--base-60, #717171)',
+            }}
+          >
+            <FavoriteSVG
+              aria-hidden="true"
+              focusable="false"
+              width="96"
+              height="96"
+              style={{ width: '96px', height: '96px' }}
+            />
+          </div>
+          <p class="fs-base color-base-70 m-0">{modalExhaustedBody}</p>
+          <div class="mt-2">
+            <Button
+              variant="secondary"
+              size="large"
+              onClick={() => setShowExhaustedModal(false)}
+            >
+              {modalExhaustedClose}
             </Button>
           </div>
         </div>
@@ -185,7 +233,8 @@ export const FavoriteControl = ({
               checked={favoritedByCurrentUser}
             />
           </span>
-          {renderModal()}
+          {renderSuccessModal()}
+          {renderExhaustedModal()}
         </Fragment>
       );
     }
@@ -200,14 +249,18 @@ export const FavoriteControl = ({
           />
           <Tooltip label={label} />
         </span>
-        {renderModal()}
+        {renderSuccessModal()}
+        {renderExhaustedModal()}
       </Fragment>
     );
   }
 
-  // Only users with favorites to spend get the control
-  const canFavorite = currentUser?.favorite_allowance > 0;
-  if (!canFavorite) {
+  // Community leaders and users with favorite allowance get the control
+  const canSeeControl =
+    currentUser?.community_leader === true ||
+    (currentUser?.favorite_allowance != null && currentUser.favorite_allowance > 0);
+
+  if (!canSeeControl) {
     return null;
   }
 
@@ -218,6 +271,12 @@ export const FavoriteControl = ({
 
   const onClick = async () => {
     if (submitting) return;
+
+    if (currentUser?.favorite_allowance != null && currentUser.favorite_allowance <= 0) {
+      setShowExhaustedModal(true);
+      return;
+    }
+
     setSubmitting(true);
     try {
       const response = await makeFavorite({ favoritableId, favoritableType });
@@ -231,7 +290,7 @@ export const FavoriteControl = ({
         setFavorited(true);
         setFavoritedById(userId);
         setRemainingAllowance(remaining);
-        setShowModal(true);
+        setShowSuccessModal(true);
         return;
       }
 
@@ -240,6 +299,9 @@ export const FavoriteControl = ({
       if (code === 'already_favorited') {
         setFavorited(true);
         setFavoritedById(null);
+      } else if (code === 'no_allowance') {
+        setShowExhaustedModal(true);
+        return;
       }
 
       if (error && typeof window.top.addSnackbarItem === 'function') {
@@ -263,7 +325,8 @@ export const FavoriteControl = ({
           <span class="fw-bold">{labelFavorite}</span>
           <FavoriteIcon variant={variant} />
         </button>
-        {renderModal()}
+        {renderSuccessModal()}
+        {renderExhaustedModal()}
       </Fragment>
     );
   }
@@ -280,7 +343,8 @@ export const FavoriteControl = ({
         <FavoriteIcon variant={variant} />
         <Tooltip label={labelFavorite} />
       </button>
-      {renderModal()}
+      {renderSuccessModal()}
+      {renderExhaustedModal()}
     </Fragment>
   );
 };

--- a/app/javascript/favoriteControl/FavoriteControl.jsx
+++ b/app/javascript/favoriteControl/FavoriteControl.jsx
@@ -135,15 +135,29 @@ export const FavoriteControl = ({
         backdropDismissible
         size="small"
       >
-        <div class="p-4 text-center grid gap-3" data-testid="gem-modal-content">
-          <div class="mx-auto" style={{ width: '48px', height: '48px' }}>
-            <FavoriteIcon variant="article" filled checked />
+        <div class="p-6 text-center grid gap-4" data-testid="gem-modal-content">
+          <div
+            class="mx-auto flex items-center justify-center"
+            style={{
+              width: '96px',
+              height: '96px',
+              color: 'var(--reaction-favorite-color, #7026b8)',
+            }}
+          >
+            <FavoriteCheckedSVG
+              aria-hidden="true"
+              focusable="false"
+              width="96"
+              height="96"
+              style={{ width: '96px', height: '96px' }}
+            />
           </div>
-          <p class="fs-base fw-bold m-0">{modalBody}</p>
-          <p class="fs-s color-base-70 m-0">{remainingText}</p>
+          <p class="fs-l fw-bold m-0">{modalBody}</p>
+          <p class="fs-base color-base-70 m-0">{remainingText}</p>
           <div class="mt-2">
             <Button
               variant="primary"
+              size="large"
               onClick={() => setShowModal(false)}
             >
               {modalClose}

--- a/app/javascript/favoriteControl/FavoriteControl.jsx
+++ b/app/javascript/favoriteControl/FavoriteControl.jsx
@@ -1,6 +1,6 @@
-import { h } from 'preact';
+import { h, Fragment } from 'preact';
 import { useState } from 'preact/hooks';
-import { Icon } from '@crayons';
+import { Icon, Modal, ButtonNew as Button } from '@crayons';
 import FavoriteSVG from '@images/favorite.svg';
 import FavoriteFilledSVG from '@images/favorite-filled.svg';
 import FavoriteCheckedSVG from '@images/favorite-checked.svg';
@@ -89,9 +89,15 @@ export const FavoriteControl = ({
   favoritableUserId,
   favorited: initialFavorited,
   favoritedByUserId: initialFavoritedByUserId,
-  labelFavorite,
-  labelFavorited,
-  labelFavoritedByYou,
+  labelFavorite = 'Pick as gem',
+  labelFavorited = 'Picked as gem',
+  labelFavoritedByYou = 'Picked as gem by you',
+  modalTitle = 'Gem Picked!',
+  modalBody = "You've picked this as a community gem!",
+  modalRemainingZero = 'You have no more gems left to give out today.',
+  modalRemainingOne = 'You have 1 more gem left to give out today.',
+  modalRemainingOther = 'You have %{count} more gems left to give out today.',
+  modalClose = 'Got it',
 }) => {
   const [favorited, setFavorited] = useState(
     initialFavorited === 'true' || initialFavorited === true,
@@ -100,39 +106,88 @@ export const FavoriteControl = ({
     initialFavoritedByUserId ? Number(initialFavoritedByUserId) : null,
   );
   const [submitting, setSubmitting] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  const [remainingAllowance, setRemainingAllowance] = useState(null);
 
   const userId = currentUser?.id ?? null;
   const favoritedByCurrentUser =
     favorited && userId != null && favoritedById === userId;
 
+  const renderModal = () => {
+    if (!showModal) {
+      return null;
+    }
+
+    let remainingText = modalRemainingOther.replace(
+      '%{count}',
+      String(remainingAllowance ?? 0),
+    );
+    if (remainingAllowance === 1) {
+      remainingText = modalRemainingOne;
+    } else if (remainingAllowance === 0) {
+      remainingText = modalRemainingZero;
+    }
+
+    return (
+      <Modal
+        title={modalTitle}
+        onClose={() => setShowModal(false)}
+        backdropDismissible
+        size="small"
+      >
+        <div class="p-4 text-center grid gap-3" data-testid="gem-modal-content">
+          <div class="mx-auto" style={{ width: '48px', height: '48px' }}>
+            <FavoriteIcon variant="article" filled checked />
+          </div>
+          <p class="fs-base fw-bold m-0">{modalBody}</p>
+          <p class="fs-s color-base-70 m-0">{remainingText}</p>
+          <div class="mt-2">
+            <Button
+              variant="primary"
+              onClick={() => setShowModal(false)}
+            >
+              {modalClose}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    );
+  };
+
   if (favorited) {
     const label = favoritedByCurrentUser ? labelFavoritedByYou : labelFavorited;
     if (variant === 'dropdown') {
       return (
-        <span
-          class={controlClass(variant, true)}
-          role="img"
-          aria-label={label}
-        >
-          <span class="fw-bold">{label}</span>
+        <Fragment>
+          <span
+            class={controlClass(variant, true)}
+            role="img"
+            aria-label={label}
+          >
+            <span class="fw-bold">{label}</span>
+            <FavoriteIcon
+              variant={variant}
+              filled
+              checked={favoritedByCurrentUser}
+            />
+          </span>
+          {renderModal()}
+        </Fragment>
+      );
+    }
+
+    return (
+      <Fragment>
+        <span class={controlClass(variant, true)} role="img" aria-label={label}>
           <FavoriteIcon
             variant={variant}
             filled
             checked={favoritedByCurrentUser}
           />
+          <Tooltip label={label} />
         </span>
-      );
-    }
-
-    return (
-      <span class={controlClass(variant, true)} role="img" aria-label={label}>
-        <FavoriteIcon
-          variant={variant}
-          filled
-          checked={favoritedByCurrentUser}
-        />
-        <Tooltip label={label} />
-      </span>
+        {renderModal()}
+      </Fragment>
     );
   }
 
@@ -153,8 +208,16 @@ export const FavoriteControl = ({
     try {
       const response = await makeFavorite({ favoritableId, favoritableType });
       if (response.ok) {
+        const data = await response.json().catch(() => ({}));
+        const remaining =
+          data.remaining_allowance ??
+          (currentUser?.favorite_allowance != null
+            ? Math.max(0, currentUser.favorite_allowance - 1)
+            : 0);
         setFavorited(true);
         setFavoritedById(userId);
+        setRemainingAllowance(remaining);
+        setShowModal(true);
         return;
       }
 
@@ -175,6 +238,24 @@ export const FavoriteControl = ({
 
   if (variant === 'dropdown') {
     return (
+      <Fragment>
+        <button
+          type="button"
+          class={controlClass(variant, false)}
+          aria-label={labelFavorite}
+          disabled={submitting}
+          onClick={onClick}
+        >
+          <span class="fw-bold">{labelFavorite}</span>
+          <FavoriteIcon variant={variant} />
+        </button>
+        {renderModal()}
+      </Fragment>
+    );
+  }
+
+  return (
+    <Fragment>
       <button
         type="button"
         class={controlClass(variant, false)}
@@ -182,22 +263,10 @@ export const FavoriteControl = ({
         disabled={submitting}
         onClick={onClick}
       >
-        <span class="fw-bold">{labelFavorite}</span>
         <FavoriteIcon variant={variant} />
+        <Tooltip label={labelFavorite} />
       </button>
-    );
-  }
-
-  return (
-    <button
-      type="button"
-      class={controlClass(variant, false)}
-      aria-label={labelFavorite}
-      disabled={submitting}
-      onClick={onClick}
-    >
-      <FavoriteIcon variant={variant} />
-      <Tooltip label={labelFavorite} />
-    </button>
+      {renderModal()}
+    </Fragment>
   );
 };

--- a/app/javascript/favoriteControl/__tests__/FavoriteControl.test.jsx
+++ b/app/javascript/favoriteControl/__tests__/FavoriteControl.test.jsx
@@ -90,8 +90,12 @@ describe('<FavoriteControl />', () => {
   });
 
   describe('favoriting', () => {
-    it('POSTs the favorite and switches to favorited state on click', async () => {
-      const { getByLabelText, findByLabelText } = renderControl();
+    it('POSTs the favorite, switches to favorited state, and displays the confirmation modal', async () => {
+      makeFavorite.mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, remaining_allowance: 4 }),
+      });
+      const { getByLabelText, findByLabelText, findByText, getByText, queryByText } = renderControl();
 
       fireEvent.click(getByLabelText('Pick as gem'));
 
@@ -102,6 +106,37 @@ describe('<FavoriteControl />', () => {
 
       const indicator = await findByLabelText('Picked as gem by you');
       expect(indicator.tagName).toBe('SPAN');
+
+      expect(await findByText('Gem Picked!')).toBeInTheDocument();
+      expect(getByText("You've picked this as a community gem!")).toBeInTheDocument();
+      expect(getByText('You have 4 more gems left to give out today.')).toBeInTheDocument();
+
+      fireEvent.click(getByText('Got it'));
+      expect(queryByText('Gem Picked!')).toBeNull();
+    });
+
+    it('shows singular remaining allowance when 1 gem left', async () => {
+      makeFavorite.mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, remaining_allowance: 1 }),
+      });
+      const { getByLabelText, findByText } = renderControl();
+
+      fireEvent.click(getByLabelText('Pick as gem'));
+
+      expect(await findByText('You have 1 more gem left to give out today.')).toBeInTheDocument();
+    });
+
+    it('shows zero remaining allowance when 0 gems left', async () => {
+      makeFavorite.mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, remaining_allowance: 0 }),
+      });
+      const { getByLabelText, findByText } = renderControl();
+
+      fireEvent.click(getByLabelText('Pick as gem'));
+
+      expect(await findByText('You have no more gems left to give out today.')).toBeInTheDocument();
     });
 
     it('shows an error message on failure', async () => {

--- a/app/javascript/favoriteControl/__tests__/FavoriteControl.test.jsx
+++ b/app/javascript/favoriteControl/__tests__/FavoriteControl.test.jsx
@@ -49,12 +49,20 @@ describe('<FavoriteControl />', () => {
       expect(getByRole('button')).toBeInTheDocument();
     });
 
-    it('renders nothing when the viewer has no favorites to spend', () => {
+    it('renders nothing when a non-leader has no favorites to spend', () => {
       const { container } = renderControl({
-        currentUser: { id: CURRENT_USER_ID, favorite_allowance: 0 },
+        currentUser: { id: CURRENT_USER_ID, favorite_allowance: 0, community_leader: false },
       });
 
       expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders the button for a community leader even when their allowance is 0', () => {
+      const { getByRole } = renderControl({
+        currentUser: { id: CURRENT_USER_ID, favorite_allowance: 0, community_leader: true },
+      });
+
+      expect(getByRole('button')).toBeInTheDocument();
     });
 
     it('renders nothing when not logged in', () => {
@@ -137,6 +145,38 @@ describe('<FavoriteControl />', () => {
       fireEvent.click(getByLabelText('Pick as gem'));
 
       expect(await findByText('You have no more gems left to give out today.')).toBeInTheDocument();
+    });
+
+    it('shows the out of gems modal when a community leader with 0 gems attempts to favorite', async () => {
+      const { getByLabelText, getByText, findByText, queryByText } = renderControl({
+        currentUser: { id: CURRENT_USER_ID, favorite_allowance: 0, community_leader: true },
+      });
+
+      fireEvent.click(getByLabelText('Pick as gem'));
+
+      expect(makeFavorite).not.toHaveBeenCalled();
+      expect(await findByText('Out of Gems')).toBeInTheDocument();
+      expect(
+        getByText('You have no more gems left to give out today. Your allowance will refresh soon!'),
+      ).toBeInTheDocument();
+
+      fireEvent.click(getByText('Got it'));
+      expect(queryByText('Out of Gems')).toBeNull();
+    });
+
+    it('shows the out of gems modal when the API returns no_allowance error code', async () => {
+      makeFavorite.mockResolvedValue({
+        ok: false,
+        json: async () => ({
+          error: 'You have no more gems.',
+          code: 'no_allowance',
+        }),
+      });
+      const { getByLabelText, findByText } = renderControl();
+
+      fireEvent.click(getByLabelText('Pick as gem'));
+
+      expect(await findByText('Out of Gems')).toBeInTheDocument();
     });
 
     it('shows an error message on failure', async () => {

--- a/app/javascript/packs/favoriteControls.jsx
+++ b/app/javascript/packs/favoriteControls.jsx
@@ -28,6 +28,9 @@ function initializeFavoriteControls(currentUser) {
       modalRemainingOne,
       modalRemainingOther,
       modalClose,
+      modalExhaustedTitle,
+      modalExhaustedBody,
+      modalExhaustedClose,
     } = node.dataset;
 
     render(
@@ -48,6 +51,9 @@ function initializeFavoriteControls(currentUser) {
         modalRemainingOne={modalRemainingOne}
         modalRemainingOther={modalRemainingOther}
         modalClose={modalClose}
+        modalExhaustedTitle={modalExhaustedTitle}
+        modalExhaustedBody={modalExhaustedBody}
+        modalExhaustedClose={modalExhaustedClose}
       />,
       node,
     );

--- a/app/javascript/packs/favoriteControls.jsx
+++ b/app/javascript/packs/favoriteControls.jsx
@@ -22,6 +22,12 @@ function initializeFavoriteControls(currentUser) {
       labelFavorite,
       labelFavorited,
       labelFavoritedByYou,
+      modalTitle,
+      modalBody,
+      modalRemainingZero,
+      modalRemainingOne,
+      modalRemainingOther,
+      modalClose,
     } = node.dataset;
 
     render(
@@ -36,6 +42,12 @@ function initializeFavoriteControls(currentUser) {
         labelFavorite={labelFavorite}
         labelFavorited={labelFavorited}
         labelFavoritedByYou={labelFavoritedByYou}
+        modalTitle={modalTitle}
+        modalBody={modalBody}
+        modalRemainingZero={modalRemainingZero}
+        modalRemainingOne={modalRemainingOne}
+        modalRemainingOther={modalRemainingOther}
+        modalClose={modalClose}
       />,
       node,
     );

--- a/app/services/badges/award_community_favorite.rb
+++ b/app/services/badges/award_community_favorite.rb
@@ -63,7 +63,7 @@ module Badges
 
       json_data = {
         message: html_message,
-        user: Notifications.user_data(favoriter),
+        user: Notifications.user_data(favoriter)
       }
       if comment?
         json_data[:comment] = Notifications.comment_data(favoritable)
@@ -89,7 +89,7 @@ module Badges
     end
 
     def next_milestone_for(count)
-      MILESTONES.find { |m| m > count }
+      MILESTONES.detect { |m| m > count }
     end
 
     def milestone_message(count)
@@ -102,12 +102,14 @@ module Badges
           count: count,
           next_count: next_milestone,
           url: favoritable_url,
+          title: favoritable_title,
         )
       else
         I18n.t(
           "services.badges.award_community_favorite.#{key_prefix}_max_milestone_message",
           count: count,
           url: favoritable_url,
+          title: favoritable_title,
         )
       end
     end
@@ -119,6 +121,7 @@ module Badges
         I18n.t(
           "services.badges.award_community_favorite.#{key_prefix}_first_gem_notification",
           url: favoritable_url,
+          title: favoritable_title,
         )
       else
         next_milestone = next_milestone_for(count)
@@ -128,15 +131,26 @@ module Badges
             count: count,
             next_count: next_milestone,
             url: favoritable_url,
+            title: favoritable_title,
           )
         else
           I18n.t(
             "services.badges.award_community_favorite.#{key_prefix}_max_progress_notification",
             count: count,
             url: favoritable_url,
+            title: favoritable_title,
           )
         end
       end
+    end
+
+    def favoritable_title
+      raw_title = if comment?
+                    favoritable.commentable.try(:title).presence || "post"
+                  else
+                    favoritable.title.presence || "post"
+                  end
+      raw_title.to_s.gsub("[", "\\[").gsub("]", "\\]")
     end
 
     def favoritable_url

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,13 @@ en:
     favorite: Pick as gem
     favorited: Picked as gem
     favorited_by_you: Picked as gem by you
+    modal:
+      title: Gem Picked!
+      body: You've picked this as a community gem!
+      remaining_zero: You have no more gems left to give out today.
+      remaining_one: You have 1 more gem left to give out today.
+      remaining_other: You have %{count} more gems left to give out today.
+      close: Got it
   core:
     add_comment: Add comment
     beta: beta

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,10 @@ en:
       remaining_one: You have 1 more gem left to give out today.
       remaining_other: You have %{count} more gems left to give out today.
       close: Got it
+    modal_exhausted:
+      title: Out of Gems
+      body: You have no more gems left to give out today. Your allowance will refresh soon!
+      close: Got it
   core:
     add_comment: Add comment
     beta: beta

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -18,6 +18,10 @@ fr:
       remaining_one: Il vous reste 1 pépite à distribuer aujourd'hui.
       remaining_other: Il vous reste %{count} pépites à distribuer aujourd'hui.
       close: Compris
+    modal_exhausted:
+      title: Plus de pépites
+      body: Vous n'avez plus de pépites à distribuer aujourd'hui. Votre quota sera bientôt renouvelé !
+      close: Compris
   core:
     add_comment: Ajouter un commentaire
     beta: bêta

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -11,6 +11,13 @@ fr:
     favorite: Choisir comme pépite
     favorited: Choisi comme pépite
     favorited_by_you: Choisi comme pépite par vous
+    modal:
+      title: Pépite sélectionnée !
+      body: Vous avez sélectionné ceci comme pépite de la communauté !
+      remaining_zero: Vous n'avez plus de pépites à distribuer aujourd'hui.
+      remaining_one: Il vous reste 1 pépite à distribuer aujourd'hui.
+      remaining_other: Il vous reste %{count} pépites à distribuer aujourd'hui.
+      close: Compris
   core:
     add_comment: Ajouter un commentaire
     beta: bêta

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -18,6 +18,10 @@ pt:
       remaining_one: Você tem mais 1 joia para distribuir hoje.
       remaining_other: Você tem mais %{count} joias para distribuir hoje.
       close: Entendi
+    modal_exhausted:
+      title: Sem joias restantes
+      body: Você não tem mais joias para distribuir hoje. Seu limite será renovado em breve!
+      close: Entendi
   core:
     add_comment: Adicionar comentário
     beta: beta

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -11,6 +11,13 @@ pt:
     favorite: Escolher como joia
     favorited: Escolhido como joia
     favorited_by_you: Escolhido como joia por você
+    modal:
+      title: Joia Escolhida!
+      body: Você escolheu isto como uma joia da comunidade!
+      remaining_zero: Você não tem mais joias para distribuir hoje.
+      remaining_one: Você tem mais 1 joia para distribuir hoje.
+      remaining_other: Você tem mais %{count} joias para distribuir hoje.
+      close: Entendi
   core:
     add_comment: Adicionar comentário
     beta: beta

--- a/config/locales/services/en.yml
+++ b/config/locales/services/en.yml
@@ -15,16 +15,16 @@ en:
         not_enabled: Provider %{name} is not enabled!
     badges:
       award_community_favorite:
-        article_first_gem_notification: "Community curators have picked [your post](%{url}) as a gem! If you get two gems you will receive a new badge on your profile."
-        comment_first_gem_notification: "Community curators have picked [your comment](%{url}) as a gem! If you get two gems you will receive a new badge on your profile."
-        article_progress_notification: "Community curators have picked [your post](%{url}) as a gem! You've been picked %{count} times — the next eligible badge is when you get picked %{next_count} times."
-        comment_progress_notification: "Community curators have picked [your comment](%{url}) as a gem! You've been picked %{count} times — the next eligible badge is when you get picked %{next_count} times."
-        article_max_progress_notification: "Community curators have picked [your post](%{url}) as a gem! You've been picked %{count} times."
-        comment_max_progress_notification: "Community curators have picked [your comment](%{url}) as a gem! You've been picked %{count} times."
-        article_milestone_message: "Well done! Community curators picked [your post](%{url}) as a gem. You've earned the %{count} Gems badge! The next eligible badge is when you get picked %{next_count} times."
-        comment_milestone_message: "Well done! Community curators picked [your comment](%{url}) as a gem. You've earned the %{count} Gems badge! The next eligible badge is when you get picked %{next_count} times."
-        article_max_milestone_message: "Incredible! Community curators picked [your post](%{url}) as a gem. You've earned the %{count} Gems badge — the highest milestone!"
-        comment_max_milestone_message: "Incredible! Community curators picked [your comment](%{url}) as a gem. You've earned the %{count} Gems badge — the highest milestone!"
+        article_first_gem_notification: "Community curators have picked your post, [%{title}](%{url}), as a gem! If you get two gems you will receive a new badge on your profile."
+        comment_first_gem_notification: "Community curators have picked your comment on [%{title}](%{url}) as a gem! If you get two gems you will receive a new badge on your profile."
+        article_progress_notification: "Community curators have picked your post, [%{title}](%{url}), as a gem! You've been picked %{count} times — the next eligible badge is when you get picked %{next_count} times."
+        comment_progress_notification: "Community curators have picked your comment on [%{title}](%{url}) as a gem! You've been picked %{count} times — the next eligible badge is when you get picked %{next_count} times."
+        article_max_progress_notification: "Community curators have picked your post, [%{title}](%{url}), as a gem! You've been picked %{count} times."
+        comment_max_progress_notification: "Community curators have picked your comment on [%{title}](%{url}) as a gem! You've been picked %{count} times."
+        article_milestone_message: "Well done! Community curators picked your post, [%{title}](%{url}), as a gem. You've earned the %{count} Gems badge! The next eligible badge is when you get picked %{next_count} times."
+        comment_milestone_message: "Well done! Community curators picked your comment on [%{title}](%{url}) as a gem. You've earned the %{count} Gems badge! The next eligible badge is when you get picked %{next_count} times."
+        article_max_milestone_message: "Incredible! Community curators picked your post, [%{title}](%{url}), as a gem. You've earned the %{count} Gems badge — the highest milestone!"
+        comment_max_milestone_message: "Incredible! Community curators picked your comment on [%{title}](%{url}) as a gem. You've earned the %{count} Gems badge — the highest milestone!"
       award_beloved_comment:
         message: "You're famous! [This is the comment](%{comment}) for which you're being recognized. 😄"
       award_streak:

--- a/config/locales/services/fr.yml
+++ b/config/locales/services/fr.yml
@@ -15,16 +15,16 @@ fr:
         not_enabled: Le fournisseur %{name} n'est pas activé !
     badges:
       award_community_favorite:
-        article_first_gem_notification: "Les modérateurs de la communauté ont sélectionné [votre publication](%{url}) comme un gem ! Si vous obtenez deux gems, vous recevrez un nouveau badge sur votre profil."
-        comment_first_gem_notification: "Les modérateurs de la communauté ont sélectionné [votre commentaire](%{url}) comme un gem ! Si vous obtenez deux gems, vous recevrez un nouveau badge sur votre profil."
-        article_progress_notification: "Les modérateurs de la communauté ont sélectionné [votre publication](%{url}) comme un gem ! Vous avez été sélectionné %{count} fois — le prochain badge est accessible à %{next_count} gems."
-        comment_progress_notification: "Les modérateurs de la communauté ont sélectionné [votre commentaire](%{url}) comme un gem ! Vous avez été sélectionné %{count} fois — le prochain badge est accessible à %{next_count} gems."
-        article_max_progress_notification: "Les modérateurs de la communauté ont sélectionné [votre publication](%{url}) comme un gem ! Vous avez été sélectionné %{count} fois."
-        comment_max_progress_notification: "Les modérateurs de la communauté ont sélectionné [votre commentaire](%{url}) comme un gem ! Vous avez été sélectionné %{count} fois."
-        article_milestone_message: "Bravo ! Les modérateurs de la communauté ont sélectionné [votre publication](%{url}) comme un gem. Vous avez remporté le badge %{count} Gems ! Le prochain badge sera disponible à %{next_count} gems."
-        comment_milestone_message: "Bravo ! Les modérateurs de la communauté ont sélectionné [votre commentaire](%{url}) comme un gem. Vous avez remporté le badge %{count} Gems ! Le prochain badge sera disponible à %{next_count} gems."
-        article_max_milestone_message: "Incroyable ! Les modérateurs de la communauté ont sélectionné [votre publication](%{url}) comme un gem. Vous avez remporté le badge %{count} Gems — le palier le plus élevé !"
-        comment_max_milestone_message: "Incroyable ! Les modérateurs de la communauté ont sélectionné [votre commentaire](%{url}) comme un gem. Vous avez remporté le badge %{count} Gems — le palier le plus élevé !"
+        article_first_gem_notification: "Les modérateurs de la communauté ont sélectionné votre publication, [%{title}](%{url}), comme un gem ! Si vous obtenez deux gems, vous recevrez un nouveau badge sur votre profil."
+        comment_first_gem_notification: "Les modérateurs de la communauté ont sélectionné votre commentaire sur [%{title}](%{url}) comme un gem ! Si vous obtenez deux gems, vous recevrez un nouveau badge sur votre profil."
+        article_progress_notification: "Les modérateurs de la communauté ont sélectionné votre publication, [%{title}](%{url}), comme un gem ! Vous avez été sélectionné %{count} fois — le prochain badge est accessible à %{next_count} gems."
+        comment_progress_notification: "Les modérateurs de la communauté ont sélectionné votre commentaire sur [%{title}](%{url}) comme un gem ! Vous avez été sélectionné %{count} fois — le prochain badge est accessible à %{next_count} gems."
+        article_max_progress_notification: "Les modérateurs de la communauté ont sélectionné votre publication, [%{title}](%{url}), comme un gem ! Vous avez été sélectionné %{count} fois."
+        comment_max_progress_notification: "Les modérateurs de la communauté ont sélectionné votre commentaire sur [%{title}](%{url}) comme un gem ! Vous avez été sélectionné %{count} fois."
+        article_milestone_message: "Bravo ! Les modérateurs de la communauté ont sélectionné votre publication, [%{title}](%{url}), comme un gem. Vous avez remporté le badge %{count} Gems ! Le prochain badge sera disponible à %{next_count} gems."
+        comment_milestone_message: "Bravo ! Les modérateurs de la communauté ont sélectionné votre commentaire sur [%{title}](%{url}) comme un gem. Vous avez remporté le badge %{count} Gems ! Le prochain badge sera disponible à %{next_count} gems."
+        article_max_milestone_message: "Incroyable ! Les modérateurs de la communauté ont sélectionné votre publication, [%{title}](%{url}), comme un gem. Vous avez remporté le badge %{count} Gems — le palier le plus élevé !"
+        comment_max_milestone_message: "Incroyable ! Les modérateurs de la communauté ont sélectionné votre commentaire sur [%{title}](%{url}) comme un gem. Vous avez remporté le badge %{count} Gems — le palier le plus élevé !"
       award_beloved_comment:
         message: "Vous êtes célèbre ! [C'est le commentaire](%{comment}) pour lequel vous êtes reconnu. 😄"
       award_streak:

--- a/config/locales/services/pt.yml
+++ b/config/locales/services/pt.yml
@@ -15,16 +15,16 @@ pt:
         not_enabled: Provedor %{name} não está habilitado!
     badges:
       award_community_favorite:
-        article_first_gem_notification: "Os curadores da comunidade escolheram [sua publicação](%{url}) como uma joia! Se você receber duas joias, ganhará um novo badge no seu perfil."
-        comment_first_gem_notification: "Os curadores da comunidade escolheram [seu comentário](%{url}) como uma joia! Se você receber duas joias, ganhará um novo badge no seu perfil."
-        article_progress_notification: "Os curadores da comunidade escolheram [sua publicação](%{url}) como uma joia! Você foi escolhido %{count} vezes — o próximo badge elegível é com %{next_count} joias."
-        comment_progress_notification: "Os curadores da comunidade escolheram [seu comentário](%{url}) como uma joia! Você foi escolhido %{count} vezes — o próximo badge elegível é com %{next_count} joias."
-        article_max_progress_notification: "Os curadores da comunidade escolheram [sua publicação](%{url}) como uma joia! Você foi escolhido %{count} vezes."
-        comment_max_progress_notification: "Os curadores da comunidade escolheram [seu comentário](%{url}) como uma joia! Você foi escolhido %{count} vezes."
-        article_milestone_message: "Muito bem! Os curadores da comunidade escolheram [sua publicação](%{url}) como uma joia. Você ganhou o badge de %{count} Joias! O próximo badge elegível é quando for escolhido %{next_count} vezes."
-        comment_milestone_message: "Muito bem! Os curadores da comunidade escolheram [seu comentário](%{url}) como uma joia. Você ganhou o badge de %{count} Joias! O próximo badge elegível é quando for escolhido %{next_count} vezes."
-        article_max_milestone_message: "Incrível! Os curadores da comunidade escolheram [sua publicação](%{url}) como uma joia. Você ganhou o badge de %{count} Joias — o nível mais alto!"
-        comment_max_milestone_message: "Incrível! Os curadores da comunidade escolheram [seu comentário](%{url}) como uma joia. Você ganhou o badge de %{count} Joias — o nível mais alto!"
+        article_first_gem_notification: "Os curadores da comunidade escolheram sua publicação, [%{title}](%{url}), como uma joia! Se você receber duas joias, ganhará um novo badge no seu perfil."
+        comment_first_gem_notification: "Os curadores da comunidade escolheram seu comentário em [%{title}](%{url}) como uma joia! Se você receber duas joias, ganhará um novo badge no seu perfil."
+        article_progress_notification: "Os curadores da comunidade escolheram sua publicação, [%{title}](%{url}), como uma joia! Você foi escolhido %{count} vezes — o próximo badge elegível é com %{next_count} joias."
+        comment_progress_notification: "Os curadores da comunidade escolheram seu comentário em [%{title}](%{url}) como uma joia! Você foi escolhido %{count} vezes — o próximo badge elegível é com %{next_count} joias."
+        article_max_progress_notification: "Os curadores da comunidade escolheram sua publicação, [%{title}](%{url}), como uma joia! Você foi escolhido %{count} vezes."
+        comment_max_progress_notification: "Os curadores da comunidade escolheram seu comentário em [%{title}](%{url}) como uma joia! Você foi escolhido %{count} vezes."
+        article_milestone_message: "Muito bem! Os curadores da comunidade escolheram sua publicação, [%{title}](%{url}), como uma joia. Você ganhou o badge de %{count} Joias! O próximo badge elegível é quando for escolhido %{next_count} vezes."
+        comment_milestone_message: "Muito bem! Os curadores da comunidade escolheram seu comentário em [%{title}](%{url}) como uma joia. Você ganhou o badge de %{count} Joias! O próximo badge elegível é quando for escolhido %{next_count} vezes."
+        article_max_milestone_message: "Incrível! Os curadores da comunidade escolheram sua publicação, [%{title}](%{url}), como uma joia. Você ganhou o badge de %{count} Joias — o nível mais alto!"
+        comment_max_milestone_message: "Incrível! Os curadores da comunidade escolheram seu comentário em [%{title}](%{url}) como uma joia. Você ganhou o badge de %{count} Joias — o nível mais alto!"
       award_beloved_comment:
         message: "Você é famoso! [Este é o comentário](%{comment}) pelo qual você está sendo reconhecido. 😄"
       award_streak:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -300,17 +300,27 @@ seeder.create_if_none(Badge) do
   end
 end
 
+unless Badge.exists?(slug: "community-favorite")
+  Badge.create!(
+    title: "Community Favorite",
+    slug: "community-favorite",
+    description: "Awarded to authors whose posts or comments have been picked as gems.",
+    badge_image: Rails.root.join("app/assets/images/community-favorite-badge.png").open,
+    allow_multiple_awards: false,
+  )
+end
+
 Badges::AwardCommunityFavorite::MILESTONES.each do |milestone|
   slug = "community-favorite-#{milestone}-gems"
-  unless Badge.exists?(slug: slug)
-    Badge.create!(
-      title: "Community Favorite - #{milestone} Gems",
-      slug: slug,
-      description: "Awarded to authors whose posts or comments have been picked as gems #{milestone} times.",
-      badge_image: Rails.root.join("app/assets/images/community-favorite-badge.png").open,
-      allow_multiple_awards: false,
-    )
-  end
+  next if Badge.exists?(slug: slug)
+
+  Badge.create!(
+    title: "Community Favorite - #{milestone} Gems",
+    slug: slug,
+    description: "Awarded to authors whose posts or comments have been picked as gems #{milestone} times.",
+    badge_image: Rails.root.join("app/assets/images/community-favorite-badge.png").open,
+    allow_multiple_awards: false,
+  )
 end
 ##############################################################################
 

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe "Favorites" do
         post favorites_path, params: { favoritable_type: "Article", favoritable_id: article.id }, as: :json
 
         expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["success"]).to be(true)
+        expect(response.parsed_body["remaining_allowance"]).to be_a(Integer)
         expect(article.reload.favorited_by_user_id).to eq(leader.id)
       end
 

--- a/spec/services/badges/award_community_favorite_spec.rb
+++ b/spec/services/badges/award_community_favorite_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Badges::AwardCommunityFavorite, type: :service do
       expect(achievement.rewarder_id).to eq(leader.id)
       expect(achievement.rewarding_context_message_markdown).to include("2 Gems badge")
       expect(achievement.rewarding_context_message_markdown).to include("4 times")
-      expect(achievement.rewarding_context_message_markdown).to include(URL.article(article))
+      expect(achievement.rewarding_context_message_markdown).to include("[#{article.title}](#{URL.article(article)})")
     end
   end
 
@@ -143,7 +143,21 @@ RSpec.describe Badges::AwardCommunityFavorite, type: :service do
 
       achievement = BadgeAchievement.last
       expect(achievement.badge.slug).to eq("community-favorite-2-gems")
-      expect(achievement.rewarding_context_message_markdown).to include(URL.comment(comment))
+      link_markdown = "[#{comment.commentable.title}](#{URL.comment(comment)})"
+      expect(achievement.rewarding_context_message_markdown).to include(link_markdown)
+    end
+  end
+
+  context "when badge has fallback slug without -gems (e.g. community-favorite-2)" do
+    before do
+      Badge.destroy_all
+      create(:badge, title: "Community Favorite 2", slug: "community-favorite-2")
+      create(:article, user: author, favorited_by_user_id: leader.id, favorited_at: Time.current)
+    end
+
+    it "finds and awards the badge using fallback slug" do
+      expect { award }.to change(BadgeAchievement, :count).by(1)
+      expect(BadgeAchievement.last.badge.slug).to eq("community-favorite-2")
     end
   end
 


### PR DESCRIPTION
## Description
This PR enhances the Community Favorite experience across backend notifications and frontend feedback:

### Key Changes
1. **Gem Picked Confirmation Modal**:
   - Added a confirmation modal upon picking an article (or comment) as a gem in `FavoriteControl.jsx`.
   - Displays a celebratory gem icon, confirmation text, remaining daily gem allowance, and a dismiss action.
   - Updated `FavoritesController#create` to return `{ success: true, remaining_allowance: current_user.favorite_allowance }` on 200 OK.
2. **Direct Post/Comment Links in Badge Notifications**:
   - Updated `Badges::AwardCommunityFavorite` to interpolate `title: favoritable_title` and `url: favoritable_url` so notifications display `[Post Title](url)` directly in the context message.
3. **i18n Localization**:
   - Synchronized all updated copy across `en`, `fr`, and `pt` locale files in `config/locales/` and `config/locales/services/`.
4. **Idempotent Seeds**:
   - Updated `db/seeds.rb` to ensure both the base `community-favorite` badge and all milestone badges (`community-favorite-#{count}-gems`) are seeded properly.

## Verification
- `yarn jest app/javascript/favoriteControl/__tests__/FavoriteControl.test.jsx` (18 passed, 0 failures)
- `bin/rspec spec/requests/favorites_spec.rb spec/services/badges/award_community_favorite_spec.rb spec/models/badge_spec.rb` (42 passed, 0 failures)
- `bundle exec rubocop` (0 offenses)