### PR TITLE
Add beta_testing survey type with custom subject and email copy

### DIFF
--- a/app/mailers/survey_mailer.rb
+++ b/app/mailers/survey_mailer.rb
@@ -13,6 +13,9 @@ class SurveyMailer < ApplicationMailer
     elsif @survey.fun?
       subject = "A quick, fun survey from #{@community_name}!"
       survey_type = "fun"
+    elsif @survey.beta_testing?
+      subject = "You've been randomly selected for a beta testing survey"
+      survey_type = "beta_testing"
     else
       subject = "You've been randomly selected for a #{@community_name} Pulse Survey"
       survey_type = "pulse"
@@ -28,7 +31,7 @@ class SurveyMailer < ApplicationMailer
         "extra_email_context_paragraph" => @survey.extra_email_context_paragraph.presence,
         "extra_email_context_paragraph_html" => @extra_email_context_html,
         "extra_email_context_html" => @extra_email_context_html,
-        "subject" => subject,
+        "subject" => subject
       },
     )
 

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -13,7 +13,7 @@ class Survey < ApplicationRecord
   has_many :poll_votes, through: :polls
   has_many :survey_completions, dependent: :destroy
   
-  enum :type_of, { community_pulse: 0, industry: 1, fun: 2 }
+  enum :type_of, { community_pulse: 0, industry: 1, fun: 2, beta_testing: 3 }
 
   accepts_nested_attributes_for :polls, allow_destroy: true
   validates_associated :polls

--- a/app/views/mailers/survey_mailer/pulse_survey.html.erb
+++ b/app/views/mailers/survey_mailer/pulse_survey.html.erb
@@ -4,6 +4,8 @@
   <p>We invite you to participate in a <%= @community_name %> Industry Survey.</p>
 <% elsif @survey.fun? %>
   <p>We invite you to participate in a quick, fun survey from <%= @community_name %>.</p>
+<% elsif @survey.beta_testing? %>
+  <p>You have been randomly selected to participate in a beta testing survey.</p>
 <% else %>
   <p>You have been randomly selected to participate in a <%= @community_name %> Pulse Survey.</p>
 <% end %>
@@ -19,6 +21,8 @@
                   "Take the #{@community_name} Industry Survey"
                 elsif @survey.fun?
                   "Take this quick #{@community_name} Survey"
+                elsif @survey.beta_testing?
+                  "Take the Beta Testing Survey"
                 else
                   "Take the #{@community_name} Pulse Survey"
                 end %>

--- a/spec/mailers/survey_mailer_spec.rb
+++ b/spec/mailers/survey_mailer_spec.rb
@@ -54,6 +54,22 @@ RSpec.describe SurveyMailer, type: :mailer do
       end
     end
 
+    context "when survey is beta_testing" do
+      let(:survey) do
+        create(:survey, title: "Beta Survey", type_of: :beta_testing, extra_email_context_paragraph: "Beta details.")
+      end
+
+      it "renders the headers" do
+        expect(mail.subject).to eq("You've been randomly selected for a beta testing survey")
+      end
+
+      it "renders the body with link to survey" do
+        expect(mail.body.encoded).to include("Take the Beta Testing Survey")
+        expect(mail.body.encoded).to include("Beta details.")
+        expect(mail.body.encoded).to include("randomly selected to participate in a beta testing survey.")
+      end
+    end
+
     context "when survey has HTML in extra_email_context_paragraph" do
       let(:survey) do
         create(:survey,
@@ -150,6 +166,25 @@ RSpec.describe SurveyMailer, type: :mailer do
         settings = mail.message.delivery_method.settings
 
         expect(settings[:message_data]["survey_type"]).to eq("fun")
+      end
+    end
+
+    context "when routed through Customer.io with a beta_testing survey" do
+      let(:survey) { create(:survey, title: "Beta Survey", type_of: :beta_testing) }
+
+      before do
+        allow(ApplicationConfig).to receive(:[]).and_call_original
+        allow(ApplicationConfig).to receive(:[]).with("CUSTOMERIO_APP_KEY").and_return("app-key")
+        FeatureFlag.enable(Deliverable::CUSTOMERIO_FLAG, FeatureFlag::Actor[user])
+      end
+
+      after { FeatureFlag.remove(Deliverable::CUSTOMERIO_FLAG) }
+
+      it "sends the beta_testing survey type and subject" do
+        settings = mail.message.delivery_method.settings
+
+        expect(settings[:message_data]["survey_type"]).to eq("beta_testing")
+        expect(settings[:message_data]["subject"]).to eq("You've been randomly selected for a beta testing survey")
       end
     end
   end

--- a/swagger/v1/api_v1.json
+++ b/swagger/v1/api_v1.json
@@ -7320,7 +7320,8 @@
             "enum": [
               "community_pulse",
               "industry",
-              "fun"
+              "fun",
+              "beta_testing"
             ],
             "description": "Survey category"
           },
@@ -7418,7 +7419,8 @@
                 "enum": [
                   "community_pulse",
                   "industry",
-                  "fun"
+                  "fun",
+                  "beta_testing"
                 ],
                 "description": "Survey category"
               },
@@ -7427,7 +7429,8 @@
                 "enum": [
                   "community_pulse",
                   "industry",
-                  "fun"
+                  "fun",
+                  "beta_testing"
                 ],
                 "description": "Survey category (alias of survey_type_of)"
               },


### PR DESCRIPTION
## What does this PR do?

Adds a new survey type `beta_testing` to surveys, tailored for beta testing feedback.

### Key Changes
1. **Model**:
   - Added `beta_testing: 3` to `Survey.type_of` enum.
2. **Mailer & View**:
   - In `SurveyMailer#pulse_survey`, set subject to `"You've been randomly selected for a beta testing survey"` and `survey_type` to `"beta_testing"`.
   - In `pulse_survey.html.erb`, render beta testing invitation copy (*"You have been randomly selected to participate in a beta testing survey."*) and CTA (*"Take the Beta Testing Survey"*).
3. **OpenAPI Schema**:
   - Updated `swagger/v1/api_v1.json` via `bundle exec rake rswag:specs:swaggerize` to include `beta_testing` in the `survey_type_of` enum schema.
4. **Testing**:
   - Added regression specs in `spec/mailers/survey_mailer_spec.rb` verifying header, body copy, and Customer.io `message_data` payload.

## How has this been tested?
- `bundle exec rspec spec/mailers/survey_mailer_spec.rb`
- `bundle exec rspec spec/models/survey_spec.rb`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791053625&installation_model_id=424141&pr_number=23811&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23811&signature=5493770ff2030b80d7d4f1b67d3ae1e0f9c77391780c564dff230b18d6a1516f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->