### PR TITLE
Synchronize InstantClick history state with feed tab soft navigations

### DIFF
--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -33,6 +33,7 @@ var instantClick
     , $isWaitingForCompletion = false
     , $trackedAssets = []
     , $keepScrollPosition = false
+    , $isInternalNavigation = false
 
   // Variables defined by public functions
     , $preloadOnMousedown
@@ -157,7 +158,9 @@ var instantClick
         routeChangeTarget.focus();
       }
       document.getElementById('page-route-change').textContent = title;
+      $isInternalNavigation = true;
       history.pushState(null, null, newUrl.replace("?samepage=true","").replace("&samepage=true",""))
+      $isInternalNavigation = false;
 
       var hashIndex = newUrl.indexOf('#'),
           hashElem = hashIndex > -1 && (
@@ -676,12 +679,67 @@ var instantClick
     $xhr = new XMLHttpRequest()
     $xhr.addEventListener('readystatechange', readystatechangeListener)
 
+    hookHistory()
     instantanize(true)
 
     triggerPageEvent('change', true)
 
     addEventListener('popstate', popstateListener)
     addRefreshBehavior();
+  }
+
+  function hookHistory() {
+    if (!supported || window._instantClickHistoryHooked) {
+      return;
+    }
+    window._instantClickHistoryHooked = true;
+
+    var nativePushState = history.pushState;
+    history.pushState = function(state, title, url) {
+      if (!$isInternalNavigation && url && $currentLocationWithoutHash) {
+        try {
+          var newLoc = removeHash(new URL(url, location.href).href);
+          if (newLoc !== $currentLocationWithoutHash) {
+            var pageContent = document.getElementById("page-content");
+            if (pageContent) {
+              $history[$currentLocationWithoutHash] = {
+                body: pageContent,
+                title: document.title,
+                scrollY: pageYOffset
+              };
+            }
+            $currentLocationWithoutHash = newLoc;
+            if (pageContent) {
+              $history[newLoc] = {
+                body: pageContent,
+                title: title || document.title,
+                scrollY: 0
+              };
+            }
+          }
+        } catch (e) {}
+      }
+      return nativePushState.apply(history, arguments);
+    };
+
+    var nativeReplaceState = history.replaceState;
+    history.replaceState = function(state, title, url) {
+      if (!$isInternalNavigation && url && $currentLocationWithoutHash) {
+        try {
+          var newLoc = removeHash(new URL(url, location.href).href);
+          $currentLocationWithoutHash = newLoc;
+          var pageContent = document.getElementById("page-content");
+          if (pageContent) {
+            $history[newLoc] = {
+              body: pageContent,
+              title: title || document.title,
+              scrollY: pageYOffset
+            };
+          }
+        } catch (e) {}
+      }
+      return nativeReplaceState.apply(history, arguments);
+    };
   }
 
   function on(eventType, callback) {

--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -158,9 +158,12 @@ var instantClick
         routeChangeTarget.focus();
       }
       document.getElementById('page-route-change').textContent = title;
-      $isInternalNavigation = true;
-      history.pushState(null, null, newUrl.replace("?samepage=true","").replace("&samepage=true",""))
-      $isInternalNavigation = false;
+      try {
+        $isInternalNavigation = true;
+        history.pushState(null, null, newUrl.replace("?samepage=true","").replace("&samepage=true",""))
+      } finally {
+        $isInternalNavigation = false;
+      }
 
       var hashIndex = newUrl.indexOf('#'),
           hashElem = hashIndex > -1 && (
@@ -696,49 +699,77 @@ var instantClick
 
     var nativePushState = history.pushState;
     history.pushState = function(state, title, url) {
-      if (!$isInternalNavigation && url && $currentLocationWithoutHash) {
+      var shouldTrack = !$isInternalNavigation && url && $currentLocationWithoutHash;
+      var newLoc = null;
+      var oldLoc = $currentLocationWithoutHash;
+      var pageContent = null;
+      var pageTitle = document.title;
+      var scrollY = pageYOffset;
+
+      if (shouldTrack) {
         try {
-          var newLoc = removeHash(new URL(url, location.href).href);
-          if (newLoc !== $currentLocationWithoutHash) {
-            var pageContent = document.getElementById("page-content");
-            if (pageContent) {
-              $history[$currentLocationWithoutHash] = {
-                body: pageContent,
-                title: document.title,
-                scrollY: pageYOffset
-              };
-            }
-            $currentLocationWithoutHash = newLoc;
-            if (pageContent) {
-              $history[newLoc] = {
-                body: pageContent,
-                title: title || document.title,
-                scrollY: 0
-              };
-            }
+          newLoc = removeHash(new URL(url, location.href).href);
+          if (newLoc !== oldLoc) {
+            pageContent = document.getElementById("page-content");
           }
-        } catch (e) {}
+        } catch (e) {
+          shouldTrack = false;
+        }
       }
-      return nativePushState.apply(history, arguments);
+
+      var result = nativePushState.apply(history, arguments);
+
+      if (shouldTrack && newLoc && newLoc !== oldLoc) {
+        if (pageContent) {
+          $history[oldLoc] = {
+            body: pageContent,
+            title: pageTitle,
+            scrollY: scrollY
+          };
+        }
+        $currentLocationWithoutHash = newLoc;
+        if (pageContent) {
+          $history[newLoc] = {
+            body: pageContent,
+            title: title || document.title,
+            scrollY: 0
+          };
+        }
+      }
+
+      return result;
     };
 
     var nativeReplaceState = history.replaceState;
     history.replaceState = function(state, title, url) {
-      if (!$isInternalNavigation && url && $currentLocationWithoutHash) {
+      var shouldTrack = !$isInternalNavigation && url && $currentLocationWithoutHash;
+      var newLoc = null;
+      var pageContent = null;
+      var scrollY = pageYOffset;
+
+      if (shouldTrack) {
         try {
-          var newLoc = removeHash(new URL(url, location.href).href);
-          $currentLocationWithoutHash = newLoc;
-          var pageContent = document.getElementById("page-content");
-          if (pageContent) {
-            $history[newLoc] = {
-              body: pageContent,
-              title: title || document.title,
-              scrollY: pageYOffset
-            };
-          }
-        } catch (e) {}
+          newLoc = removeHash(new URL(url, location.href).href);
+          pageContent = document.getElementById("page-content");
+        } catch (e) {
+          shouldTrack = false;
+        }
       }
-      return nativeReplaceState.apply(history, arguments);
+
+      var result = nativeReplaceState.apply(history, arguments);
+
+      if (shouldTrack && newLoc) {
+        $currentLocationWithoutHash = newLoc;
+        if (pageContent) {
+          $history[newLoc] = {
+            body: pageContent,
+            title: title || document.title,
+            scrollY: scrollY
+          };
+        }
+      }
+
+      return result;
     };
   }
 

--- a/app/views/articles/_feed_nav.html.erb
+++ b/app/views/articles/_feed_nav.html.erb
@@ -136,7 +136,7 @@
   </nav>
   <script>
     (function() {
-      function initializeFeedNavigation() {
+      function updateFeedNavActiveState() {
         var currentPath = window.location.pathname;
         var currentFeedNav = "";
 
@@ -169,6 +169,13 @@
             item.classList.remove("crayons-navigation__item--current");
           }
         });
+      }
+
+      var lastFeedPath = window.location.pathname;
+
+      function initializeFeedNavigation() {
+        lastFeedPath = window.location.pathname;
+        updateFeedNavActiveState();
 
         // Setup soft navigations
         var feedLinks = document.querySelectorAll(".pill-nav-item");
@@ -179,6 +186,7 @@
             if (window.location.pathname === targetHref) return;
             
             e.preventDefault();
+            lastFeedPath = targetHref;
             window.history.pushState({}, "", targetHref);
             handleFeedSoftNavigation(targetHref);
           });
@@ -186,13 +194,20 @@
 
         if (!window.feedPopstateHandler) {
           window.feedPopstateHandler = function() {
-            // Only fire soft SPA reloads if we are currently on the feed view layout.
-            // If popping back from an Article, the DOM is still Article markup, so we let InstantClick natively restore!
-            if (document.getElementById("homepage-feed") || document.getElementById("rendered-article-feed")) {
-              handleFeedSoftNavigation(window.location.pathname);
+            var currentPath = window.location.pathname;
+            updateFeedNavActiveState();
+            // If navigating between different feed tabs via browser back/forward, soft navigate
+            if (lastFeedPath && currentPath !== lastFeedPath && (document.getElementById("homepage-feed") || document.getElementById("rendered-article-feed"))) {
+              lastFeedPath = currentPath;
+              handleFeedSoftNavigation(currentPath);
+            } else {
+              lastFeedPath = currentPath;
             }
           };
           window.addEventListener("popstate", window.feedPopstateHandler);
+          if (window.InstantClick) {
+            window.InstantClick.on("restore", updateFeedNavActiveState);
+          }
         }
       }
 

--- a/app/views/articles/_feed_nav.html.erb
+++ b/app/views/articles/_feed_nav.html.erb
@@ -171,10 +171,8 @@
         });
       }
 
-      var lastFeedPath = window.location.pathname;
-
       function initializeFeedNavigation() {
-        lastFeedPath = window.location.pathname;
+        window._feedLastPath = window.location.pathname;
         updateFeedNavActiveState();
 
         // Setup soft navigations
@@ -186,7 +184,7 @@
             if (window.location.pathname === targetHref) return;
             
             e.preventDefault();
-            lastFeedPath = targetHref;
+            window._feedLastPath = targetHref;
             window.history.pushState({}, "", targetHref);
             handleFeedSoftNavigation(targetHref);
           });
@@ -195,13 +193,12 @@
         if (!window.feedPopstateHandler) {
           window.feedPopstateHandler = function() {
             var currentPath = window.location.pathname;
+            var lastPath = window._feedLastPath || currentPath;
+            window._feedLastPath = currentPath;
             updateFeedNavActiveState();
             // If navigating between different feed tabs via browser back/forward, soft navigate
-            if (lastFeedPath && currentPath !== lastFeedPath && (document.getElementById("homepage-feed") || document.getElementById("rendered-article-feed"))) {
-              lastFeedPath = currentPath;
+            if (currentPath !== lastPath && (document.getElementById("homepage-feed") || document.getElementById("rendered-article-feed"))) {
               handleFeedSoftNavigation(currentPath);
-            } else {
-              lastFeedPath = currentPath;
             }
           };
           window.addEventListener("popstate", window.feedPopstateHandler);


### PR DESCRIPTION
## Summary

When navigating between feed tabs (such as Discover, Curated, Following, and Latest) via client-side soft navigations (`history.pushState`), InstantClick was previously unaware of the URL transitions. Consequently:
1. InstantClick retained its initial `$currentLocationWithoutHash` key (e.g. `/`).
2. When navigating to an article from `/latest` (or other tab), InstantClick stored the `/latest` DOM into `$history["/"]` instead of `$history["/latest"]`.
3. When pressing browser **Back** from the article, InstantClick failed to find `/latest` in `$history` and triggered its fallback `location.href = location.href;` (a full-page browser hard reload), resetting the feed, displaying loading skeletons, and losing scroll position.

## Changes

- **InstantClick Core (`base.js.erb`)**:
  - Wrapped `history.pushState` and `history.replaceState` during `InstantClick.init()` to preserve `$history[$currentLocationWithoutHash]`, update `$currentLocationWithoutHash`, and pre-populate `$history[newLoc]`.
  - Guarded InstantClick's internal page swaps (`changePage()`) with `$isInternalNavigation = true` to avoid capturing the incoming page's DOM under the prior URL key.
  - Added defensive `try...catch` around URL resolution.
- **Feed Navigation (`_feed_nav.html.erb`)**:
  - Extracted `updateFeedNavActiveState()` to synchronize active tab UI on `popstate` and InstantClick `restore`.
  - Tracked `lastFeedPath` to smoothly support browser Back/Forward between different feed tabs without triggering redundant re-fetches when restoring from an article.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790956123&installation_model_id=424141&pr_number=23800&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23800&signature=a4a6357bb7961fc7cebd80de1a850b2a065beeedcb2456f18d5586b7b4cadec3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->