### PR TITLE
Let URL_PORT override the development URL port

### DIFF
--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -8,7 +8,14 @@ module URL
   # to preserve historical behavior, but can be overridden by setting the
   # PORT environment variable to match the actual server port (useful when
   # Forem runs alongside other Rails apps that also default to 3000).
+  #
+  # URL_PORT, when set, wins over PORT: it names the port the public URL
+  # should carry rather than the one Puma listens on. Set it to an empty value
+  # when a TLS proxy such as Caddy fronts the app on the standard port, so
+  # OAuth callbacks and other absolute URLs carry no port at all.
   def self.dev_port
+    return ENV["URL_PORT"] if ENV.key?("URL_PORT")
+
     ENV.fetch("PORT", "3000")
   end
 
@@ -37,8 +44,10 @@ module URL
 
   def self.url(uri = nil, domain_or_subforem = nil)
     base_url = "#{protocol}#{domain(domain_or_subforem)}"
-    base_url += ":#{dev_port}" if Rails.env.development? && !base_url.include?(":#{dev_port}")
+    port = dev_port
+    base_url += ":#{port}" if Rails.env.development? && port.present? && base_url.exclude?(":#{port}")
     return base_url unless uri
+
     Addressable::URI.parse(base_url).join(uri).normalize.to_s
   end
 

--- a/spec/lib/url_spec.rb
+++ b/spec/lib/url_spec.rb
@@ -16,15 +16,35 @@ RSpec.describe URL, type: :lib do
 
   describe ".dev_port" do
     it "defaults to 3000 when the PORT env var is not set" do
+      allow(ENV).to receive(:key?).and_call_original
+      allow(ENV).to receive(:key?).with("URL_PORT").and_return(false)
       allow(ENV).to receive(:fetch).and_call_original
       allow(ENV).to receive(:fetch).with("PORT", "3000").and_return("3000")
       expect(described_class.dev_port).to eq("3000")
     end
 
     it "returns the value of the PORT env var when set" do
+      allow(ENV).to receive(:key?).and_call_original
+      allow(ENV).to receive(:key?).with("URL_PORT").and_return(false)
       allow(ENV).to receive(:fetch).and_call_original
       allow(ENV).to receive(:fetch).with("PORT", "3000").and_return("3005")
       expect(described_class.dev_port).to eq("3005")
+    end
+
+    it "prefers URL_PORT over PORT when URL_PORT is set" do
+      allow(ENV).to receive(:key?).and_call_original
+      allow(ENV).to receive(:key?).with("URL_PORT").and_return(true)
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("URL_PORT").and_return("8443")
+      expect(described_class.dev_port).to eq("8443")
+    end
+
+    it "returns an empty string when URL_PORT is set but blank" do
+      allow(ENV).to receive(:key?).and_call_original
+      allow(ENV).to receive(:key?).with("URL_PORT").and_return(true)
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("URL_PORT").and_return("")
+      expect(described_class.dev_port).to eq("")
     end
   end
 
@@ -108,6 +128,11 @@ RSpec.describe URL, type: :lib do
         allow(described_class).to receive(:dev_port).and_return("3005")
         allow(Settings::General).to receive(:app_domain).and_return("localhost:3005")
         expect(described_class.url).to eq("https://localhost:3005")
+      end
+
+      it "omits the port entirely when dev_port is blank, for a TLS proxy in front of the app" do
+        allow(described_class).to receive(:dev_port).and_return("")
+        expect(described_class.url).to eq("https://localhost")
       end
     end
   end


### PR DESCRIPTION
## Summary

Adds `URL_PORT` as an override for the port `URL.dev_port` appends to development URLs. When a TLS reverse proxy (Caddy on `forem.mlh.test` in the local rig) fronts Forem on the standard port, set `URL_PORT=` (blank) and absolute URLs carry no port at all.

## Why

`dev_port` reads `PORT`, which is the port Puma listens on (3006 behind the proxy), so OmniAuth built the MLH callback as `https://forem.mlh.test:3006/users/auth/mlh/callback`. Doorkeeper on Core matches redirect URIs by exact string and answered 422, and following the URL directly fails TLS because nothing serves HTTPS on 3006. The workaround was registering the ported URI on Core's OAuth application, which every re-seed wipes.

## Change

- `URL.dev_port` returns `ENV["URL_PORT"]` when the variable is present (blank allowed), otherwise `PORT` as before.
- `URL.url` appends the port only when it is present.
- Specs: `URL_PORT` preferred over `PORT`, blank `URL_PORT` yields no port, and the URL omits the port when `dev_port` is blank. The two existing `PORT` examples now stub `URL_PORT` absent so a developer's own `.env` cannot fail them.

No behavior change when `URL_PORT` is unset.

https://claude.ai/code/session_01A1nNEEfcWXiwxD433Sva5t

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791420292&installation_model_id=424141&pr_number=23823&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23823&signature=089ea56d083fdc8a39b07e7e52b3724e8b6602480ee249744e18130028ca342b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->