### PR TITLE
Fix community leader icon alignment in embed context

### DIFF
--- a/app/assets/stylesheets/base/typography.scss
+++ b/app/assets/stylesheets/base/typography.scss
@@ -152,7 +152,8 @@ body {
   }
 
   .ltag__link--embedded,
-  .ltag-org-posts {
+  .ltag-org-posts,
+  .ltag-feed {
     font-size: var(--fs-base);
     font-family: var(--ff-sans-serif);
 
@@ -193,6 +194,16 @@ body {
       max-width: 21px;
       display: inline-block;
       border-radius: 0;
+    }
+
+    img.community-leader-icon {
+      height: 0.95em;
+      max-height: 22px;
+      display: inline-block;
+      vertical-align: middle;
+      margin: 0 0 0.05em;
+      border-radius: 0;
+      aspect-ratio: 1 / 1;
     }
 
     h1,
@@ -409,6 +420,25 @@ body {
     max-width: 100%;
     max-height: calc(50vh + 180px);
     border-radius: var(--radius);
+  }
+
+  img.subscription-icon {
+    max-height: 13px;
+    max-width: 21px;
+    display: inline-block;
+    vertical-align: middle;
+    margin: 0 0 0.05em;
+    border-radius: 0;
+  }
+
+  img.community-leader-icon {
+    height: 0.95em;
+    max-height: 22px;
+    display: inline-block;
+    vertical-align: middle;
+    margin: 0 0 0.05em;
+    border-radius: 0;
+    aspect-ratio: 1 / 1;
   }
 
   .article-body-image-wrapper {

--- a/spec/liquid_tags/link_tag_spec.rb
+++ b/spec/liquid_tags/link_tag_spec.rb
@@ -117,4 +117,23 @@ RSpec.describe LinkTag, type: :liquid_tag do
     liquid = generate_new_liquid(slug: "/#{user.username}/#{escaped_article.slug}/")
     assert_link_tag_renders(liquid.render, escaped_article)
   end
+
+  context "when the article author is a community leader" do
+    let(:leader) { create(:user, :community_leader_level_2) }
+    let(:leader_article) { create(:article, user: leader) }
+
+    before do
+      FeatureFlag.add(:community_favorites)
+      FeatureFlag.enable(:community_favorites)
+    end
+
+    after do
+      FeatureFlag.remove(:community_favorites)
+    end
+
+    it "renders the community leader icon" do
+      liquid = generate_new_liquid(slug: "/#{leader.username}/#{leader_article.slug}")
+      expect(liquid.render).to include(%(class="community-leader-icon"))
+    end
+  end
 end


### PR DESCRIPTION
## What does this PR do?

Fixes the alignment of the community leader / curator icon in embedded article contexts (such as `{% link ... %}` or `{% feed ... %}`). Previously, generic `.text-styles img` markdown rules forced all images to `display: block`, causing the community leader icon to drop down onto a new line below the author's name instead of appearing inline beside it.

## Key Changes
- **Styling (`app/assets/stylesheets/base/typography.scss`)**:
  - Adds `img.community-leader-icon` styling within `.ltag__link--embedded, .ltag-org-posts, .ltag-feed` with `display: inline-block; vertical-align: middle; height: 0.95em; max-height: 22px; aspect-ratio: 1 / 1; border-radius: 0; margin: 0 0 0.05em;` so the icon remains inline beside the user name.
  - Adds `img.community-leader-icon` and `img.subscription-icon` rules directly under `.text-styles` to safeguard inline icon rendering throughout post markdown.
- **Specs (`spec/liquid_tags/link_tag_spec.rb`)**:
  - Adds test coverage verifying that embedded article cards render `class="community-leader-icon"` when the article author is a community leader.

## Verification
- `bundle exec rspec spec/liquid_tags/link_tag_spec.rb` (15 examples, 0 failures)
- `bundle exec rubocop spec/liquid_tags/link_tag_spec.rb` (0 offenses)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791120723&installation_model_id=424141&pr_number=23815&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23815&signature=a3a86b7e1651d05b0b45d83485a9a8764d924a2b5d3472d821efcdc6e4b2e714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->