### PR TITLE
Grant unlimited gems to admin curators

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -21,7 +21,7 @@ class FavoritesController < ApplicationController
       current_user.reload
       render json: {
         success: true,
-        remaining_allowance: current_user.favorite_allowance
+        remaining_allowance: current_user.favorite_allowance_for_client
       }, status: :ok
     else
       render_favorite_error(result.error)

--- a/app/controllers/leadership_dashboards_controller.rb
+++ b/app/controllers/leadership_dashboards_controller.rb
@@ -9,7 +9,8 @@ class LeadershipDashboardsController < ApplicationController
     return head :not_found unless current_user.community_leader?
 
     @section = SECTIONS.include?(params[:section]) ? params[:section] : "community"
-    @favorite_allowance = current_user.favorite_allowance
+    @unlimited_favorites = current_user.unlimited_favorites?
+    @favorite_allowance = current_user.favorite_allowance_for_client
 
     if @section == "yours"
       @favorited = Favorites::Fetch.call(user: current_user, page: params[:page])

--- a/app/helpers/favorites_helper.rb
+++ b/app/helpers/favorites_helper.rb
@@ -90,6 +90,7 @@ module FavoritesHelper
         modal_remaining_zero: t("favorites.modal.remaining_zero"),
         modal_remaining_one: t("favorites.modal.remaining_one"),
         modal_remaining_other: t("favorites.modal.remaining_other"),
+        modal_remaining_unlimited: t("favorites.modal.remaining_unlimited"),
         modal_close: t("favorites.modal.close"),
         modal_exhausted_title: t("favorites.modal_exhausted.title"),
         modal_exhausted_body: t("favorites.modal_exhausted.body"),

--- a/app/javascript/favoriteControl/FavoriteControl.jsx
+++ b/app/javascript/favoriteControl/FavoriteControl.jsx
@@ -97,6 +97,7 @@ export const FavoriteControl = ({
   modalRemainingZero = 'You have no more gems left to give out today.',
   modalRemainingOne = 'You have 1 more gem left to give out today.',
   modalRemainingOther = 'You have %{count} more gems left to give out today.',
+  modalRemainingUnlimited = 'You have unlimited gems to give out.',
   modalClose = 'Got it',
   modalExhaustedTitle = 'Out of Gems',
   modalExhaustedBody = 'You have no more gems left to give out today. Your allowance will refresh soon!',
@@ -122,14 +123,17 @@ export const FavoriteControl = ({
       return null;
     }
 
-    let remainingText = modalRemainingOther.replace(
-      '%{count}',
-      String(remainingAllowance ?? 0),
-    );
+    // A null allowance means the curator is not metered.
+    let remainingText = modalRemainingUnlimited;
     if (remainingAllowance === 1) {
       remainingText = modalRemainingOne;
     } else if (remainingAllowance === 0) {
       remainingText = modalRemainingZero;
+    } else if (remainingAllowance != null) {
+      remainingText = modalRemainingOther.replace(
+        '%{count}',
+        String(remainingAllowance),
+      );
     }
 
     return (
@@ -283,10 +287,11 @@ export const FavoriteControl = ({
       if (response.ok) {
         const data = await response.json().catch(() => ({}));
         const remaining =
-          data.remaining_allowance ??
-          (currentUser?.favorite_allowance != null
-            ? Math.max(0, currentUser.favorite_allowance - 1)
-            : 0);
+          data.remaining_allowance !== undefined
+            ? data.remaining_allowance
+            : currentUser?.favorite_allowance != null
+              ? Math.max(0, currentUser.favorite_allowance - 1)
+              : null;
         setFavorited(true);
         setFavoritedById(userId);
         setRemainingAllowance(remaining);

--- a/app/javascript/favoriteControl/__tests__/FavoriteControl.test.jsx
+++ b/app/javascript/favoriteControl/__tests__/FavoriteControl.test.jsx
@@ -147,6 +147,46 @@ describe('<FavoriteControl />', () => {
       expect(await findByText('You have no more gems left to give out today.')).toBeInTheDocument();
     });
 
+    it('shows an unlimited allowance when the API reports a null remaining allowance', async () => {
+      makeFavorite.mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, remaining_allowance: null }),
+      });
+      const { getByLabelText, findByText } = renderControl({
+        currentUser: {
+          id: CURRENT_USER_ID,
+          favorite_allowance: null,
+          community_leader: true,
+        },
+      });
+
+      fireEvent.click(getByLabelText('Pick as gem'));
+
+      expect(
+        await findByText('You have unlimited gems to give out.'),
+      ).toBeInTheDocument();
+    });
+
+    it('lets an unmetered curator favorite instead of showing the out of gems modal', async () => {
+      makeFavorite.mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, remaining_allowance: null }),
+      });
+      const { getByLabelText, findByLabelText, queryByText } = renderControl({
+        currentUser: {
+          id: CURRENT_USER_ID,
+          favorite_allowance: null,
+          community_leader: true,
+        },
+      });
+
+      fireEvent.click(getByLabelText('Pick as gem'));
+
+      expect(makeFavorite).toHaveBeenCalled();
+      expect(await findByLabelText('Picked as gem by you')).toBeInTheDocument();
+      expect(queryByText('Out of Gems')).toBeNull();
+    });
+
     it('shows the out of gems modal when a community leader with 0 gems attempts to favorite', async () => {
       const { getByLabelText, getByText, findByText, queryByText } = renderControl({
         currentUser: { id: CURRENT_USER_ID, favorite_allowance: 0, community_leader: true },

--- a/app/javascript/packs/favoriteControls.jsx
+++ b/app/javascript/packs/favoriteControls.jsx
@@ -27,6 +27,7 @@ function initializeFavoriteControls(currentUser) {
       modalRemainingZero,
       modalRemainingOne,
       modalRemainingOther,
+      modalRemainingUnlimited,
       modalClose,
       modalExhaustedTitle,
       modalExhaustedBody,
@@ -50,6 +51,7 @@ function initializeFavoriteControls(currentUser) {
         modalRemainingZero={modalRemainingZero}
         modalRemainingOne={modalRemainingOne}
         modalRemainingOther={modalRemainingOther}
+        modalRemainingUnlimited={modalRemainingUnlimited}
         modalClose={modalClose}
         modalExhaustedTitle={modalExhaustedTitle}
         modalExhaustedBody={modalExhaustedBody}

--- a/app/models/async_info.rb
+++ b/app/models/async_info.rb
@@ -46,7 +46,7 @@ class AsyncInfo
       display_announcements: user.display_announcements,
       trusted: user.trusted?,
       community_leader: user.community_leader?,
-      favorite_allowance: user.favorite_allowance,
+      favorite_allowance: user.favorite_allowance_for_client,
       moderator_for_tags: user.moderator_for_tags,
       moderator_for_subforems: user.moderator_for_subforems,
       config_body_class: user.config_body_class,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -643,7 +643,16 @@ class User < ApplicationRecord
   #
   ##############################################################################
 
+  # Admins who curate alongside the community are not metered, so they can keep
+  # picking gems past the community leader allowance.
+  #
+  # @return [Boolean]
+  def unlimited_favorites?
+    any_admin? && community_leader?
+  end
+
   def favorite_base_allowance
+    return Float::INFINITY if unlimited_favorites?
     return Settings::UserExperience.community_leader_l2_favorite_allowance if community_leader_level_2?
     return Settings::UserExperience.community_leader_l1_favorite_allowance if community_leader_level_1?
 
@@ -652,8 +661,9 @@ class User < ApplicationRecord
 
   # How many favorites the user can make.
   #
-  # @return [Integer]
+  # @return [Integer, Float] Float::INFINITY when the user is not metered
   def favorite_allowance
+    return Float::INFINITY if unlimited_favorites?
     return earned_favorites_count unless community_leader?
 
     # Community leader allowances refresh over the configured period
@@ -662,6 +672,15 @@ class User < ApplicationRecord
       favorited_comments.where(favorited_at: window_start..).count
 
     favorite_base_allowance - spent_this_period
+  end
+
+  # The remaining allowance as exposed to the client, where `nil` signals an
+  # unlimited allowance so the front end can skip the counter.
+  #
+  # @return [Integer, nil]
+  def favorite_allowance_for_client
+    allowance = favorite_allowance
+    allowance.finite? ? allowance : nil
   end
 
   # The name of the tags moderated by the user.

--- a/app/services/favorites/create.rb
+++ b/app/services/favorites/create.rb
@@ -71,6 +71,8 @@ module Favorites
     # made, and updates it for regular users.
     # Returns true on valid and successful spend, or false otherwise.
     def can_afford_claim?
+      # Unmetered curators never spend from an allowance, so skip the row lock.
+      return true if user.unlimited_favorites?
       return spend_earned_favorite == 1 unless user.community_leader?
 
       # For community leaders, lock to serialize the allowance check for the

--- a/app/views/leadership_dashboards/_sidebar.html.erb
+++ b/app/views/leadership_dashboards/_sidebar.html.erb
@@ -8,10 +8,14 @@
       <h2 class="fs-base fw-bold m-0"><%= t("views.leadership.icon.leader_alt") %></h2>
     </div>
     <p class="fs-s mb-2">
-      <%= t("views.leadership.allowance.remaining_html", count: @favorite_allowance).html_safe %>
+      <% if @unlimited_favorites %>
+        <%= t("views.leadership.allowance.unlimited_html").html_safe %>
+      <% else %>
+        <%= t("views.leadership.allowance.remaining_html", count: @favorite_allowance).html_safe %>
+      <% end %>
     </p>
     <p class="fs-xs color-base-60 m-0">
-      <%= t("views.leadership.allowance.replenish_note") %>
+      <%= @unlimited_favorites ? t("views.leadership.allowance.unlimited_note") : t("views.leadership.allowance.replenish_note") %>
     </p>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,7 @@ en:
       remaining_zero: You have no more gems left to give out today.
       remaining_one: You have 1 more gem left to give out today.
       remaining_other: You have %{count} more gems left to give out today.
+      remaining_unlimited: You have unlimited gems to give out.
       close: Got it
     modal_exhausted:
       title: Out of Gems

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -17,6 +17,7 @@ fr:
       remaining_zero: Vous n'avez plus de pépites à distribuer aujourd'hui.
       remaining_one: Il vous reste 1 pépite à distribuer aujourd'hui.
       remaining_other: Il vous reste %{count} pépites à distribuer aujourd'hui.
+      remaining_unlimited: Vous disposez de pépites illimitées à distribuer.
       close: Compris
     modal_exhausted:
       title: Plus de pépites

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -17,6 +17,7 @@ pt:
       remaining_zero: Você não tem mais joias para distribuir hoje.
       remaining_one: Você tem mais 1 joia para distribuir hoje.
       remaining_other: Você tem mais %{count} joias para distribuir hoje.
+      remaining_unlimited: Você tem joias ilimitadas para distribuir.
       close: Entendi
     modal_exhausted:
       title: Sem joias restantes

--- a/config/locales/views/leadership/en.yml
+++ b/config/locales/views/leadership/en.yml
@@ -12,6 +12,8 @@ en:
       allowance:
         remaining_html: "You have <strong class=\"color-base-100\">%{count}</strong> gem picks remaining."
         replenish_note: "Gems replenish as your picks generate community impact and meaningful discussions."
+        unlimited_html: "You have <strong class=\"color-base-100\">unlimited</strong> gem picks."
+        unlimited_note: "As an admin curator, your gem picks are never metered."
       explainer:
         heading: How Curation Works
         human_touch_title: The Power of Human Curation

--- a/config/locales/views/leadership/fr.yml
+++ b/config/locales/views/leadership/fr.yml
@@ -12,6 +12,8 @@ fr:
       allowance:
         remaining_html: "Il vous reste <strong class=\"color-base-100\">%{count}</strong> pépites à attribuer."
         replenish_note: "Vos pépites se renouvellent au fur et à mesure que vos sélections génèrent de l'engagement et des échanges de qualité."
+        unlimited_html: "Vous disposez de pépites <strong class=\"color-base-100\">illimitées</strong> à attribuer."
+        unlimited_note: "En tant qu'administrateur curateur, vos pépites ne sont jamais limitées."
       explainer:
         heading: Comment fonctionne la curation
         human_touch_title: L'importance de la curation humaine

--- a/config/locales/views/leadership/pt.yml
+++ b/config/locales/views/leadership/pt.yml
@@ -13,6 +13,8 @@ pt:
       allowance:
         remaining_html: "Você tem <strong class=\"color-base-100\">%{count}</strong> joias restantes para escolher."
         replenish_note: "Suas joias se renovam conforme suas escolhas geram impacto e discussões de qualidade na comunidade."
+        unlimited_html: "Você tem joias <strong class=\"color-base-100\">ilimitadas</strong> para escolher."
+        unlimited_note: "Como curador administrador, suas joias nunca são limitadas."
       explainer:
         heading: Como funciona a curadoria
         human_touch_title: O poder da curadoria humana

--- a/spec/models/async_info_spec.rb
+++ b/spec/models/async_info_spec.rb
@@ -39,6 +39,13 @@ RSpec.describe AsyncInfo do
       expect(described_class.to_hash(user: user, context: context)[:favorite_allowance]).to eq(3)
     end
 
+    it "sends a nil favorite allowance for an admin curator" do
+      user.add_role(:admin)
+      user.add_role(:community_leader_level_1)
+
+      expect(described_class.to_hash(user: user, context: context)[:favorite_allowance]).to be_nil
+    end
+
     it "includes a list of admin_organization_ids for the current user" do
       org = create(:organization)
       create(:organization_membership, user: user, organization: org, type_of_user: "admin")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1810,9 +1810,32 @@ RSpec.describe User do
     end
   end
 
+  describe "#unlimited_favorites?" do
+    it "is true for an admin who curates" do
+      expect(create(:user, :admin, :community_leader_level_1)).to be_unlimited_favorites
+    end
+
+    it "is true for a super admin who curates" do
+      expect(create(:user, :super_admin, :community_leader_level_2)).to be_unlimited_favorites
+    end
+
+    it "is false for an admin who does not curate" do
+      expect(create(:user, :admin)).not_to be_unlimited_favorites
+    end
+
+    it "is false for a curator who is not an admin" do
+      expect(create(:user, :community_leader_level_1)).not_to be_unlimited_favorites
+    end
+  end
+
   describe "#favorite_base_allowance" do
     it "is 0 for a non-leader" do
       expect(create(:user).favorite_base_allowance).to eq(0)
+    end
+
+    it "is infinite for an admin curator" do
+      expect(create(:user, :admin, :community_leader_level_1).favorite_base_allowance)
+        .to eq(Float::INFINITY)
     end
 
     it "uses the level 1 setting for a level 1 leader" do
@@ -1856,6 +1879,30 @@ RSpec.describe User do
       create(:article, favorited_by_user: leader, favorited_at: 2.days.ago)
 
       expect(leader.favorite_allowance).to eq(5)
+    end
+
+    it "is infinite for an admin curator, no matter what they have spent" do
+      allow(Settings::UserExperience).to receive_messages(
+        community_leader_l1_favorite_allowance: 1, community_leader_favorite_refresh_hours: 24,
+      )
+      admin_curator = create(:user, :admin, :community_leader_level_1)
+      create(:article, favorited_by_user: admin_curator, favorited_at: 1.hour.ago)
+
+      expect(admin_curator.favorite_allowance).to eq(Float::INFINITY)
+    end
+  end
+
+  describe "#favorite_allowance_for_client" do
+    it "returns the numeric allowance for a metered user" do
+      user = create(:user, earned_favorites_count: 2)
+
+      expect(user.favorite_allowance_for_client).to eq(2)
+    end
+
+    it "returns nil for an admin curator" do
+      admin_curator = create(:user, :admin, :community_leader_level_1)
+
+      expect(admin_curator.favorite_allowance_for_client).to be_nil
     end
   end
 end

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -56,6 +56,25 @@ RSpec.describe "Favorites" do
       end
     end
 
+    context "when signed in as an admin curator" do
+      let(:admin_curator) { create(:user, :admin, :community_leader_level_1) }
+
+      before do
+        allow(Settings::UserExperience)
+          .to receive(:community_leader_l1_favorite_allowance).and_return(0)
+        sign_in admin_curator
+      end
+
+      it "favorites past the leader allowance and reports an unlimited balance" do
+        post favorites_path, params: { favoritable_type: "Article", favoritable_id: article.id }, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["success"]).to be(true)
+        expect(response.parsed_body["remaining_allowance"]).to be_nil
+        expect(article.reload.favorited_by_user_id).to eq(admin_curator.id)
+      end
+    end
+
     context "when signed in as a non-leader with no earned credits" do
       before { sign_in create(:user) }
 

--- a/spec/requests/leadership_dashboards_spec.rb
+++ b/spec/requests/leadership_dashboards_spec.rb
@@ -68,6 +68,20 @@ RSpec.describe "Curation dashboard" do
       end
     end
 
+    context "when signed in as an admin curator" do
+      let(:admin_curator) { create(:user, :admin, :community_leader_level_1) }
+
+      before { sign_in admin_curator }
+
+      it "renders unlimited gem picks allowance text" do
+        get curation_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(I18n.t("views.leadership.allowance.unlimited_html"))
+        expect(response.body).to include(I18n.t("views.leadership.allowance.unlimited_note"))
+      end
+    end
+
     context "when signed in as a non-leader" do
       it "returns 404" do
         sign_in create(:user)

--- a/spec/services/favorites/create_spec.rb
+++ b/spec/services/favorites/create_spec.rb
@@ -117,6 +117,33 @@ RSpec.describe Favorites::Create, type: :service do
     end
   end
 
+  describe "favoriting by admin curators" do
+    let(:admin_curator) { create(:user, :admin, :community_leader_level_1) }
+
+    before do
+      allow(Settings::UserExperience)
+        .to receive(:community_leader_l1_favorite_allowance).and_return(1)
+    end
+
+    it "keeps favoriting past the leader budget" do
+      described_class.call(favoritable: create(:article, user: author), user: admin_curator)
+
+      result = described_class.call(favoritable: article, user: admin_curator)
+
+      expect(result.success?).to be true
+      expect(article.reload.favorited_by_user_id).to eq(admin_curator.id)
+    end
+
+    it "leaves an admin who does not curate metered" do
+      admin = create(:user, :admin)
+
+      result = described_class.call(favoritable: article, user: admin)
+
+      expect(result.error).to eq(:no_allowance)
+      expect(article.reload.favorited_by_user_id).to be_nil
+    end
+  end
+
   describe "favoriting by regular users" do
     it "lets the user spend earned credits" do
       spender = create(:user, earned_favorites_count: 1)


### PR DESCRIPTION
### What does this PR do?

Ensures administrators who are also community curators (`any_admin? && community_leader?`) have unlimited gems (favorite allowance) so they can actively curate articles and comments alongside community leaders without being blocked or constrained by the daily quota.

### Key Changes:
- **Backend Allowance Logic**:
  - Added `User#unlimited_favorites?` (`any_admin? && community_leader?`).
  - Updated `User#favorite_base_allowance` and `User#favorite_allowance` to return `Float::INFINITY` for unmetered curators.
  - Added `User#favorite_allowance_for_client` which returns `nil` for infinite allowances to cleanly serialize to JSON without `Float::INFINITY` issues.
  - Updated `Favorites::Create` to bypass allowance locking and balance subtraction for unmetered curators.
  - Updated `FavoritesController` to return `remaining_allowance: current_user.favorite_allowance_for_client`.
- **Curation Dashboard & Preact Favorite Controls**:
  - Updated `LeadershipDashboardsController` and `_sidebar.html.erb` to display unlimited gem picks text and explanation for admin curators.
  - Updated `FavoriteControl.jsx` and `favoriteControls.jsx` to support unlimited gem messaging and prevent out-of-gems modal triggers for unmetered curators.
- **Internationalization (i18n)**:
  - Added translation keys in `en.yml`, `fr.yml`, and `pt.yml` across `favorites.modal` and `views.leadership.allowance`.
- **Tests**:
  - Unit specs in `spec/models/user_spec.rb` and `spec/models/async_info_spec.rb`.
  - Service spec in `spec/services/favorites/create_spec.rb`.
  - Request specs in `spec/requests/favorites_spec.rb` and `spec/requests/leadership_dashboards_spec.rb`.
  - Frontend component tests in `FavoriteControl.test.jsx`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791055258&installation_model_id=424141&pr_number=23812&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23812&signature=eb49a81528d8300ba2a88bf05c6df678677317a50e5b373f034d785f258e4b8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->