### PR TITLE
Treat favorited (gemmed) articles similarly to featured in signed-out home feed

### DIFF
--- a/app/lib/black_box.rb
+++ b/app/lib/black_box.rb
@@ -12,7 +12,7 @@ class BlackBox
       today_bonus = usable_date > 26.hours.ago ? 795 : 0
       two_day_bonus = usable_date > 48.hours.ago ? 830 : 0
       four_day_bonus = usable_date > 96.hours.ago ? 930 : 0
-      featured_bonus = article.featured ? 200 : 0
+      curation_bonus = calculate_curation_bonus(article)
       if usable_date < 4.days.ago
         reaction_points /= 2 # Older posts should fade
       end
@@ -27,7 +27,7 @@ class BlackBox
 
       (
         article_hotness + reaction_points + recency_bonus + super_recent_bonus +
-        super_super_recent_bonus + today_bonus + two_day_bonus + four_day_bonus + featured_bonus
+        super_super_recent_bonus + today_bonus + two_day_bonus + four_day_bonus + curation_bonus
       )
     end
 
@@ -39,6 +39,12 @@ class BlackBox
     end
 
     private
+
+    def calculate_curation_bonus(article)
+      featured_bonus = article.featured ? 200 : 0
+      favorited_bonus = article.respond_to?(:favorited?) && article.favorited? ? 200 : 0
+      featured_bonus + favorited_bonus
+    end
 
     def calculate_bonus_score(body_markdown)
       size_bonus = body_markdown.size > 200 ? 2 : 0

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -572,12 +572,11 @@ class Article < ApplicationRecord
     end
   }
 
-  # @note This includes the `featured` scope, which may or may not be
-  #       something we expose going forward.  However, it was
-  #       something used in two of the three queries we had that
-  #       included the where `score > Settings::UserExperience.home_feed_minimum_score`
+  # @note This includes the `featured` and `favorited` scopes, which allows
+  #       featured and community favorite (gemmed) articles to bypass the
+  #       home feed minimum score threshold.
   scope :with_at_least_home_feed_minimum_score, lambda {
-    featured.or(
+    featured.or(favorited).or(
       where(score: Settings::UserExperience.home_feed_minimum_score..),
     )
   }

--- a/spec/lib/black_box_spec.rb
+++ b/spec/lib/black_box_spec.rb
@@ -23,6 +23,28 @@ RSpec.describe BlackBox, type: :lib do
       score = described_class.article_hotness_score(article)
       expect(score).to eq(0)
     end
+
+    it "adds a 200 point bonus for featured articles" do
+      now = Time.current
+      article = build_stubbed(:article, score: 99, published_at: now, featured: false)
+      featured_article = build_stubbed(:article, score: 99, published_at: now, featured: true)
+
+      base_score = described_class.article_hotness_score(article)
+      featured_score = described_class.article_hotness_score(featured_article)
+
+      expect(featured_score - base_score).to eq(200)
+    end
+
+    it "adds a 200 point bonus for favorited (gemmed) articles" do
+      now = Time.current
+      article = build_stubbed(:article, score: 99, published_at: now, favorited_by_user_id: nil)
+      favorited_article = build_stubbed(:article, score: 99, published_at: now, favorited_by_user_id: 123)
+
+      base_score = described_class.article_hotness_score(article)
+      favorited_score = described_class.article_hotness_score(favorited_article)
+
+      expect(favorited_score - base_score).to eq(200)
+    end
   end
 
   describe "#comment_quality_score" do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1779,6 +1779,34 @@ RSpec.describe Article do
     end
   end
 
+  describe ".with_at_least_home_feed_minimum_score" do
+    let(:leader) { create(:user, :community_leader_level_1) }
+
+    before do
+      allow(Settings::UserExperience).to receive(:home_feed_minimum_score).and_return(10)
+    end
+
+    it "includes articles with score at or above the minimum score" do
+      article = create(:article, score: 10, featured: false, favorited_by_user: nil)
+      expect(described_class.with_at_least_home_feed_minimum_score).to include(article)
+    end
+
+    it "excludes articles with score below the minimum score when not featured or favorited" do
+      article = create(:article, score: 5, featured: false, favorited_by_user: nil)
+      expect(described_class.with_at_least_home_feed_minimum_score).not_to include(article)
+    end
+
+    it "includes featured articles even if score is below the minimum score" do
+      article = create(:article, score: -5, featured: true, favorited_by_user: nil)
+      expect(described_class.with_at_least_home_feed_minimum_score).to include(article)
+    end
+
+    it "includes favorited (gemmed) articles even if score is below the minimum score" do
+      article = create(:article, score: -5, featured: false, favorited_by_user: leader, favorited_at: Time.current)
+      expect(described_class.with_at_least_home_feed_minimum_score).to include(article)
+    end
+  end
+
   describe ".cached_admin_published_with" do
     let(:admin) { create(:user, :admin) }
     let(:cache_store) { ActiveSupport::Cache::MemoryStore.new }

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -173,6 +173,17 @@ RSpec.describe "StoriesIndex" do
       expect(response.body).not_to include(CGI.escapeHTML(article.title))
     end
 
+    it "renders a favorited (gemmed) article even if below home feed minimum score" do
+      allow(Settings::UserExperience).to receive(:home_feed_minimum_score).and_return(50)
+      favorited_article = create(:article, score: 5, favorited_by_user: create(:user), favorited_at: Time.current)
+      unfavorited_low_score = create(:article, score: 5, featured: false, favorited_by_user: nil)
+
+      get "/"
+
+      expect(response.body).to include(CGI.escapeHTML(favorited_article.title))
+      expect(response.body).not_to include(CGI.escapeHTML(unfavorited_low_score.title))
+    end
+
     def renders_proper_description
       expect(response.body).to include(Settings::Community.community_description)
     end

--- a/spec/services/articles/feeds/large_forem_experimental_spec.rb
+++ b/spec/services/articles/feeds/large_forem_experimental_spec.rb
@@ -29,6 +29,17 @@ RSpec.describe Articles::Feeds::LargeForemExperimental, type: :service do
       expect(stories).to include(min_score_article)
     end
 
+    it "includes favorited articles even if their score is below the home feed minimum score" do
+      favorited_low_score_article = create(:article, score: -100, favorited_by_user: create(:user),
+                                                     favorited_at: Time.current)
+      expect(stories).to include(favorited_low_score_article)
+    end
+
+    it "includes featured articles even if their score is below the home feed minimum score" do
+      featured_low_score_article = create(:article, score: -100, featured: true)
+      expect(stories).to include(featured_low_score_article)
+    end
+
     context "when user logged in" do
       let(:result) { feed.featured_story_and_default_home_feed(user_signed_in: true) }
       let(:featured_story) { result.first }


### PR DESCRIPTION
## What does this PR do?

Treats favorited (gemmed) articles similarly to featured articles on the signed-out home feed:

1. **Home Feed Minimum Score Bypass**: Updates `Article.with_at_least_home_feed_minimum_score` to include `favorited` (`where.not(favorited_by_user_id: nil)`) alongside `featured`. Favorited articles are now included in the signed-out home feed query even if their raw score is below `Settings::UserExperience.home_feed_minimum_score`.
2. **Hotness Score Boost**: Updates `BlackBox.article_hotness_score` to award a +200 bonus for favorited articles (`article.favorited? ? 200 : 0`), mirroring the +200 bonus given to featured articles. Because the signed-out feed is ordered by `hotness_score: :desc`, this boost elevates favorited articles up the feed and qualifies them for the lead featured story slot.

## Tests & Verification

- Added unit tests in `spec/lib/black_box_spec.rb` for the +200 hotness bonus on favorited articles.
- Added scope specs in `spec/models/article_spec.rb` for `.with_at_least_home_feed_minimum_score`.
- Added service specs in `spec/services/articles/feeds/large_forem_experimental_spec.rb` for signed-out feed score bypass.
- Added request specs in `spec/requests/stories_index_spec.rb` verifying a favorited article below minimum score renders on the signed-out homepage (`GET /`).
- All 30 examples pass with 0 failures.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791057494&installation_model_id=424141&pr_number=23813&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23813&signature=516b4f45d47578a1db9e38018f1336a0ac872b32a51d3e3f584a9f3e5b321ba5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->