### PR TITLE
Add dark mode compatibility for live event chat (YouTube and Twitch)

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -75,6 +75,51 @@
               <iframe id="chat-frame" width="100%" height="100%" src="<%= chat_url %>" frameborder="0" title="Event Chat" loading="lazy">
               </iframe>
           </div>
+          <script>
+            (function() {
+              const chatFrame = document.getElementById("chat-frame");
+              if (!chatFrame) return;
+
+              function isDark() {
+                return document.body.classList.contains("dark-theme") ||
+                  (localStorage.getItem("config_body_class") || "").includes("dark-theme");
+              }
+
+              function applyThemeToChatUrl() {
+                try {
+                  const url = new URL(chatFrame.src);
+                  const dark = isDark();
+
+                  if (url.hostname.includes("youtube.com")) {
+                    if (dark) {
+                      url.searchParams.set("dark_theme", "1");
+                    } else {
+                      url.searchParams.delete("dark_theme");
+                    }
+                  } else if (url.hostname.includes("twitch.tv")) {
+                    if (dark) {
+                      url.searchParams.set("darkpopout", "");
+                    } else {
+                      url.searchParams.delete("darkpopout");
+                    }
+                  }
+
+                  if (url.toString() !== chatFrame.src) {
+                    chatFrame.src = url.toString();
+                  }
+                } catch (e) {
+                  // ignore invalid URLs
+                }
+              }
+
+              applyThemeToChatUrl();
+
+              const observer = new MutationObserver(function() {
+                applyThemeToChatUrl();
+              });
+              observer.observe(document.body, { attributes: true, attributeFilter: ["class"] });
+            })();
+          </script>
         <% end %>
     </div>
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -52,6 +52,19 @@ RSpec.describe "Events" do
         end
       end
 
+      context "when the event has chat_url data" do
+        it "renders the chat iframe and dark mode synchronization script" do
+          published_event.update!(data: { "chat_url" => "https://www.youtube.com/live_chat?v=12345" })
+
+          get event_path(published_event.event_name_slug, published_event.event_variation_slug)
+
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include("id=\"chat-frame\"")
+          expect(response.body).to include("dark_theme")
+          expect(response.body).to include("darkpopout")
+        end
+      end
+
       context "when the event has associated articles via tags" do
         let(:tag) { create(:tag, name: "awstest") }
         let(:article) { create(:article, title: "A Custom Event Article", tag_list: tag.name, published: true) }


### PR DESCRIPTION
## Description
Live event chat iframes (embedded via YouTube or Twitch) previously did not adapt to the user's theme selection on Forem, appearing in bright white light mode even when viewing the page with dark theme enabled. Statically hardcoding query params into `chat_url` in the database does not adapt to dynamic theme toggling or individual user preferences.

This change dynamically sets theme parameters on `#chat-frame`:
- **YouTube**: Sets `&dark_theme=1` when dark theme is enabled; removes it for light mode.
- **Twitch**: Sets `&darkpopout` when dark theme is enabled; removes it for light mode.
- Uses `MutationObserver` on `document.body` class changes to immediately synchronize the chat iframe if the user toggles dark/light theme while on the page.

## Testing
- Added regression tests in `spec/requests/events_spec.rb` verifying that event show pages with `chat_url` properly render the chat iframe and dark mode synchronization logic.
- Ran test suite: `bin/bundle exec rspec spec/requests/events_spec.rb` (14 examples, 0 failures).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791053555&installation_model_id=424141&pr_number=23810&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23810&signature=c13c59a29bdfd2d68a33159fb41f209bdda6c5bfcc11777b8c0879e0cc156259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->