### PR TITLE
Limit feed pagination to max page 100 and normalize search throttle path

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -80,6 +80,12 @@ class SearchController < ApplicationController
 
   # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
   def feed_content
+    requested_page = (feed_params[:page] || params[:page]).to_i
+    if requested_page >= Homepage::ArticlesQuery::MAX_PAGE
+      render json: { result: [] }
+      return
+    end
+
     class_name = feed_params[:class_name].to_s.inquiry
 
     is_homepage_search = (

--- a/app/queries/homepage/articles_query.rb
+++ b/app/queries/homepage/articles_query.rb
@@ -20,6 +20,8 @@ module Homepage
     ].freeze
     DEFAULT_PER_PAGE = 60
     MAX_PER_PAGE = 100
+    MAX_PAGE = 100
+    MAX_OFFSET = 10_000
 
     SORT_PARAMS = %i[hotness_score public_reactions_count published_at].freeze
     DEFAULT_SORT_DIRECTION = :desc
@@ -59,6 +61,8 @@ module Homepage
     end
 
     def call
+      return Article.none if beyond_max_offset?
+
       filter.merge(sort).merge(paginate)
     end
 
@@ -90,6 +94,10 @@ module Homepage
 
     def paginate
       relation.page(page).per(per_page)
+    end
+
+    def beyond_max_offset?
+      page > MAX_PAGE || ((page - 1) * per_page) >= MAX_OFFSET
     end
   end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -112,7 +112,7 @@ module Rack
     end
 
     throttle("search_feed_content_throttle", limit: 10, period: 1.minute) do |request|
-      if request.path == "/search/feed_content"
+      if request.path.chomp("/") == "/search/feed_content"
         request.track_and_return_ip
       end
     end

--- a/spec/initializers/rack_attack_spec.rb
+++ b/spec/initializers/rack_attack_spec.rb
@@ -71,6 +71,24 @@ describe Rack, ".attack", throttle: true, type: :request do
         expect(new_ip_response).not_to eq(429)
       end
     end
+
+    it "throttles /search/feed_content/ with trailing slash" do
+      Timecop.freeze do
+        start_time = Time.current.beginning_of_minute
+        params = { feed_params: { class_name: "Article", sort_by: "hotness_score" } }
+        headers = { "HTTP_FASTLY_CLIENT_IP" => "5.6.7.8" }
+
+        valid_responses = (1..10).map do |i|
+          Timecop.travel(start_time + i.seconds)
+          get "/search/feed_content/", params: params, headers: headers
+        end
+        Timecop.travel(start_time + 11.seconds)
+        throttled_response = get "/search/feed_content/", params: params, headers: headers
+
+        valid_responses.each { |r| expect(r).not_to eq(429) }
+        expect(throttled_response).to eq(429)
+      end
+    end
   end
 
   describe "api_throttle" do

--- a/spec/queries/homepage/articles_query_spec.rb
+++ b/spec/queries/homepage/articles_query_spec.rb
@@ -187,6 +187,18 @@ RSpec.describe Homepage::ArticlesQuery, type: :query do
 
         expect(described_class.call(page: 1, per_page: 1).size).to eq(1)
       end
+
+      it "returns an empty relation when page exceeds MAX_PAGE" do
+        create(:article)
+
+        expect(described_class.call(page: Homepage::ArticlesQuery::MAX_PAGE)).to be_empty
+      end
+
+      it "returns an empty relation when offset exceeds MAX_OFFSET" do
+        create(:article)
+
+        expect(described_class.call(page: 101, per_page: 100)).to be_empty
+      end
     end
 
     describe "sorting" do

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -60,6 +60,18 @@ RSpec.describe "Search", :proper_status do
       expect(response.parsed_body["result"]).to be_present
     end
 
+    it "returns empty result without querying articles when page exceeds MAX_PAGE" do
+      create(:article)
+      allow(Homepage::FetchArticles).to receive(:call)
+      allow(Search::Article).to receive(:search_documents)
+
+      get search_feed_content_path(homepage_params.merge(page: 100))
+
+      expect(response.parsed_body["result"]).to eq([])
+      expect(Homepage::FetchArticles).not_to have_received(:call)
+      expect(Search::Article).not_to have_received(:search_documents)
+    end
+
     it "parses published_at correctly", :aggregate_failures do
       article = create(:article)
       get search_feed_content_path(homepage_params.merge(published_at: { gte: article.published_at.iso8601 }))


### PR DESCRIPTION
## What does this PR do?

1. **Max Page / Offset Boundary**:
   - Caps `Homepage::ArticlesQuery` at `MAX_PAGE = 100` and `MAX_OFFSET = 10_000`, returning `Article.none` immediately when exceeded.
   - Adds an early return in `SearchController#feed_content` returning `{ result: [] }` when `page >= 100`, completely bypassing downstream services, serializers, tag flare fetching, and SQL queries.
   - Mitigates deep scraper queries (e.g. `page: 4068` generating `OFFSET 406800` with reaction joins) that degrade database performance.

2. **Rate Limiting Path Normalization**:
   - Updates `search_feed_content_throttle` in `Rack::Attack` to match `request.path.chomp("/") == "/search/feed_content"` so requests with trailing slashes (`/search/feed_content/`) do not bypass the per-minute IP rate limit.

## How was this tested?
- `spec/queries/homepage/articles_query_spec.rb`
- `spec/requests/search_spec.rb`
- `spec/initializers/rack_attack_spec.rb`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791049100&installation_model_id=424141&pr_number=23808&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23808&signature=5b23b0031eb25faafaf15079a7e38779379050c4588f370c32c9da7148859626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->