### PR TITLE
Per-segment feed config pools for new users, with A/B test and nightly page view goal conversion

### DIFF
--- a/app/controllers/admin/feed_configs_controller.rb
+++ b/app/controllers/admin/feed_configs_controller.rb
@@ -59,6 +59,7 @@ module Admin
 
     def feed_config_params
       params.require(:feed_config).permit(
+        :segment,
         :ai_disclosure_matching_weight,
         :autonomous_ai_penalty_weight,
         :clickbait_score_weight,

--- a/app/controllers/stories/feeds_controller.rb
+++ b/app/controllers/stories/feeds_controller.rb
@@ -67,13 +67,8 @@ module Stories
                Articles::Feeds::Basic.new(user: current_user, page: @page, tag: params[:tag])
              elsif feed_strategy == "configured" && params[:type_of] != "following"
 
-               @feed_config = if params[:item]
-                                FeedConfig.find_by(id: params[:item]) || FeedConfig.order("feed_success_score DESC").limit(rand(1..15)).sample || FeedConfig.first_or_create
-                              elsif rand(20) == 0 # 5% of the time, we'll just pick a random feed config
-                                FeedConfig.where("feed_impressions_count < 100").order("RANDOM()").limit(1).first || FeedConfig.order("feed_success_score DESC").limit(rand(1..15)).sample || FeedConfig.first_or_create
-                              else
-                                FeedConfig.order("feed_success_score DESC").limit(rand(1..15)).sample || FeedConfig.first_or_create
-                              end
+               @feed_config = FeedConfig.find_by(id: params[:item]) if params[:item]
+               @feed_config ||= FeedConfig.pick_for(current_user, segmented: segmented_feed_configs?)
                Articles::Feeds::Custom.new(user: current_user, page: @page, tag: params[:tag],
                                            feed_config: @feed_config)
              else
@@ -93,6 +88,15 @@ module Stories
       # ActiveRecord::Relation.  So this is a compromise.
 
       feed.more_comments_minimal_weight_randomized(comments_variant: @comments_variant)
+    end
+
+    # A/B test of per-segment FeedConfig pools. Only new / low-signal users are enrolled,
+    # since the general pool is the same in both arms for everyone else.
+    def segmented_feed_configs?
+      return false unless FeatureFlag.enabled?(:segmented_feed_configs)
+      return false unless FeedConfig.segment_for(current_user) == :new_user
+
+      field_test(:segmented_feed_configs_20260904, participant: current_user) == "segmented"
     end
 
     def signed_out_base_feed

--- a/app/models/feed_config.rb
+++ b/app/models/feed_config.rb
@@ -1,6 +1,42 @@
 class FeedConfig < ApplicationRecord
   has_many :feed_events, dependent: :nullify
 
+  # Each config lives in a pool for one user segment. New and low-signal users have
+  # almost no history for the follow/activity-based weights to act on, so they get
+  # their own pool that is served to, and scored on, only their own behavior.
+  enum :segment, { general: 0, new_user: 1 }
+
+  NEW_USER_TENURE = 14.days
+  TOP_POOL_SIZE = 15
+  EXPLORATION_IMPRESSIONS_THRESHOLD = 100
+
+  def self.segment_for(user)
+    return :general if user.nil?
+    return :new_user if user.registered_at.present? && user.registered_at > NEW_USER_TENURE.ago
+    return :new_user if user.user_activity&.recently_viewed_articles.blank?
+
+    :general
+  end
+
+  # Picks a config from the user's segment pool, falling back to the general pool
+  # when the segment has no configs yet. With segmented: false, every config is one
+  # pool (the pre-segmentation behavior, used as the A/B control).
+  def self.pick_for(user, explore: true, segmented: true)
+    return pick_from(all, explore: explore) || first_or_create unless segmented
+
+    pick_from(where(segment: segment_for(user)), explore: explore) ||
+      pick_from(general, explore: explore) ||
+      first_or_create
+  end
+
+  def self.pick_from(scope, explore:)
+    top = -> { scope.order("feed_success_score DESC").limit(rand(1..TOP_POOL_SIZE)).sample }
+    # 5% of the time, try a config that hasn't had many impressions yet
+    return top.call unless explore && rand(20).zero?
+
+    scope.where("feed_impressions_count < ?", EXPLORATION_IMPRESSIONS_THRESHOLD).order("RANDOM()").first || top.call
+  end
+
   def score_sql(user)
     activity_store = user.user_activity
 
@@ -195,8 +231,9 @@ class FeedConfig < ApplicationRecord
     SQL
   end
 
-  def create_slightly_modified_clone!
+  def create_slightly_modified_clone!(segment: nil)
     clone = dup
+    clone.segment = segment if segment
     clone.comment_recency_weight = comment_recency_weight * rand(0.9..1.1)
     clone.comment_score_weight = comment_score_weight * rand(0.9..1.1)
     clone.feed_success_weight = feed_success_weight * rand(0.9..1.1)

--- a/app/models/feed_event.rb
+++ b/app/models/feed_event.rb
@@ -35,6 +35,12 @@ class FeedEvent < ApplicationRecord
 
   REACTION_SCORE_MULTIPLIER = 6
   COMMENT_SCORE_MULTIPLIER = 12
+  RETENTION_SCORE_MULTIPLIER = 3
+  # Feed configs are scored on a trailing window so the pool tracks current behavior
+  # rather than a config's lifetime.
+  FEED_CONFIG_SCORING_WINDOW = 7.days
+  # A user counts as retained by a config if they act again this long after first seeing it.
+  RETENTION_GAP = 24.hours
 
   validates :article_position, numericality: { only_integer: true, greater_than: 0 }
   validates :context_type, inclusion: { in: VALID_CONTEXT_TYPES }, presence: true
@@ -103,13 +109,15 @@ class FeedEvent < ApplicationRecord
 
   def self.update_single_feed_config_counters(feed_config_id)
     ThrottledCall.perform("feed_config_feed_success_score_#{feed_config_id}", throttle_for: 5.minutes) do
-      impressions = FeedEvent.where(feed_config_id: feed_config_id, category: "impression")
+      window_start = FEED_CONFIG_SCORING_WINDOW.ago
+      events = FeedEvent.where(feed_config_id: feed_config_id).where("created_at >= ?", window_start)
+      impressions = events.where(category: "impression")
       return if impressions.empty?
 
-      clicks = FeedEvent.where(feed_config_id: feed_config_id, category: "click")
-      reactions = FeedEvent.where(feed_config_id: feed_config_id, category: "reaction")
-      comments = FeedEvent.where(feed_config_id: feed_config_id, category: "comment")
-      pageviews = FeedEvent.where(feed_config_id: feed_config_id, category: "extended_pageview")
+      clicks = events.where(category: "click")
+      reactions = events.where(category: "reaction")
+      comments = events.where(category: "comment")
+      pageviews = events.where(category: "extended_pageview")
 
       # Count the distinct users for impressions and each event type
       distinct_impressions_users = impressions.distinct.pluck(:user_id)
@@ -123,12 +131,43 @@ class FeedEvent < ApplicationRecord
       clicks_score = clicks.sum("POWER(2.0/3, article_position - 1)")
       comments_score = distinct_comments_users.size * COMMENT_SCORE_MULTIPLIER * 2
       pageviews_score = distinct_pageviews_users.size # 1x multiplier for extended pageviews
+      retention_score = retained_user_count(feed_config_id, since: window_start) * RETENTION_SCORE_MULTIPLIER
 
-      score = (clicks_score + pageviews_score + reactions_score + comments_score).to_f / distinct_impressions_users.size
-      
+      total = clicks_score + pageviews_score + reactions_score + comments_score + retention_score
+      score = total.to_f / distinct_impressions_users.size
+
       # Update the feed config counters
       FeedConfig.find_by(id: feed_config_id)&.update_columns(feed_success_score: score, feed_impressions_count: impressions.size)
     end
+  end
+
+  # Distinct users who saw this config in the window and then came back and acted
+  # (click, reaction, comment, or extended pageview) at least RETENTION_GAP after their first impression.
+  def self.retained_user_count(feed_config_id, since:)
+    sql = <<~SQL.squish
+      SELECT COUNT(DISTINCT later.user_id)
+      FROM (
+        SELECT user_id, MIN(created_at) AS first_seen
+        FROM feed_events
+        WHERE feed_config_id = :feed_config_id
+          AND category = :impression
+          AND user_id IS NOT NULL
+          AND created_at >= :since
+        GROUP BY user_id
+      ) first_impressions
+      INNER JOIN feed_events later
+        ON later.user_id = first_impressions.user_id
+        AND later.category <> :impression
+        AND later.created_at >= :since
+        AND later.created_at >= first_impressions.first_seen + (:gap_seconds * INTERVAL '1 second')
+    SQL
+    binds = {
+      feed_config_id: feed_config_id,
+      impression: categories[:impression],
+      since: since,
+      gap_seconds: RETENTION_GAP.to_i
+    }
+    connection.select_value(sanitize_sql_array([sql, binds])).to_i
   end
 
   private
@@ -143,7 +182,10 @@ class FeedEvent < ApplicationRecord
     return unless feed_config
     return unless %w[reaction comment].include?(category)
 
-    feed_config.create_slightly_modified_clone!
+    # The clone joins the pool of the user who engaged, so a new user reacting under a
+    # general config seeds the new-user pool.
+    segment = user ? FeedConfig.segment_for(user) : nil
+    feed_config.create_slightly_modified_clone!(segment: segment)
   end
 
   # @see AbExperiment::GoalConversionHandler

--- a/app/services/email_digest_article_collector.rb
+++ b/app/services/email_digest_article_collector.rb
@@ -153,7 +153,9 @@ class EmailDigestArticleCollector
   # rubocop:enable Metrics/PerceivedComplexity
 
   def personalized_articles
-    feed_config = FeedConfig.order(feed_success_score: :desc).limit(15).to_a.sample || FeedConfig.first_or_create
+    # Unsegmented until the segmented_feed_configs experiment concludes, so the digest
+    # doesn't leak the treatment into the control arm.
+    feed_config = FeedConfig.pick_for(@user, explore: false, segmented: false)
     return unless feed_config
 
     set_subforem_context

--- a/app/views/admin/feed_configs/_form.html.erb
+++ b/app/views/admin/feed_configs/_form.html.erb
@@ -1,5 +1,14 @@
 <div class="flex flex-col gap-6">
   <fieldset class="border p-4 rounded-md">
+    <legend class="fw-bold px-2 text-base color-base-90">🎯 Segment</legend>
+    <div class="crayons-field mt-2">
+      <%= f.label :segment, "User Segment", class: "crayons-field__label" %>
+      <p class="fs-xs color-base-60 mb-1">Which pool this config is served from and scored in. "New user" configs only serve users registered in the last <%= FeedConfig::NEW_USER_TENURE.inspect %> or with no reading activity yet.</p>
+      <%= f.select :segment, FeedConfig.segments.keys.map { |s| [s.humanize, s] }, {}, class: "crayons-select" %>
+    </div>
+  </fieldset>
+
+  <fieldset class="border p-4 rounded-md">
     <legend class="fw-bold px-2 text-base color-base-90">🤖 AI & Disclosure Controls</legend>
     <div class="grid grid-cols-1 m:grid-cols-2 gap-4 mt-2">
       <div class="crayons-field">

--- a/app/views/admin/feed_configs/index.html.erb
+++ b/app/views/admin/feed_configs/index.html.erb
@@ -46,6 +46,7 @@
     <thead>
       <tr>
         <th scope="col">Config ID</th>
+        <th scope="col">Segment</th>
         <th scope="col">Success Score</th>
         <th scope="col">Impressions</th>
         <th scope="col">AI Weights (Matching / Penalty)</th>
@@ -62,6 +63,7 @@
               <span class="c-indicator c-indicator--success ml-1">Best</span>
             <% end %>
           </td>
+          <td><%= config.segment.humanize %></td>
           <td><%= config.feed_success_score.round(4) %></td>
           <td><%= number_with_delimiter(config.feed_impressions_count) %></td>
           <td>

--- a/app/workers/users/convert_pageview_field_test_goals_worker.rb
+++ b/app/workers/users/convert_pageview_field_test_goals_worker.rb
@@ -1,0 +1,54 @@
+module Users
+  # Nightly, batched replacement for the per-page-view conversion that
+  # PageView#record_field_test_event used to enqueue (disabled for load).
+  # Converts the cumulative "viewed pages on N different days" goals for every
+  # recently present participant of the given experiment, once per goal.
+  class ConvertPageviewFieldTestGoalsWorker
+    include Sidekiq::Job
+
+    sidekiq_options queue: :low_priority, retry: 5, lock: :until_and_while_executing
+
+    PAGEVIEW_DAY_GOALS = {
+      "user_views_pages_on_at_least_two_different_days_within_a_week" => { days: 7, min_days: 2 },
+      "user_views_pages_on_at_least_four_different_days_within_a_week" => { days: 7, min_days: 4 },
+      "user_views_pages_on_at_least_nine_different_days_within_two_weeks" => { days: 14, min_days: 9 }
+    }.freeze
+    PRESENCE_LOOKBACK = 14.days
+
+    def perform(experiment_name)
+      data = FieldTest.config.dig("experiments", experiment_name)
+      return if data.nil? || data.key?("winner")
+
+      goals = PAGEVIEW_DAY_GOALS.slice(*Array(data["goals"]))
+      return if goals.empty?
+
+      experiment = FieldTest::Experiment.find(experiment_name)
+      started_at = data.fetch("started_at").beginning_of_day
+
+      memberships_scope = FieldTest::Membership.where(experiment: experiment_name, participant_type: "User")
+      memberships_scope.find_in_batches do |memberships|
+        users = User.where(id: memberships.map(&:participant_id))
+          .where("last_presence_at >= ?", PRESENCE_LOOKBACK.ago)
+          .index_by { |user| user.id.to_s }
+
+        memberships.each do |membership|
+          user = users[membership.participant_id]
+          next unless user
+
+          convert_goals_for(user, membership, experiment, goals, started_at)
+        end
+      end
+    end
+
+    private
+
+    def convert_goals_for(user, membership, experiment, goals, started_at)
+      already_converted = membership.events.where(name: goals.keys).distinct.pluck(:name)
+      goals.except(*already_converted).each do |goal, rule|
+        since = [rule[:days].days.ago, started_at].max
+        distinct_days = user.page_views.where("created_at > ?", since).distinct.count("DATE(created_at)")
+        experiment.convert(user, goal: goal) if distinct_days >= rule[:min_days]
+      end
+    end
+  end
+end

--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -28,6 +28,22 @@
 ################################################################################
 
 experiments:
+  # Home feed for new / low-signal users: per-segment FeedConfig pool vs. the single shared pool.
+  # Enrollment happens in Stories::FeedsController behind the :segmented_feed_configs feature flag.
+  # Page view goals are converted nightly by Users::ConvertPageviewFieldTestGoalsWorker (see schedule.yml).
+  segmented_feed_configs_20260904:
+    started_at: 2026-09-04
+    variants:
+    - control
+    - segmented
+    weights:
+    - 50
+    - 50
+    goals:
+    - user_creates_comment
+    - user_creates_article_reaction
+    - user_views_pages_on_at_least_two_different_days_within_a_week
+    - user_views_pages_on_at_least_four_different_days_within_a_week
   personalized_email_digests_ab_test:
     started_at: 2026-05-19
     variants:

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -234,3 +234,9 @@ evaluate_concept_thresholds:
   class: "Concepts::EvaluateThresholdsWorker"
 
 
+convert_pageview_field_test_goals:
+  description: "Converts cumulative page view goals for the segmented feed config A/B test in one nightly batch (runs daily at 03:30 UTC)"
+  cron: "30 3 * * *"
+  class: "Users::ConvertPageviewFieldTestGoalsWorker"
+  args:
+    - segmented_feed_configs_20260904

--- a/db/migrate/20260904120000_add_segment_to_feed_configs.rb
+++ b/db/migrate/20260904120000_add_segment_to_feed_configs.rb
@@ -1,0 +1,5 @@
+class AddSegmentToFeedConfigs < ActiveRecord::Migration[8.0]
+  def change
+    add_column :feed_configs, :segment, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_09_03_120001) do
+ActiveRecord::Schema[8.0].define(version: 2026_09_04_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -840,6 +840,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_03_120001) do
     t.integer "recent_tag_count_min", default: 0
     t.float "recently_active_past_day_bonus_weight", default: 0.0, null: false
     t.float "score_weight", default: 1.0
+    t.integer "segment", default: 0, null: false
     t.float "semantic_similarity_weight", default: 0.0, null: false
     t.float "shuffle_weight", default: 0.0, null: false
     t.float "status_weight", default: 0.0, null: false

--- a/spec/models/feed_config_spec.rb
+++ b/spec/models/feed_config_spec.rb
@@ -493,6 +493,19 @@ RSpec.describe FeedConfig, type: :model do
       expect(clone.all_time_tag_count_max).to eq(9)
       expect(clone.feed_impressions_count).to eq(0)
     end
+
+    context "with a segment" do
+      it "places the clone in the given segment" do
+        config = described_class.create!(segment: :general)
+        expect { config.create_slightly_modified_clone!(segment: :new_user) }
+          .to change(described_class.new_user, :count).by(1)
+      end
+
+      it "keeps the parent's segment by default" do
+        config = described_class.create!(segment: :new_user)
+        expect { config.create_slightly_modified_clone! }.to change(described_class.new_user, :count).by(1)
+      end
+    end
   end
 
   describe "#score_sql" do
@@ -560,6 +573,48 @@ RSpec.describe FeedConfig, type: :model do
         sql = feed_config.score_sql(user)
         expect(sql).to include("CASE WHEN articles.ai_disclosure_level = 5 THEN -25.0 ELSE 0 END")
       end
+    end
+  end
+
+  describe ".segment_for" do
+    it "returns :general for nil" do
+      expect(described_class.segment_for(nil)).to eq(:general)
+    end
+
+    it "returns :new_user for recently registered users" do
+      expect(described_class.segment_for(create(:user, registered_at: 3.days.ago))).to eq(:new_user)
+    end
+
+    it "returns :new_user for older users with no reading activity" do
+      expect(described_class.segment_for(create(:user, registered_at: 60.days.ago))).to eq(:new_user)
+    end
+
+    it "returns :general for older users with reading activity" do
+      active = create(:user, registered_at: 60.days.ago)
+      create(:user_activity, user: active, recently_viewed_articles: [[1, Time.current.to_s, 30]])
+      expect(described_class.segment_for(active)).to eq(:general)
+    end
+  end
+
+  describe ".pick_for" do
+    let(:new_user) { create(:user, registered_at: 1.day.ago) }
+
+    it "picks from the user's segment pool even when a general config scores higher" do
+      described_class.create!(segment: :general, feed_success_score: 100)
+      new_user_config = described_class.create!(segment: :new_user, feed_success_score: 1)
+      expect(described_class.pick_for(new_user, explore: false)).to eq(new_user_config)
+    end
+
+    it "falls back to the general pool when the segment pool is empty" do
+      general = described_class.create!(segment: :general)
+      expect(described_class.pick_for(new_user, explore: false)).to eq(general)
+    end
+
+    it "treats every config as one pool when not segmented" do
+      described_class.create!(segment: :new_user, feed_success_score: 1)
+      general = described_class.create!(segment: :general, feed_success_score: 100)
+      allow(described_class).to receive(:rand).and_return(1)
+      expect(described_class.pick_for(new_user, explore: false, segmented: false)).to eq(general)
     end
   end
 end

--- a/spec/models/feed_event_spec.rb
+++ b/spec/models/feed_event_spec.rb
@@ -265,6 +265,38 @@ RSpec.describe FeedEvent do
       end
     end
 
+    context "when events fall outside the scoring window" do
+      before do
+        create(:feed_event, category: "impression", feed_config: feed_config, user: user1, article_position: 1)
+        create(:feed_event, category: "comment", feed_config: feed_config, user: user1, article_position: 1,
+                            created_at: (FeedEvent::FEED_CONFIG_SCORING_WINDOW + 1.day).ago)
+      end
+
+      it "ignores them" do
+        described_class.update_single_feed_config_counters(feed_config.id)
+        expect(feed_config.reload.feed_success_score).to eq(0.0)
+      end
+    end
+
+    context "when a user comes back and acts a day after first seeing the config" do
+      before do
+        create(:feed_event, category: "impression", feed_config: feed_config, user: user1, article_position: 1,
+                            created_at: 3.days.ago)
+        create(:feed_event, category: "impression", feed_config: feed_config, user: user2, article_position: 1,
+                            created_at: 3.days.ago)
+        # user1 returns a day later; user2 acts within the same session. Neither click is attributed to this config.
+        create(:feed_event, category: "click", feed_config: nil, user: user1, article_position: 1,
+                            created_at: 1.day.ago)
+        create(:feed_event, category: "click", feed_config: nil, user: user2, article_position: 1,
+                            created_at: 3.days.ago + 1.hour)
+      end
+
+      it "counts only the returning user as retained" do
+        described_class.update_single_feed_config_counters(feed_config.id)
+        expect(feed_config.reload.feed_success_score).to eq(FeedEvent::RETENTION_SCORE_MULTIPLIER.to_f / 2)
+      end
+    end
+
     context "when no impression events exist for the feed config" do
       before do
         create(:feed_event, category: "click", feed_config: feed_config, user: user1, article_position: 1)
@@ -300,6 +332,14 @@ RSpec.describe FeedEvent do
       it "calls create_slightly_modified_clone! on the feed_config" do
         expect_any_instance_of(FeedConfig).to receive(:create_slightly_modified_clone!)
         create(:feed_event, feed_config: feed_config, article: article, user: user, category: "comment")
+      end
+    end
+
+    context "when the engaging user is in the new-user segment" do
+      it "clones into the new-user pool" do
+        new_user = create(:user, registered_at: 1.day.ago)
+        expect { create(:feed_event, feed_config: feed_config, article: article, user: new_user, category: "reaction") }
+          .to change(FeedConfig.new_user, :count).by(1)
       end
     end
 

--- a/spec/requests/stories/feeds_spec.rb
+++ b/spec/requests/stories/feeds_spec.rb
@@ -15,6 +15,59 @@ RSpec.describe "Stories::Feeds" do
     let(:response_json) { response.parsed_body }
     let(:response_article) { response_json.first }
 
+    context "when the segmented feed config experiment is on" do
+      let(:experiment) { "segmented_feed_configs_20260904" }
+      let(:new_user) { create(:user, registered_at: 1.day.ago) }
+
+      before do
+        config = FieldTest.config.deep_dup
+        config["experiments"][experiment] = {
+          "started_at" => 1.day.ago.to_date, "variants" => %w[control segmented], "weights" => [50, 50],
+          "goals" => ["user_creates_comment"]
+        }
+        allow(FieldTest).to receive(:config).and_return(config)
+        allow(Settings::UserExperience).to receive(:feed_strategy).and_return("configured")
+        allow(FeedConfig).to receive(:pick_for).and_call_original
+        FeatureFlag.enable(:segmented_feed_configs)
+      end
+
+      after { FeatureFlag.disable(:segmented_feed_configs) }
+
+      def enroll(participant, variant)
+        FieldTest::Membership.create!(experiment: experiment, participant_type: "User",
+                                      participant_id: participant.id.to_s, variant: variant)
+      end
+
+      it "serves the segmented pool to the segmented variant" do
+        enroll(new_user, "segmented")
+        sign_in new_user
+
+        get stories_feed_path
+
+        expect(FeedConfig).to have_received(:pick_for).with(new_user, segmented: true)
+      end
+
+      it "serves the shared pool to the control variant" do
+        enroll(new_user, "control")
+        sign_in new_user
+
+        get stories_feed_path
+
+        expect(FeedConfig).to have_received(:pick_for).with(new_user, segmented: false)
+      end
+
+      it "does not enroll established users" do
+        established = create(:user, registered_at: 60.days.ago)
+        create(:user_activity, user: established, recently_viewed_articles: [[1, Time.current.to_s, 30]])
+        sign_in established
+
+        get stories_feed_path
+
+        expect(FieldTest::Membership.where(experiment: experiment)).to be_empty
+        expect(FeedConfig).to have_received(:pick_for).with(established, segmented: false)
+      end
+    end
+
     it "renders article list as json" do
       get stories_feed_path
 

--- a/spec/workers/users/convert_pageview_field_test_goals_worker_spec.rb
+++ b/spec/workers/users/convert_pageview_field_test_goals_worker_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe Users::ConvertPageviewFieldTestGoalsWorker, type: :worker do
+  include FieldTest::Helpers
+
+  include_examples "#enqueues_on_correct_queue", "low_priority", "some_experiment"
+
+  describe "#perform" do
+    let(:experiment) { "segmented_feed_configs_20260904" }
+    let(:two_days_goal) { "user_views_pages_on_at_least_two_different_days_within_a_week" }
+    let(:four_days_goal) { "user_views_pages_on_at_least_four_different_days_within_a_week" }
+    let(:user) { create(:user, last_presence_at: 1.hour.ago) }
+    let(:membership) { FieldTest::Membership.find_by(experiment: experiment, participant_id: user.id.to_s) }
+
+    before do
+      config = FieldTest.config.deep_dup
+      config["experiments"][experiment] = {
+        "started_at" => 30.days.ago.to_date,
+        "variants" => %w[control segmented],
+        "weights" => [50, 50],
+        "goals" => ["user_creates_comment", two_days_goal, four_days_goal]
+      }
+      allow(FieldTest).to receive(:config).and_return(config)
+
+      field_test(experiment, participant: user)
+      create(:page_view, user: user, created_at: 1.day.ago)
+      create(:page_view, user: user, created_at: 2.days.ago)
+    end
+
+    it "converts the satisfied day-count goals once, even when run repeatedly" do
+      described_class.new.perform(experiment)
+      described_class.new.perform(experiment)
+
+      expect(membership.events.pluck(:name)).to eq([two_days_goal])
+    end
+
+    it "skips participants who have not been present recently" do
+      user.update_column(:last_presence_at, 20.days.ago)
+
+      described_class.new.perform(experiment)
+
+      expect(membership.events).to be_empty
+    end
+
+    it "does nothing for an unknown experiment" do
+      expect { described_class.new.perform("nope") }.not_to change(FieldTest::Event, :count)
+    end
+  end
+end


### PR DESCRIPTION
## What this does

Applies the per-segment idea from [CORAL (Meta AI, arXiv 2609.02730)](https://arxiv.org/abs/2609.02730) to DEV's evolving `FeedConfig` pool. The paper's clearest finding for our purposes: a recommender tuned on the whole population under-serves new and low-signal users, and giving that segment its own settings, scored only on its own behavior, lifted their sessions. It also argues the best settings drift, so scores should track a recent window, and that every change should be measured with an A/B test.

### Changes

**Segmented feed config pools**
- `feed_configs.segment` enum: `general` (default) / `new_user`. One migration, no index (small table).
- `FeedConfig.segment_for(user)`: `new_user` if registered within 14 days or with no page-view activity yet.
- `FeedConfig.pick_for(user, explore:, segmented:)` replaces the inline top-15 sampling in the feeds controller and the digest collector. Falls back to the general pool when the segment pool is empty.
- Clones spawned by a reaction/comment now land in the *engaging user's* segment, so the new-user pool seeds itself from the first new user who reacts under a general config.

**Scoring**
- `FeedEvent.update_single_feed_config_counters` scores on a trailing 7-day window instead of lifetime.
- Adds a retention term: distinct users who saw the config in the window and then acted (click / reaction / comment / extended pageview) 24h+ after their first impression, weighted 3x. Article scoring is unchanged.

**A/B test**
- `segmented_feed_configs_20260904` in `config/field_test.yml`: `control` vs `segmented`, 50/50, goals: comment, article reaction, pages viewed on 2+ and 4+ different days in a week.
- `Stories::FeedsController` enrolls a user only when `FeatureFlag.enabled?(:segmented_feed_configs)` and the user is in the new-user segment. Control gets one pool of all configs (the pre-change behavior). Established users are never enrolled since both arms are the same for them.
- The digest uses the unsegmented pool until the test concludes so it can't leak treatment into control.

**Nightly page view goal conversion**
- The per-page-view `PageView#record_field_test_event` callback has been commented out for load, so the "viewed pages on N different days" goals never converted.
- `Users::ConvertPageviewFieldTestGoalsWorker` (scheduled 03:30 UTC with the experiment name as its arg) walks the experiment's memberships in batches, skips users not present in the last 14 days, and converts each day-count goal at most once per member. Same dashboard numbers, no per-request jobs.

**Admin**
- Segment dropdown on the feed config form; Segment column on the index.

### To turn it on
1. Run the migration.
2. Enable `segmented_feed_configs` at `/admin/feature_flags`.
3. Make sure `field_test_event_for_reactions` is enabled or the reaction column stays empty.
4. Results at `/admin/abtests`.

### Not in this PR
- The paper's LLM tuning loop (memory + attribution + constrained optimizer). This PR builds the segmented pools, the moving score, and the measurement that loop would consume.
- A nightly rescore for configs that fall out of the served pool (their windowed score only refreshes when they get events).
- A higher retention multiplier for the new-user segment only.

### Tests
- New specs for `segment_for`, `pick_for` (segmented and not), clone segment inheritance, windowed scoring, the retention term, offshoot segment tagging, controller enrollment (segmented / control / not enrolled), and the batch worker (converts once, skips absent users, ignores unknown experiments).
- Touched spec files: 231 examples, 1 failure. The failure is a pre-existing `http` vs `https` assertion in the custom-domain feed spec, unrelated to this change.

https://claude.ai/code/session_01AjKk5rzFLRtPr6jEGNDwM9

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791153541&installation_model_id=424141&pr_number=23816&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23816&signature=8ae7929062e51e62301a6dd1ef59d21bda739588ac40b439da04da89d1832ace"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->