### PR TITLE
Optimize cold analytics activity backfills with bulk aggregation

### DIFF
--- a/app/models/article_activity.rb
+++ b/app/models/article_activity.rb
@@ -13,6 +13,8 @@
 #   daily_comments[date]   = N            (count of scored comments)
 #   daily_referrers[date]  = { domain => N }
 class ArticleActivity < ApplicationRecord
+  include ArticleActivityBulkBackfillable
+
   belongs_to :article
 
   REACTION_CATEGORIES = %w[like readinglist unicorn exploding_head raised_hands fire].freeze

--- a/app/models/concerns/article_activity_bulk_backfillable.rb
+++ b/app/models/concerns/article_activity_bulk_backfillable.rb
@@ -1,0 +1,82 @@
+module ArticleActivityBulkBackfillable
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def bulk_backfill!(article_ids)
+      ids = Article.where(id: article_ids).ids
+      return if ids.empty?
+
+      aggregates = ids.index_with do
+        {
+          daily_page_views: {}, daily_reactions: {}, daily_comments: {}, daily_referrers: {},
+          total_page_views: 0, total_reactions: 0, total_comments: 0
+        }
+      end
+
+      aggregate_page_views(ids, aggregates)
+      aggregate_reactions(ids, aggregates)
+      aggregate_comments(ids, aggregates)
+
+      now = Time.current
+      rows = aggregates.map do |article_id, values|
+        values.merge(article_id: article_id, last_aggregated_at: now, created_at: now, updated_at: now)
+      end
+      insert_all(rows, unique_by: :index_article_activities_on_article_id)
+    end
+
+    private
+
+    def aggregate_page_views(ids, aggregates)
+      PageView.where(article_id: ids)
+        .group(:article_id, "DATE(created_at)", :domain)
+        .pluck(
+          :article_id,
+          Arel.sql("DATE(created_at)"),
+          :domain,
+          Arel.sql("COALESCE(SUM(counts_for_number_of_views), 0)"),
+          Arel.sql("COALESCE(SUM(time_tracked_in_seconds) FILTER (WHERE user_id IS NOT NULL), 0)"),
+          Arel.sql("COUNT(*) FILTER (WHERE user_id IS NOT NULL)"),
+        ).each do |article_id, date, domain, total, sum_read, logged|
+          iso = date.iso8601
+          day = aggregates.fetch(article_id)[:daily_page_views]
+            .fetch(iso, { "total" => 0, "sum_read_seconds" => 0, "logged_in_count" => 0 })
+          day["total"] += total.to_i
+          day["sum_read_seconds"] += sum_read.to_i
+          day["logged_in_count"] += logged.to_i
+          aggregates.fetch(article_id)[:daily_page_views][iso] = day
+          aggregates.fetch(article_id)[:daily_referrers][iso] ||= {}
+          aggregates.fetch(article_id)[:daily_referrers][iso][domain.to_s] = total.to_i
+          aggregates.fetch(article_id)[:total_page_views] += total.to_i
+        end
+    end
+
+    def aggregate_reactions(ids, aggregates)
+      Reaction.for_analytics
+        .where(reactable_id: ids, reactable_type: "Article")
+        .group(:reactable_id, "DATE(created_at)")
+        .pluck(
+          :reactable_id,
+          Arel.sql("DATE(created_at)"),
+          Arel.sql("COUNT(*)"),
+          *self::REACTION_CATEGORIES.map { |category| Arel.sql("COUNT(*) FILTER (WHERE category = '#{category}')") },
+          Arel.sql("COALESCE(array_agg(DISTINCT user_id) FILTER (WHERE user_id IS NOT NULL), '{}')"),
+        ).each do |row|
+          article_id, date, total, *counts, reactor_ids = row
+          values = { "total" => total.to_i, "reactor_ids" => Array(reactor_ids).map(&:to_i) }
+          self::REACTION_CATEGORIES.zip(counts) { |category, count| values[category] = count.to_i }
+          aggregates.fetch(article_id)[:daily_reactions][date.iso8601] = values
+          aggregates.fetch(article_id)[:total_reactions] += total.to_i
+        end
+    end
+
+    def aggregate_comments(ids, aggregates)
+      Comment.where(commentable_id: ids, commentable_type: "Article")
+        .where("score > 0")
+        .group(:commentable_id, "DATE(created_at)")
+        .count.each do |(article_id, date), total|
+          aggregates.fetch(article_id)[:daily_comments][date.iso8601] = total
+          aggregates.fetch(article_id)[:total_comments] += total
+        end
+    end
+  end
+end

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -191,7 +191,7 @@ class AnalyticsService
 
   attr_reader(
     :user_or_org, :article_id, :start_date, :end_date,
-    :article_data, :reaction_data, :comment_data, :follow_data, :page_view_data
+    :article_data, :article_ids, :reaction_data, :comment_data, :follow_data, :page_view_data
   )
 
   def load_data
@@ -201,11 +201,9 @@ class AnalyticsService
 
       # check article_id is published and belongs to the user/org
       raise ArgumentError, I18n.t("services.analytics_service.no_stats") unless @article_data.exists?
-
-      article_ids = [@article_id]
-    else
-      article_ids = @article_data.ids
     end
+
+    @article_ids = @article_data.ids
 
     # prepare relations for metrics
     @comment_data = Comment
@@ -439,7 +437,6 @@ class AnalyticsService
   def scoped_activities
     return @scoped_activities if defined?(@scoped_activities)
 
-    article_ids = article_data.ids
     if article_ids.empty?
       @scoped_activities = nil
       return nil
@@ -452,7 +449,7 @@ class AnalyticsService
       # that owners with thousands of articles don't spike the queue on a
       # cold dashboard load. The current request still falls back to the
       # raw-table path; the cache is warm on the next visit.
-      Articles::BackfillActivitiesWorker.perform_async(missing)
+      Articles::BackfillActivitiesWorker.perform_async(missing.sort)
       @scoped_activities = nil
       return nil
     end

--- a/app/workers/articles/backfill_activities_worker.rb
+++ b/app/workers/articles/backfill_activities_worker.rb
@@ -16,14 +16,8 @@ module Articles
 
     def perform(article_ids)
       Array(article_ids).each_slice(100) do |chunk|
-        existing = ArticleActivity.where(article_id: chunk).pluck(:article_id).to_set
-        missing = chunk.reject { |id| existing.include?(id) }
-        next if missing.empty?
-
-        Article.where(id: missing).find_each do |article|
-          activity = ArticleActivity.find_or_create_by!(article_id: article.id)
-          activity.recompute_all!
-        end
+        missing = chunk - ArticleActivity.where(article_id: chunk).pluck(:article_id)
+        ArticleActivity.bulk_backfill!(missing) if missing.any?
       end
     end
   end

--- a/spec/models/article_activity_spec.rb
+++ b/spec/models/article_activity_spec.rb
@@ -107,6 +107,78 @@ RSpec.describe ArticleActivity do
     end
   end
 
+  describe ".bulk_backfill!" do
+    it "rebuilds multiple article rows from batch aggregates" do
+      other_article = create(:article)
+      user = create(:user)
+      ts = Time.utc(day.year, day.month, day.day, 12, 0, 0)
+      page_view = create(
+        :page_view,
+        article: article,
+        user: user,
+        created_at: ts,
+        counts_for_number_of_views: 4,
+        time_tracked_in_seconds: 30,
+      )
+      page_view.update_column(:domain, "example.com")
+      create(:page_view, article: other_article, created_at: ts,
+                         counts_for_number_of_views: 2, domain: "forem.com")
+      create(:reaction, reactable: article, user: user, category: "fire", created_at: ts)
+      create(:comment, commentable: other_article, user: user, score: 5, created_at: ts)
+
+      sql_queries = []
+      callback = lambda do |*, payload|
+        sql_queries << payload[:sql] unless %w[SCHEMA TRANSACTION].include?(payload[:name])
+      end
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        described_class.bulk_backfill!([article.id, other_article.id])
+      end
+
+      first = described_class.find_by!(article: article)
+      second = described_class.find_by!(article: other_article)
+      expected_page_views = {
+        "total" => 4,
+        "sum_read_seconds" => 30,
+        "logged_in_count" => 1
+      }
+      expect(first).to have_attributes(
+        daily_page_views: hash_including(iso => expected_page_views),
+        daily_referrers: hash_including(iso => { "example.com" => 4 }),
+        total_page_views: 4,
+        total_reactions: 1,
+        last_aggregated_at: be_present,
+      )
+      expect(first.daily_reactions[iso]["fire"]).to eq(1)
+      expect(sql_queries.size).to eq(5)
+      expect(second).to have_attributes(
+        daily_page_views: hash_including(iso => hash_including("total" => 2)),
+        daily_comments: hash_including(iso => 1),
+        total_comments: 1,
+        last_aggregated_at: be_present,
+      )
+
+      columns = %w[daily_page_views daily_reactions daily_comments daily_referrers
+                   total_page_views total_reactions total_comments]
+      [first, second].each do |record|
+        bulk_values = record.attributes.slice(*columns)
+        record.recompute_all!
+        expect(record.reload.attributes.slice(*columns)).to eq(bulk_values)
+      end
+    end
+
+    it "preserves a row created after aggregation but before insertion" do
+      article_id = article.id
+      allow(described_class).to receive(:insert_all).and_wrap_original do |original, *args, **kwargs|
+        described_class.create!(article_id: article_id, total_page_views: 99)
+        original.call(*args, **kwargs)
+      end
+
+      described_class.bulk_backfill!([article_id])
+
+      expect(described_class.find_by!(article_id: article_id).total_page_views).to eq(99)
+    end
+  end
+
   describe "#referrer_totals" do
     it "sorts by count desc and limits" do
       activity.apply_page_view_delta!("iso" => iso, "total" => 1, "sum_read_seconds" => 0,

--- a/spec/services/analytics_service_spec.rb
+++ b/spec/services/analytics_service_spec.rb
@@ -287,6 +287,28 @@ RSpec.describe AnalyticsService, type: :service do
     end
   end
 
+  describe "activity cache lookup" do
+    it "uses an existing activity for a string article ID without enqueueing a backfill" do
+      ArticleActivity.create!(article: article, total_page_views: 42,
+                              daily_page_views: { "2019-04-01" => { "total" => 42 } })
+      allow(Articles::BackfillActivitiesWorker).to receive(:perform_async)
+
+      service = described_class.new(user, article_id: article.id.to_s)
+
+      expect(service.totals[:page_views][:total]).to eq(42)
+      expect(Articles::BackfillActivitiesWorker).not_to have_received(:perform_async)
+    end
+
+    it "enqueues missing article IDs in canonical order" do
+      articles = create_list(:article, 2, user: user, published: true)
+      allow(Articles::BackfillActivitiesWorker).to receive(:perform_async)
+
+      described_class.new(user).totals
+
+      expect(Articles::BackfillActivitiesWorker).to have_received(:perform_async).with(articles.map(&:id).sort)
+    end
+  end
+
   describe "#grouped_by_day" do
     it "returns stats grouped by day" do
       stats = described_class.new(

--- a/spec/workers/articles/backfill_activities_worker_spec.rb
+++ b/spec/workers/articles/backfill_activities_worker_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe Articles::BackfillActivitiesWorker do
+  describe "#perform" do
+    it "backfills missing rows as one batch" do
+      articles = create_list(:article, 2)
+      ids = articles.map(&:id)
+      allow(ArticleActivity).to receive(:bulk_backfill!)
+
+      described_class.new.perform(ids)
+
+      expect(ArticleActivity).to have_received(:bulk_backfill!).with(ids)
+    end
+
+    it "skips existing rows" do
+      article = create(:article)
+      activity = ArticleActivity.create!(article: article, total_page_views: 12)
+      allow(ArticleActivity).to receive(:bulk_backfill!)
+
+      described_class.new.perform([article.id])
+
+      expect(ArticleActivity).not_to have_received(:bulk_backfill!)
+      expect(activity.reload.total_page_views).to eq(12)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR improves analytics dashboard cold-cache performance by replacing per-article `ArticleActivity` recomputation with set-based aggregation.
Previously, the backfill worker recomputed each missing article independently. This caused repeated article lookups and separate page-view, reaction, and comment queries for every article in the batch.
These changes:
- Adds ArticleActivity.bulk_backfill! through a dedicated model concern.
- Aggregates page views for all requested articles in one grouped query, including:
    - Daily and total view counts
    - Logged-in view counts
    - Reading time
    - Referrer domains
- Aggregates analytics-eligible reactions in one grouped query, including:
    - Daily and total reaction counts
    - Per-category counts
    - Unique reactor IDs
- Aggregates positively scored comments in one grouped query.
- Inserts generated activity rows with one insert_all.

### Performance results 

The comparison used 10 articles. Each article contained three days of data, nine page-view rows, six reactions, and three positive comments.   Results are medians from five measured runs after three warmups, with the SQL query cache disabled.

| Scenario | Metric (median) | Before | After | Change |
|---|---|---:|---:|---:|
| cold_backfill | ms | 169.86 | 16.84 | -90.1% |
| cold_backfill | sql | 82 | 6 | -92.7% |
| cold_backfill | sql_ms | 56.58 | 8.14 | -85.6% |
| cold_backfill | allocations | 54082 | 8270 | -84.7% |
| cold_dashboard_service | ms | 11.18 | 10.52 | -6.0% |
| cold_dashboard_service | sql | 8 | 7 | -12.5% |
| cold_dashboard_service | sql_ms | 5.94 | 5.50 | -7.4% |
| cold_dashboard_service | allocations | 3880 | 3501 | -9.8% |

The cold-backfill path is approximately 10× faster, while warm/no-op behavior remains effectively unchanged.  These measurements used direct worker and service calls in the test environment. Sidekiq was configured in fake mode, so Redis uniqueness and concurrent execution were not benchmarked. Fixture setup, reset, and verification work were excluded from the measurements.

## QA Instructions, Screenshots, Recordings
Run the affected specs:                                                                                                                                                                                                     
                                                                                                                                                                                                                             
 ```shell
bundle exec rspec \
      spec/models/article_activity_spec.rb \ 
      spec/services/analytics_service_spec.rb \ 
      spec/workers/articles/backfill_activities_worker_spec.rb
```
No screenshots or browser recordings are applicable because this PR does not change the UI.

###  Added/updated tests?
- [x] Yes
- [ ] No, and this is why: please replace this line with details on why tests have not been included
- [ ] I need help with writing tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791362286&installation_model_id=424141&pr_number=23822&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23822&signature=27dec816d3957dc9919df09a5c742368e472debef1b9918493cdc662ef10edb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->