### PR TITLE
Optimize stories feed and feed_config SQL queries and preloading

### DIFF
--- a/app/controllers/stories/feeds_controller.rb
+++ b/app/controllers/stories/feeds_controller.rb
@@ -68,11 +68,11 @@ module Stories
              elsif feed_strategy == "configured" && params[:type_of] != "following"
 
                @feed_config = if params[:item]
-                                FeedConfig.find_by(id: params[:item]) || FeedConfig.order("feed_success_score DESC").limit(rand(15)).sample || FeedConfig.first_or_create
+                                FeedConfig.find_by(id: params[:item]) || FeedConfig.order("feed_success_score DESC").limit(rand(1..15)).sample || FeedConfig.first_or_create
                               elsif rand(20) == 0 # 5% of the time, we'll just pick a random feed config
-                                FeedConfig.where("feed_impressions_count < 100").order("RANDOM()").limit(1).first || FeedConfig.order("feed_success_score DESC").limit(rand(15)).sample || FeedConfig.first_or_create
+                                FeedConfig.where("feed_impressions_count < 100").order("RANDOM()").limit(1).first || FeedConfig.order("feed_success_score DESC").limit(rand(1..15)).sample || FeedConfig.first_or_create
                               else
-                                FeedConfig.order("feed_success_score DESC").limit(rand(15)).sample || FeedConfig.first_or_create
+                                FeedConfig.order("feed_success_score DESC").limit(rand(1..15)).sample || FeedConfig.first_or_create
                               end
                Articles::Feeds::Custom.new(user: current_user, page: @page, tag: params[:tag],
                                            feed_config: @feed_config)

--- a/app/models/feed_config.rb
+++ b/app/models/feed_config.rb
@@ -15,13 +15,7 @@ class FeedConfig < ApplicationRecord
 
     activity_tracked_pageview_time = activity_store&.recently_viewed_articles&.second
     time_of_second_latest_page_view = activity_tracked_pageview_time ? activity_tracked_pageview_time[1].to_datetime : 4.days.ago
-    precomputed_selections = RecommendedArticlesList.where(user_id: user.id)
-                                                     .where("expires_at > ?", Time.current)
-                                                     .last&.article_ids || []
     lookback_window = time_of_second_latest_page_view - 18.hours
-
-    languages = user.languages.pluck(:language)
-    languages = [I18n.default_locale.to_s] if languages.empty?
 
     terms = []
 
@@ -81,7 +75,10 @@ class FeedConfig < ApplicationRecord
       terms << "(CASE WHEN articles.published_at BETWEEN '#{lookback_window.utc.to_fs(:db)}' AND '#{time_of_second_latest_page_view.utc.to_fs(:db)}' THEN #{lookback_window_weight} ELSE 0 END)"
     end
 
-    if precomputed_selections_weight.positive? && precomputed_selections.present?
+    if precomputed_selections_weight.positive?
+      precomputed_selections = RecommendedArticlesList.where(user_id: user.id)
+                                                       .where("expires_at > ?", Time.current)
+                                                       .last&.article_ids || []
       selections = precomputed_selections.compact_blank
       if selections.any?
         terms << "(CASE WHEN articles.id IN (#{selections.join(',')}) THEN #{precomputed_selections_weight} ELSE 0 END)"
@@ -173,7 +170,19 @@ class FeedConfig < ApplicationRecord
     terms << "(CASE WHEN articles.type_of = 1 THEN #{status_weight} ELSE 0 END)" if status_weight.positive?
     terms << "(- (articles.clickbait_score * #{clickbait_score_weight}))" if clickbait_score_weight.positive?
     terms << "(articles.compellingness_score * #{compellingness_score_weight})" if compellingness_score_weight.positive?
-    terms << "(CASE WHEN articles.language IN ('#{languages.join("','")}') THEN #{language_match_weight} ELSE 0 END)" if language_match_weight.positive? && score_weight.positive?
+    if language_match_weight.positive? && score_weight.positive?
+      languages = if user.respond_to?(:cached_languages)
+                    user.cached_languages
+                  elsif user.respond_to?(:languages) && user.languages.respond_to?(:loaded?) && user.languages.loaded?
+                    user.languages.map(&:language)
+                  elsif user.respond_to?(:languages)
+                    user.languages.pluck(:language)
+                  else
+                    []
+                  end
+      languages = [I18n.default_locale.to_s] if languages.blank?
+      terms << "(CASE WHEN articles.language IN ('#{languages.join("','")}') THEN #{language_match_weight} ELSE 0 END)"
+    end
     if randomness_weight.positive?
       # Injecting a dynamic Ruby scope guarantees row shuffling uniquely per-request without sacrificing query planners dynamically!
       terms << "((CASE WHEN articles.id IS NOT NULL THEN MOD((articles.id * 137 + #{rand(10000)}), 1000) / 1000.0 ELSE 0 END) * #{randomness_weight})"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -543,6 +543,13 @@ class User < ApplicationRecord
     end
   end
 
+  def cached_languages
+    cache_name = "user-#{id}/languages"
+    Rails.cache.fetch(cache_name, expires_in: 24.hours) do
+      languages.pluck(:language)
+    end
+  end
+
   def refresh_auto_audience_segments
     if ENV["ENABLE_REFRESH_SEGMENT_WORKERS"]  == "true"
       SegmentedUserRefreshWorker.perform_async(id)

--- a/app/models/user_language.rb
+++ b/app/models/user_language.rb
@@ -2,4 +2,12 @@ class UserLanguage < ApplicationRecord
   belongs_to :user, inverse_of: :languages
 
   validates :language, inclusion: { in: Languages::Detection.codes }, presence: true
+
+  after_commit :clear_cached_languages
+
+  private
+
+  def clear_cached_languages
+    Rails.cache.delete("user-#{user_id}/languages")
+  end
 end

--- a/app/services/articles/feeds/custom.rb
+++ b/app/services/articles/feeds/custom.rb
@@ -11,15 +11,15 @@ module Articles
         @feed_config = feed_config
       end
 
-      def default_home_feed(**_kwargs)
+      def default_home_feed(comments_variant: "more_inclusive_recent_good_comments", **_kwargs)
         return [] if @feed_config.nil? || @user.nil?
         
-        execute_feed_query
+        execute_feed_query(comments_variant: comments_variant)
       end
 
       private
 
-      def execute_feed_query
+      def execute_feed_query(comments_variant: "more_inclusive_recent_good_comments")
         # Optimize lookback calculation - cache the result
         # Note: Partial indexes are optimized for 7-day lookback (covers 95%+ of queries)
         # If you change this, consider updating the partial indexes in the migration
@@ -29,8 +29,8 @@ module Articles
         # Pre-calculate user-specific data to avoid repeated database calls
         user_data = preload_user_data
         
-        # Build optimized base query with better index usage
-        articles = build_optimized_base_query(lookback, user_data)
+        # Build optimized base query with better index usage and preloaded associations
+        articles = build_optimized_base_query(lookback, user_data, comments_variant: comments_variant)
         
         # Apply user-specific filters early in the query
         articles = apply_user_filters(articles, user_data)
@@ -58,23 +58,34 @@ module Articles
         }
       end
 
-      def build_optimized_base_query(lookback, user_data)
-        # Use a more efficient query structure with better index hints
+      def build_optimized_base_query(lookback, user_data, comments_variant: "more_inclusive_recent_good_comments")
+        # Use limited_column_select with computed_score to avoid transferring heavy columns
+        # (e.g., body_markdown, body_html, 768-dimension semantic_embedding, tsvector).
         base_query = Article.published
           .with_at_least_home_feed_minimum_score
           .where("articles.published_at > ?", lookback)
-          .select("articles.*, (#{score_sql_method}) as computed_score")
+          .limited_column_select
+          .select("(#{score_sql_method}) as computed_score")
           .order(Arel.sql("computed_score DESC"))
           .limit(@number_of_articles)
           .offset((@page - 1) * @number_of_articles)
-          .limited_column_select
-          .includes(:subforem) # Only include essential associations
+          .includes(:subforem, :distinct_reaction_categories, :context_notes)
           .from_subforem
 
-        # Include necessary associations for performance
-        base_query = base_query.includes(:distinct_reaction_categories, :context_notes, top_comments: :user)
-        
-        base_query
+        comments_assoc = case comments_variant.to_s
+                         when "more_inclusive_recent_good_comments"
+                           { more_inclusive_recent_good_comments: :user }
+                         when "recent_good_comments"
+                           { recent_good_comments: :user }
+                         when "more_inclusive_top_comments"
+                           { more_inclusive_top_comments: :user }
+                         when "most_inclusive_recent_good_comments"
+                           { most_inclusive_recent_good_comments: :user }
+                         else
+                           { top_comments: :user }
+                         end
+
+        base_query.includes(comments_assoc)
       end
 
       def score_sql_method
@@ -93,7 +104,7 @@ module Articles
         end
         
         if user_data[:hidden_tags].any?
-          articles = if ENV["OPTIMIZED_FEED_TAGS_QUERY"] == "true"
+          articles = if Article.column_names.include?("tags_array") && ENV["OPTIMIZED_FEED_TAGS_QUERY"] != "false"
                        articles.where.not("articles.tags_array && ARRAY[?]::text[]", user_data[:hidden_tags].map(&:to_s))
                      else
                        articles.not_cached_tagged_with_any(user_data[:hidden_tags])

--- a/app/services/articles/feeds/custom.rb
+++ b/app/services/articles/feeds/custom.rb
@@ -104,8 +104,11 @@ module Articles
         end
         
         if user_data[:hidden_tags].any?
-          articles = if Article.column_names.include?("tags_array") && ENV["OPTIMIZED_FEED_TAGS_QUERY"] != "false"
-                       articles.where.not("articles.tags_array && ARRAY[?]::text[]", user_data[:hidden_tags].map(&:to_s))
+          articles = if Article.column_names.include?("tags_array") && ENV["OPTIMIZED_FEED_TAGS_QUERY"] == "true"
+                       articles.where.not(
+                         "articles.tags_array && ARRAY[?]::text[]",
+                         user_data[:hidden_tags].map(&:to_s),
+                       )
                      else
                        articles.not_cached_tagged_with_any(user_data[:hidden_tags])
                      end

--- a/db/migrate/20260903120000_add_feed_lookback_index_to_articles.rb
+++ b/db/migrate/20260903120000_add_feed_lookback_index_to_articles.rb
@@ -19,17 +19,19 @@ class AddFeedLookbackIndexToArticles < ActiveRecord::Migration[7.0]
 
   def down
     safety_assured do
-      execute "SET statement_timeout = 0;"
-      remove_index :articles,
-                   name: "index_articles_on_published_at_and_score",
-                   if_exists: true,
-                   algorithm: :concurrently
+      with_statement_timeout_disabled do
+        remove_index :articles,
+                     name: "index_articles_on_published_at_and_score",
+                     if_exists: true,
+                     algorithm: :concurrently
+      end
     end
   end
 
   private
 
   def with_statement_timeout_disabled
+    original_timeout = connection.query_value("SHOW statement_timeout")
     db_user = connection.query_value("SELECT current_user")
     begin
       execute "ALTER ROLE \"#{db_user}\" SET statement_timeout = 0;"
@@ -44,14 +46,20 @@ class AddFeedLookbackIndexToArticles < ActiveRecord::Migration[7.0]
     rescue ActiveRecord::StatementInvalid => e
       Rails.logger.warn("Could not reset role statement_timeout: #{e.message}")
     end
+    if original_timeout.present?
+      execute "SET statement_timeout = #{connection.quote(original_timeout)};"
+    else
+      execute "RESET statement_timeout;"
+    end
   end
 
   def drop_invalid_index_if_exists!(index_name)
+    quoted_index_name = connection.quote(index_name)
     query = <<~SQL.squish
       SELECT 1 FROM pg_index i
       JOIN pg_class c ON c.oid = i.indexrelid
-      WHERE c.relname = '#{index_name}' AND NOT i.indisvalid
+      WHERE c.relname = #{quoted_index_name} AND NOT i.indisvalid
     SQL
-    execute "DROP INDEX CONCURRENTLY IF EXISTS #{index_name};" if select_value(query)
+    execute "DROP INDEX CONCURRENTLY IF EXISTS #{connection.quote_table_name(index_name)};" if select_value(query)
   end
 end

--- a/db/migrate/20260903120000_add_feed_lookback_index_to_articles.rb
+++ b/db/migrate/20260903120000_add_feed_lookback_index_to_articles.rb
@@ -1,0 +1,57 @@
+class AddFeedLookbackIndexToArticles < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      with_statement_timeout_disabled do
+        drop_invalid_index_if_exists!("index_articles_on_published_at_and_score")
+
+        add_index :articles,
+                  %i[published_at score],
+                  name: "index_articles_on_published_at_and_score",
+                  where: "published = true",
+                  order: { published_at: :desc },
+                  algorithm: :concurrently,
+                  if_not_exists: true
+      end
+    end
+  end
+
+  def down
+    safety_assured do
+      execute "SET statement_timeout = 0;"
+      remove_index :articles,
+                   name: "index_articles_on_published_at_and_score",
+                   if_exists: true,
+                   algorithm: :concurrently
+    end
+  end
+
+  private
+
+  def with_statement_timeout_disabled
+    db_user = connection.query_value("SELECT current_user")
+    begin
+      execute "ALTER ROLE \"#{db_user}\" SET statement_timeout = 0;"
+    rescue ActiveRecord::StatementInvalid => e
+      Rails.logger.warn("Could not alter role statement_timeout: #{e.message}")
+    end
+    execute "SET statement_timeout = 0;"
+    yield
+  ensure
+    begin
+      execute "ALTER ROLE \"#{db_user}\" RESET statement_timeout;"
+    rescue ActiveRecord::StatementInvalid => e
+      Rails.logger.warn("Could not reset role statement_timeout: #{e.message}")
+    end
+  end
+
+  def drop_invalid_index_if_exists!(index_name)
+    query = <<~SQL.squish
+      SELECT 1 FROM pg_index i
+      JOIN pg_class c ON c.oid = i.indexrelid
+      WHERE c.relname = '#{index_name}' AND NOT i.indisvalid
+    SQL
+    execute "DROP INDEX CONCURRENTLY IF EXISTS #{index_name};" if select_value(query)
+  end
+end

--- a/db/migrate/20260903120001_add_user_expires_at_index_to_recommended_articles_lists.rb
+++ b/db/migrate/20260903120001_add_user_expires_at_index_to_recommended_articles_lists.rb
@@ -17,17 +17,19 @@ class AddUserExpiresAtIndexToRecommendedArticlesLists < ActiveRecord::Migration[
 
   def down
     safety_assured do
-      execute "SET statement_timeout = 0;"
-      remove_index :recommended_articles_lists,
-                   name: "index_recommended_articles_lists_on_user_and_expires",
-                   if_exists: true,
-                   algorithm: :concurrently
+      with_statement_timeout_disabled do
+        remove_index :recommended_articles_lists,
+                     name: "index_recommended_articles_lists_on_user_and_expires",
+                     if_exists: true,
+                     algorithm: :concurrently
+      end
     end
   end
 
   private
 
   def with_statement_timeout_disabled
+    original_timeout = connection.query_value("SHOW statement_timeout")
     db_user = connection.query_value("SELECT current_user")
     begin
       execute "ALTER ROLE \"#{db_user}\" SET statement_timeout = 0;"
@@ -42,14 +44,20 @@ class AddUserExpiresAtIndexToRecommendedArticlesLists < ActiveRecord::Migration[
     rescue ActiveRecord::StatementInvalid => e
       Rails.logger.warn("Could not reset role statement_timeout: #{e.message}")
     end
+    if original_timeout.present?
+      execute "SET statement_timeout = #{connection.quote(original_timeout)};"
+    else
+      execute "RESET statement_timeout;"
+    end
   end
 
   def drop_invalid_index_if_exists!(index_name)
+    quoted_index_name = connection.quote(index_name)
     query = <<~SQL.squish
       SELECT 1 FROM pg_index i
       JOIN pg_class c ON c.oid = i.indexrelid
-      WHERE c.relname = '#{index_name}' AND NOT i.indisvalid
+      WHERE c.relname = #{quoted_index_name} AND NOT i.indisvalid
     SQL
-    execute "DROP INDEX CONCURRENTLY IF EXISTS #{index_name};" if select_value(query)
+    execute "DROP INDEX CONCURRENTLY IF EXISTS #{connection.quote_table_name(index_name)};" if select_value(query)
   end
 end

--- a/db/migrate/20260903120001_add_user_expires_at_index_to_recommended_articles_lists.rb
+++ b/db/migrate/20260903120001_add_user_expires_at_index_to_recommended_articles_lists.rb
@@ -1,0 +1,55 @@
+class AddUserExpiresAtIndexToRecommendedArticlesLists < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      with_statement_timeout_disabled do
+        drop_invalid_index_if_exists!("index_recommended_articles_lists_on_user_and_expires")
+
+        add_index :recommended_articles_lists,
+                  %i[user_id expires_at],
+                  name: "index_recommended_articles_lists_on_user_and_expires",
+                  algorithm: :concurrently,
+                  if_not_exists: true
+      end
+    end
+  end
+
+  def down
+    safety_assured do
+      execute "SET statement_timeout = 0;"
+      remove_index :recommended_articles_lists,
+                   name: "index_recommended_articles_lists_on_user_and_expires",
+                   if_exists: true,
+                   algorithm: :concurrently
+    end
+  end
+
+  private
+
+  def with_statement_timeout_disabled
+    db_user = connection.query_value("SELECT current_user")
+    begin
+      execute "ALTER ROLE \"#{db_user}\" SET statement_timeout = 0;"
+    rescue ActiveRecord::StatementInvalid => e
+      Rails.logger.warn("Could not alter role statement_timeout: #{e.message}")
+    end
+    execute "SET statement_timeout = 0;"
+    yield
+  ensure
+    begin
+      execute "ALTER ROLE \"#{db_user}\" RESET statement_timeout;"
+    rescue ActiveRecord::StatementInvalid => e
+      Rails.logger.warn("Could not reset role statement_timeout: #{e.message}")
+    end
+  end
+
+  def drop_invalid_index_if_exists!(index_name)
+    query = <<~SQL.squish
+      SELECT 1 FROM pg_index i
+      JOIN pg_class c ON c.oid = i.indexrelid
+      WHERE c.relname = '#{index_name}' AND NOT i.indisvalid
+    SQL
+    execute "DROP INDEX CONCURRENTLY IF EXISTS #{index_name};" if select_value(query)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_09_01_140000) do
+ActiveRecord::Schema[8.0].define(version: 2026_09_03_120001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -259,6 +259,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_01_140000) do
     t.index ["published", "nth_published_by_author"], name: "index_articles_on_published_nth_published_by_author"
     t.index ["published", "score", "published_at"], name: "index_articles_on_published_score_published_at_for_moderation"
     t.index ["published"], name: "index_articles_on_published"
+    t.index ["published_at", "score"], name: "index_articles_on_published_at_and_score", order: { published_at: :desc }, where: "(published = true)"
     t.index ["published_at"], name: "index_articles_on_published_at"
     t.index ["reading_list_document"], name: "index_articles_on_reading_list_document", using: :gin
     t.index ["semantic_embedding"], name: "index_articles_on_semantic_embedding", opclass: :vector_cosine_ops, using: :hnsw
@@ -1575,6 +1576,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_01_140000) do
     t.index ["article_ids"], name: "index_recommended_articles_lists_on_article_ids", using: :gin
     t.index ["expires_at"], name: "index_recommended_articles_lists_on_expires_at"
     t.index ["placement_area"], name: "index_recommended_articles_lists_on_placement_area"
+    t.index ["user_id", "expires_at"], name: "index_recommended_articles_lists_on_user_and_expires"
     t.index ["user_id"], name: "index_recommended_articles_lists_on_user_id"
   end
 

--- a/spec/models/feed_config_spec.rb
+++ b/spec/models/feed_config_spec.rb
@@ -192,6 +192,17 @@ RSpec.describe FeedConfig, type: :model do
         expect(sql).not_to include("subforem_id IN") # Added expectation
         expect(sql).not_to include("articles.type_of = 1 AND articles.user_id IN")
       end
+
+      it "does not query RecommendedArticlesList when precomputed_selections_weight is zero" do
+        expect(RecommendedArticlesList).not_to receive(:where)
+        feed_config.score_sql(user)
+      end
+
+      it "does not query user languages when language_match_weight is zero" do
+        feed_config.language_match_weight = 0.0
+        expect(user).not_to receive(:languages)
+        feed_config.score_sql(user)
+      end
     end
 
     context "when all base weights are zero" do

--- a/spec/models/user_language_spec.rb
+++ b/spec/models/user_language_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe UserLanguage do
       original_cache = Rails.cache
       Rails.cache = cache_store
       example.run
+    ensure
       Rails.cache = original_cache
     end
 

--- a/spec/models/user_language_spec.rb
+++ b/spec/models/user_language_spec.rb
@@ -19,4 +19,29 @@ RSpec.describe UserLanguage do
       expect(lang.errors[:language]).to be_present
     end
   end
+
+  describe "caching" do
+    let(:user) { create(:user) }
+    let(:cache_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
+    around do |example|
+      original_cache = Rails.cache
+      Rails.cache = cache_store
+      example.run
+      Rails.cache = original_cache
+    end
+
+    it "caches user languages and clears cache after commit" do
+      create(:user_language, user: user, language: "en")
+      expect(user.cached_languages).to eq(["en"])
+
+      # Should be cached
+      expect(Rails.cache.exist?("user-#{user.id}/languages")).to be true
+
+      # Creating another language clears the cache
+      create(:user_language, user: user, language: "es")
+      expect(Rails.cache.exist?("user-#{user.id}/languages")).to be false
+      expect(user.cached_languages).to contain_exactly("en", "es")
+    end
+  end
 end

--- a/spec/requests/stories/feeds_spec.rb
+++ b/spec/requests/stories/feeds_spec.rb
@@ -824,6 +824,31 @@ RSpec.describe "Stories::Feeds" do
       response_article = response.parsed_body.find { |item| item["id"] == article.id }
       expect(response_article["feed_config"]).to eq(feed_config.id)
     end
+
+    it "renders configured feed payload using limited_column_select with preloaded comments" do
+      feed_config = create(:feed_config)
+      sign_in user
+      create(:comment, commentable: article, user: user, score: 5)
+      article.update_columns(comments_count: 1)
+
+      allow(Settings::UserExperience).to receive(:feed_strategy).and_return("configured")
+      get stories_feed_path(page: 1, item: feed_config.id)
+
+      expect(response).to have_http_status(:ok)
+      response_article = response.parsed_body.find { |item| item["id"] == article.id }
+      expect(response_article).to include(
+        "id" => article.id,
+        "title" => article.title,
+        "path" => article.path,
+        "comments_count" => 1,
+        "feed_config" => feed_config.id,
+      )
+      expect(response_article["top_comments"]).not_to be_empty
+      expect(response_article["top_comments"].first).to include(
+        "user_id" => user.id,
+        "username" => user.username,
+      )
+    end
   end
 
   describe "public_reaction_categories cache invalidation" do

--- a/spec/services/articles/feeds/custom_spec.rb
+++ b/spec/services/articles/feeds/custom_spec.rb
@@ -649,4 +649,20 @@ RSpec.describe Articles::Feeds::Custom, type: :service do
       end
     end
   end
+
+  describe "performance optimizations" do
+    it "preloads the requested comments_variant to prevent downstream N+1 queries" do
+      result = feed.default_home_feed(comments_variant: "more_inclusive_recent_good_comments")
+      first_article = result.first
+      expect(first_article.association(:more_inclusive_recent_good_comments)).to be_loaded
+    end
+
+    it "uses limited_column_select avoiding heavy text and vector columns" do
+      result = feed.default_home_feed.to_a
+      first_article = result.first
+      expect(first_article.has_attribute?(:title)).to be true
+      expect(first_article.has_attribute?(:body_markdown)).to be false
+      expect(first_article.has_attribute?(:semantic_embedding)).to be false
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR resolves several latency and database bottlenecks in the `/stories/feed` endpoint and its upstream `FeedConfig#score_sql` query generation:

1. **Downstream N+1 Comment Queries**:
   - `Stories::FeedsController` sets `@comments_variant = "more_inclusive_recent_good_comments"`, but `Articles::Feeds::Custom` previously only included `top_comments: :user`. In the JSON view (`app/views/stories/feeds/show.json.jbuilder`), evaluating `article.public_send(@comments_variant.to_sym).first(3)` resulted in an N+1 query for each article with comments.
   - `Articles::Feeds::Custom` now accepts `comments_variant:` and dynamically eager loads `{ comments_variant.to_sym => :user }`.

2. **Eliminate Over-fetching (`articles.*`)**:
   - `Articles::Feeds::Custom` previously chained `.select("articles.*, (#{score_sql_method}) as computed_score").limited_column_select`. Because ActiveRecord `.select` appends column expressions, `articles.*` was retained, transferring heavy unused columns (`body_markdown`, `body_html`, 768-dimension `semantic_embedding`, and `reading_list_document`).
   - All attributes and methods used by the feed view, decorator, and URL generator were audited and confirmed present in `limited_column_select`, and `articles.*` has been removed.

3. **Deferred Upstream DB Queries & Caching**:
   - `FeedConfig#score_sql`: Deferred querying `RecommendedArticlesList` and user languages until their respective weights (`precomputed_selections_weight` / `language_match_weight` && `score_weight`) are positive.
   - `User#cached_languages`: Added 24-hour caching for user languages with immediate cache invalidation via `UserLanguage` `after_commit`.
   - `Stories::FeedsController`: Replaced `limit(rand(15))` with `limit(rand(1..15))` so `limit(0)` fallback cannot trigger.

4. **Composite Database Indexes Hardened for Zero-Downtime Deployment**:
   - Added concurrent composite index on `articles` (`[:published_at, :score]`, `where: "published = true"`).
   - Added concurrent composite index on `recommended_articles_lists` (`[:user_id, :expires_at]`).
   - **Deployment Hardening (Heroku & Neon Postgres)**:
     - Set role-level and session-level statement timeouts to 0 (`ALTER ROLE "<user>" SET statement_timeout = 0;` and `SET statement_timeout = 0;`) inside an `ensure` block to prevent timeout aborts even across connection poolers (PgBouncer in transaction mode).
     - Automated detection and concurrent removal of any invalid indexes (`NOT indisvalid`) left behind by interrupted deploys.
     - DDL transactions disabled (`disable_ddl_transaction!`).

## Added/updated tests?

- [x] Yes
- Regression specs added for `FeedConfig` zero-query deferral, `Articles::Feeds::Custom` preloading and column exclusion, `UserLanguage` caching/invalidation, and full end-to-end `/stories/feed` JSON rendering.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791041505&installation_model_id=424141&pr_number=23804&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23804&signature=a6ee8dc8df2cb228e0556eb3569ef75ad1acf4e8ee5b91eaebfd482a7edccd47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->