### PR TITLE
Reduce repeated role queries in multiple request paths

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -277,7 +277,8 @@ new_email = user_params[:email].to_s.strip.presence
     end
 
     def export
-      @users = User.registered.select(ATTRIBUTES_FOR_CSV + ATTRIBUTES_FOR_LAST_ACTIVITY).includes(:organizations)
+      @users = User.registered.select(ATTRIBUTES_FOR_CSV + ATTRIBUTES_FOR_LAST_ACTIVITY)
+        .preload(:organizations, :roles)
 
       respond_to do |format|
         format.csv do
@@ -705,7 +706,7 @@ new_email = user_params[:email].to_s.strip.presence
         joining_end: params[:joining_end],
         date_format: params[:date_format],
         organizations: params[:organizations],
-      ).page(params[:page]).per(50)
+      ).preload(:roles).page(params[:page]).per(50)
 
       @organization_limit = 3
       @organizations = Organization.order(name: :desc)

--- a/app/models/async_info.rb
+++ b/app/models/async_info.rb
@@ -24,6 +24,7 @@ class AsyncInfo
 
   def initialize(user:, context:)
     @user = user.decorate
+    @user.roles.load
     @context = context
   end
 
@@ -50,7 +51,7 @@ class AsyncInfo
       moderator_for_tags: user.moderator_for_tags,
       moderator_for_subforems: user.moderator_for_subforems,
       config_body_class: user.config_body_class,
-      feed_style: feed_style_preference_variable(user),
+      feed_style: feed_style_preference_variable,
       created_at: user.created_at,
       admin: user.any_admin?,
       admin_organization_ids: user.organization_memberships.admin.pluck(:organization_id),
@@ -82,7 +83,7 @@ class AsyncInfo
     false
   end
 
-  def feed_style_preference_variable(user)
+  def feed_style_preference_variable
     # TODO: Let users set their own feed style preference
     # Currently only at app level
 

--- a/app/policies/authorizer.rb
+++ b/app/policies/authorizer.rb
@@ -165,17 +165,13 @@ module Authorizer
     def tag_moderator?(tag: nil)
       return true if community_leader?
 
-      # Note a fan of "peeking" into the roles table, which in a way
-      # circumvents the rolify gem.  But this was the past implementation.
-      return user.roles.exists?(name: "tag_moderator") unless tag
+      return has_role?(:tag_moderator, :any) unless tag
 
       has_role?(:tag_moderator, tag)
     end
 
     def subforem_moderator?(subforem: nil)
-      # Note a fan of "peeking" into the roles table, which in a way
-      # circumvents the rolify gem.  But this was the past implementation.
-      return user.roles.exists?(name: "subforem_moderator") unless subforem
+      return has_role?(:subforem_moderator, :any) unless subforem
 
       has_role?(:subforem_moderator, subforem)
     end
@@ -211,11 +207,25 @@ module Authorizer
     private
 
     def has_role?(*args)
+      return user.has_cached_role?(*args) if roles_loaded?
+
       user.__send__(:has_role?, *args)
     end
 
     def has_any_role?(*args)
-      user.__send__(:has_any_role?, *args)
+      return user.__send__(:has_any_role?, *args) unless roles_loaded?
+
+      args.any? do |role|
+        if role.is_a?(Hash)
+          user.has_cached_role?(role[:name], role[:resource])
+        else
+          user.has_cached_role?(role)
+        end
+      end
+    end
+
+    def roles_loaded?
+      user.association(:roles).loaded?
     end
   end
 end

--- a/app/services/re_captcha/check_enabled.rb
+++ b/app/services/re_captcha/check_enabled.rb
@@ -19,6 +19,8 @@ module ReCaptcha
       return false unless keys_configured?
       # recaptcha will always be enabled when not logged in
       return true if @user.nil?
+
+      @user.roles.load
       # recaptcha will not be enabled for tag moderator/trusted/admin users
       return false if @user.tag_moderator? || @user.trusted? || @user.any_admin?
       # recaptcha will be enabled if the user has been suspended

--- a/spec/lib/data_update_scripts/backfill_creator_role_for_first_super_admin_spec.rb
+++ b/spec/lib/data_update_scripts/backfill_creator_role_for_first_super_admin_spec.rb
@@ -9,7 +9,7 @@ describe DataUpdateScripts::BackfillCreatorRoleForFirstSuperAdmin do
 
   it "Only the first super admin should have the creator role" do
     described_class.new.run
-    expect(creator).to be_creator
-    expect(admin).not_to be_creator
+    expect(creator.reload).to be_creator
+    expect(admin.reload).not_to be_creator
   end
 end

--- a/spec/models/async_info_spec.rb
+++ b/spec/models/async_info_spec.rb
@@ -54,5 +54,20 @@ RSpec.describe AsyncInfo do
       expect(payload).to have_key(:admin_organization_ids)
       expect(payload[:admin_organization_ids]).to eq([org.id])
     end
+
+    it "loads roles once for all role-based values" do
+      user.add_role(:admin)
+      user.reload
+      role_queries = []
+      subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
+        role_queries << payload[:sql] if payload[:sql].include?('FROM "roles"')
+      end
+
+      payload = nil
+      ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record") { payload = async_info }
+
+      expect(payload[:admin]).to be(true)
+      expect(role_queries.size).to eq(3)
+    end
   end
 end

--- a/spec/policies/authorizer_spec.rb
+++ b/spec/policies/authorizer_spec.rb
@@ -140,6 +140,36 @@ RSpec.describe Authorizer, type: :policy do
     end
   end
 
+  describe "with preloaded roles" do
+    let(:tag) { create(:tag) }
+    let(:subforem) { create(:subforem) }
+
+    before do
+      user.add_role(:admin)
+      user.add_role(:tag_moderator, tag)
+      user.add_role(:subforem_moderator, subforem)
+      user.reload
+      user.roles.load
+    end
+
+    it "answers global and resource role questions without more role queries" do
+      role_queries = []
+      subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
+        role_queries << payload[:sql] if payload[:sql].include?('FROM "roles"')
+      end
+
+      ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record") do
+        expect(authorizer.any_admin?).to be(true)
+        expect(authorizer.tag_moderator?).to be(true)
+        expect(authorizer.tag_moderator?(tag: tag)).to be(true)
+        expect(authorizer.subforem_moderator?).to be(true)
+        expect(authorizer.subforem_moderator?(subforem: subforem)).to be(true)
+      end
+
+      expect(role_queries).to be_empty
+    end
+  end
+
   describe "#vomited_on?" do
     subject(:method_call) { authorizer.vomited_on? }
 

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -17,6 +17,20 @@ RSpec.describe "/admin/member_manager/users" do
       expect(response.body).to include(user.username)
     end
 
+    it "does not query roles separately for each user displayed" do
+      create_list(:user, 2)
+      scoped_role_queries = []
+      subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
+        sql = payload[:sql]
+        scoped_role_queries << sql if sql.match?(/FROM "roles".*"users_roles".*"users_roles"\."user_id" =/)
+      end
+
+      ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record") { get admin_users_path }
+
+      expect(response).to have_http_status(:ok)
+      expect(scoped_role_queries).to be_empty
+    end
+
     context "when searching" do
       it "finds the proper user by GitHub username" do
         get "#{admin_users_path}?search=#{user.github_username}"

--- a/spec/services/re_captcha/check_enabled_spec.rb
+++ b/spec/services/re_captcha/check_enabled_spec.rb
@@ -36,6 +36,20 @@ RSpec.describe ReCaptcha::CheckEnabled, type: :request do
         expect(described_class.call(older_user)).to be(false)
       end
 
+      it "loads roles once when evaluating all role exemptions" do
+        older_user
+        role_queries = []
+        subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
+          role_queries << payload[:sql] if payload[:sql].include?('FROM "roles"')
+        end
+
+        ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record") do
+          expect(described_class.call(older_user)).to be(false)
+        end
+
+        expect(role_queries.size).to eq(1)
+      end
+
       it "marks ReCaptcha as not enabled when admin is logged in" do
         sign_in admin
         expect(described_class.call(admin)).to be(false)


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

## Related Tickets & Documents
This PR reduces repeated role queries across several role-heavy paths:
- Updates Authorizer to use Rolify’s cached role checks when the user’s roles are already loaded, while preserving the existing database-backed behavior otherwise.
- Preloads roles for the admin member list and CSV export.
- Loads roles once when building the async user payload.
- Loads roles once when evaluating reCAPTCHA role exemptions.
 This avoids repeated COUNT/EXISTS queries without changing authorization or role-checking behavior.

## Performance benchmark results
Done using 5 executions per path and revision after 3 warmups.

### Authenticated `GET /async_info/base_data` (`Accept: application/json`)
| Metric | Before mean | After mean | Mean change | Before median | After median |
|---|---:|---:|---:|---:|---:|
| Request duration (ms) | 119.53 | 116.66 | -2.4% | 119.69 | 102.60 |
| SQL duration (ms) | 18.46 | 14.17 | -23.2% | 18.81 | 13.92 |
| Allocated objects | 30580 | 27485 | -10.1% | 30575 | 27484 |
| SQL events | 33 | 23 | -30.3% | 33 | 23 |
| Duplicate fingerprints | 10 | 2 | -80.0% | 10 | 2 |
| Role queries | 13 | 3 | -76.9% | 13 | 3 |
| Role snapshot queries | 1 | 1 | +0.0% | 1 | 1 |
| Role COUNT/EXISTS queries | 8 | 0 | -100.0% | 8 | 0 |

### Super-admin `GET /admin/member_manager/users` (`Accept: text/html`)
| Metric | Before mean | After mean | Mean change | Before median | After median |
|---|---:|---:|---:|---:|---:|
| Request duration (ms) | 1409.14 | 893.24 | -36.6% | 1371.71 | 889.69 |
| SQL duration (ms) | 284.29 | 58.47 | -79.4% | 283.62 | 58.22 |
| Allocated objects | 965895 | 751768 | -22.2% | 965916 | 751768 |
| SQL events | 683 | 119 | -82.6% | 683 | 119 |
| Duplicate fingerprints | 661 | 96 | -85.5% | 661 | 96 |
| Role queries | 568 | 4 | -99.3% | 568 | 4 |
| Role snapshot queries | 0 | 2 | n/a | 0 | 2 |
| Role COUNT/EXISTS queries | 1 | 1 | +0.0% | 1 | 1 |

### Super-admin `GET /admin/member_manager/users/export.csv` (`Accept: text/csv`)
| Metric | Before mean | After mean | Mean change | Before median | After median |
|---|---:|---:|---:|---:|---:|
| Request duration (ms) | 229.24 | 124.98 | -45.5% | 220.05 | 129.37 |
| SQL duration (ms) | 64.66 | 10.24 | -84.2% | 62.09 | 10.50 |
| Allocated objects | 106728 | 50653 | -52.5% | 106727 | 50654 |
| SQL events | 152 | 16 | -89.5% | 152 | 16 |
| Duplicate fingerprints | 139 | 2 | -98.6% | 139 | 2 |
| Role queries | 139 | 3 | -97.8% | 139 | 3 |
| Role snapshot queries | 0 | 2 | n/a | 0 | 2 |
| Role COUNT/EXISTS queries | 1 | 1 | +0.0% | 1 | 1 |

### Direct `ReCaptcha::CheckEnabled.call(user)` service invocation (no HTTP route)
| Metric | Before mean | After mean | Mean change | Before median | After median |
|---|---:|---:|---:|---:|---:|
| Request duration (ms) | 10.22 | 3.31 | -67.7% | 9.59 | 2.92 |
| SQL duration (ms) | 4.76 | 1.41 | -70.4% | 4.53 | 1.25 |
| Allocated objects | 2670 | 1176 | -56.0% | 2567 | 1072 |
| SQL events | 5 | 2 | -57.7% | 5 | 2 |
| Duplicate fingerprints | 2 | 0 | -100.0% | 2 | 0 |
| Role queries | 4 | 1 | -75.0% | 4 | 1 |
| Role snapshot queries | 0 | 1 | n/a | 0 | 1 |
| Role COUNT/EXISTS queries | 4 | 0 | -100.0% | 4 | 0 |

## QA Instructions, Screenshots, Recordings

 Run the affected specs:                                                                                                                                                                                                     
                                                                                                                                                                                                                             
 ```shell                                                                                                                                                                                                                    
   bundle exec rspec \                                                                                                                                                                                                       
     spec/models/async_info_spec.rb \                                                                                                                                                                                        
     spec/policies/authorizer_spec.rb \                                                                                                                                                                                      
     spec/requests/admin/users_spec.rb \                                                                                                                                                                                     
     spec/services/re_captcha/check_enabled_spec.rb                                                                                                                                                                          
 ```                                                                                                                                                                                                                         
                                                                                                                                                                                                                             
 Manual verification:                                                                                                                                                                                                        
                                                                                                                                                                                                                             
 1. Sign in as a super admin and visit /admin/member_manager/users.                                                                                                                                                          
 2. Confirm users and their role-related controls render correctly.                                                                                                                                                          
 3. Export the member CSV and confirm it contains the expected users and role-related data.                                                                                                                                  
 4. Confirm async user data and reCAPTCHA exemptions remain correct for admins, trusted users, and moderators.                                                                                                               
                                                                                                                                                                                                                             
 No UI changes are included.                                                                                                                                                                       
                                                                                                                                                                                                                             
 ### Added/updated tests?                                                                                                                                                                                                        
                                                                                                                                                                                                                             
 - [x] Yes                                                                                                                                                                                                                   
 - [ ] No                                                                                                                                                                                                                    
 - [ ] I need help with writing tests 

Regression coverage verifies that:
- Preloaded global and resource-scoped roles are evaluated without additional role queries.
- Async user data loads roles once for its role-based values.
- The admin member list does not issue role queries for each displayed user.
- reCAPTCHA role exemptions load roles once.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791200668&installation_model_id=424141&pr_number=23817&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23817&signature=30759ae62f3eb486d90dfa47ced0f7abdd16048dfa88970cf5e2b983459424cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->