### PR TITLE
Keep sending broadcasts to the Customer.io rollout cohort

### DIFF
--- a/app/mailers/concerns/deliverable.rb
+++ b/app/mailers/concerns/deliverable.rb
@@ -3,6 +3,20 @@ module Deliverable
 
   CUSTOMERIO_FLAG = :customerio_email_delivery
 
+  # Temporary rollout switch, expected to be removed at full cutover.
+  #
+  # While CUSTOMERIO_FLAG is only partially on, the guards that skip broadcast
+  # email for the enabled cohort (CustomMailer, Emails::BatchCustomSendWorker)
+  # assume Customer.io is already sending that broadcast from a campaign of its
+  # own. Until it is, those recipients get nothing at all. Enabling this flag
+  # keeps Forem authoring the broadcast and lets it go out over the Customer.io
+  # body-passthrough path instead, so the cohort is never silently skipped.
+  #
+  # Turn it off once Customer.io owns the campaign, and delete it -- along with
+  # the two guards it gates -- at full cutover, when customerio_email_cutover?
+  # stops every Forem-side broadcast anyway.
+  CUSTOMERIO_BROADCAST_PASSTHROUGH_FLAG = :customerio_broadcast_passthrough
+
   included do
     before_action :set_perform_deliveries
     after_action  :set_delivery_options

--- a/app/mailers/custom_mailer.rb
+++ b/app/mailers/custom_mailer.rb
@@ -26,7 +26,9 @@ class CustomMailer < ApplicationMailer
     # broadcast/newsletter/drip from the Customer.io side. Sending it from here
     # too would deliver it twice to exactly those people. Emails::BatchCustomSendWorker
     # skips them before we get here; this backstop also covers the drip worker,
-    # which builds its sends itself.
+    # which builds its sends itself. Until Customer.io actually owns the
+    # campaign, CUSTOMERIO_BROADCAST_PASSTHROUGH_FLAG turns this skip off so the
+    # cohort keeps receiving it over the Customer.io passthrough path.
     return if customerio_managed_recipient?
 
     @content = Email.replace_merge_tags(params[:content], @user)
@@ -57,6 +59,7 @@ class CustomMailer < ApplicationMailer
   # admins still need the preview while the flag is rolling out.
   def customerio_managed_recipient?
     return false unless ForemInstance.customerio_enabled?
+    return false if ForemInstance.customerio_broadcast_passthrough?
     return false if params[:subject].to_s.start_with?(Email::TEST_SUBJECT_PREFIX)
 
     FeatureFlag.enabled_for_user?(Deliverable::CUSTOMERIO_FLAG, @user)

--- a/app/models/forem_instance.rb
+++ b/app/models/forem_instance.rb
@@ -67,6 +67,15 @@ class ForemInstance
     customerio_enabled? && FeatureFlag.enabled?(Deliverable::CUSTOMERIO_FLAG)
   end
 
+  # Rollout-only: send broadcast email to the CUSTOMERIO_FLAG cohort over the
+  # Customer.io passthrough path rather than skipping them. See
+  # Deliverable::CUSTOMERIO_BROADCAST_PASSTHROUGH_FLAG. Never applies after full
+  # cutover -- customerio_email_cutover? returns before any of this is reached.
+  def self.customerio_broadcast_passthrough?
+    customerio_enabled? &&
+      FeatureFlag.enabled?(Deliverable::CUSTOMERIO_BROADCAST_PASSTHROUGH_FLAG)
+  end
+
   def self.sendgrid_enabled?
     ENV["SENDGRID_API_KEY"].present?
   end

--- a/app/workers/emails/batch_custom_send_worker.rb
+++ b/app/workers/emails/batch_custom_send_worker.rb
@@ -73,8 +73,13 @@ module Emails
     #
     # Test sends are exempt (see #perform): nothing on the Customer.io side
     # duplicates them, and admins still need the preview during the rollout.
+    #
+    # Until Customer.io actually owns the campaign there is nothing to duplicate
+    # either, and skipping would just drop the broadcast. CUSTOMERIO_BROADCAST_
+    # PASSTHROUGH_FLAG turns the skip off for that window.
     def customerio_managed_user_ids(users)
       return Set.new unless ForemInstance.customerio_enabled?
+      return Set.new if ForemInstance.customerio_broadcast_passthrough?
 
       users.each_with_object(Set.new) do |user, ids|
         ids << user.id if FeatureFlag.enabled_for_user?(Deliverable::CUSTOMERIO_FLAG, user)

--- a/spec/mailers/custom_mailer_spec.rb
+++ b/spec/mailers/custom_mailer_spec.rb
@@ -204,6 +204,53 @@ RSpec.describe CustomMailer, type: :mailer do
       end
     end
 
+    # Rollout window: nothing on the Customer.io side duplicates the broadcast
+    # yet, so the backstop stands down and the send goes out over the
+    # Customer.io body-passthrough path.
+    context "when the broadcast passthrough flag is enabled" do
+      let(:email) { create(:email, type_of: "newsletter") }
+      let(:broadcast_subject) { "Test Email Subject for *|name|*" }
+      let(:api_client) { instance_double(Customerio::APIClient, send_email: { "delivery_id" => "dev-123" }) }
+
+      before do
+        allow(ForemInstance).to receive_messages(
+          smtp_enabled?: true,
+          customerio_enabled?: true,
+          customerio_broadcast_passthrough?: true,
+        )
+        allow(FeatureFlag).to receive(:enabled_for_user?)
+          .with(Deliverable::CUSTOMERIO_FLAG, having_attributes(id: user.id)).and_return(true)
+        stub_const("CUSTOMERIO_API", api_client)
+      end
+
+      it "sends the broadcast through Customer.io rather than dropping it" do
+        described_class.with(
+          user: user, content: content, subject: broadcast_subject, email_id: email.id,
+        ).custom_email.deliver_now
+
+        expect(api_client).to have_received(:send_email)
+      end
+
+      it "records an ahoy message so the send is not invisible" do
+        expect do
+          described_class.with(
+            user: user, content: content, subject: broadcast_subject, email_id: email.id,
+          ).custom_email.deliver_now
+        end.to change(EmailMessage, :count).by(1)
+      end
+
+      it "sends a body passthrough, not a transactional template" do
+        described_class.with(
+          user: user, content: content, subject: broadcast_subject, email_id: email.id,
+        ).custom_email.deliver_now
+
+        expect(api_client).to have_received(:send_email) do |request|
+          expect(request.message[:transactional_message_id]).to be_nil
+          expect(request.message[:body]).to include(content.sub("*|name|*", user.name))
+        end
+      end
+    end
+
     context "when SendGrid is disabled" do
       before do
         allow(ForemInstance).to receive(:sendgrid_enabled?).and_return(false)

--- a/spec/models/forem_instance_spec.rb
+++ b/spec/models/forem_instance_spec.rb
@@ -162,6 +162,33 @@ RSpec.describe ForemInstance do
     end
   end
 
+  describe ".customerio_broadcast_passthrough?" do
+    after { FeatureFlag.remove(Deliverable::CUSTOMERIO_BROADCAST_PASSTHROUGH_FLAG) }
+
+    it "is true when CUSTOMERIO_APP_KEY is present and the passthrough flag is enabled" do
+      allow(ApplicationConfig).to receive(:[]).and_call_original
+      allow(ApplicationConfig).to receive(:[]).with("CUSTOMERIO_APP_KEY").and_return("app-key")
+      FeatureFlag.enable(Deliverable::CUSTOMERIO_BROADCAST_PASSTHROUGH_FLAG)
+
+      expect(described_class.customerio_broadcast_passthrough?).to be(true)
+    end
+
+    it "is false when the passthrough flag has never been enabled" do
+      allow(ApplicationConfig).to receive(:[]).and_call_original
+      allow(ApplicationConfig).to receive(:[]).with("CUSTOMERIO_APP_KEY").and_return("app-key")
+
+      expect(described_class.customerio_broadcast_passthrough?).to be(false)
+    end
+
+    it "is false when CUSTOMERIO_APP_KEY is absent even if the flag is enabled" do
+      allow(ApplicationConfig).to receive(:[]).and_call_original
+      allow(ApplicationConfig).to receive(:[]).with("CUSTOMERIO_APP_KEY").and_return(nil)
+      FeatureFlag.enable(Deliverable::CUSTOMERIO_BROADCAST_PASSTHROUGH_FLAG)
+
+      expect(described_class.customerio_broadcast_passthrough?).to be(false)
+    end
+  end
+
   describe ".contact_email" do
     let(:email) { "contact@dev.to" }
 

--- a/spec/workers/emails/batch_custom_send_worker_spec.rb
+++ b/spec/workers/emails/batch_custom_send_worker_spec.rb
@@ -54,6 +54,30 @@ RSpec.describe Emails::BatchCustomSendWorker, type: :worker do
       end
     end
 
+    # Rollout window: Customer.io does not own the campaign yet, so skipping the
+    # cohort would drop the broadcast rather than avoid a duplicate.
+    context "when the broadcast passthrough flag is enabled" do
+      before do
+        allow(ForemInstance).to receive_messages(
+          customerio_enabled?: true, customerio_broadcast_passthrough?: true,
+        )
+        allow(FeatureFlag).to receive(:enabled_for_user?)
+          .with(Deliverable::CUSTOMERIO_FLAG, anything).and_return(true)
+      end
+
+      it "sends to flag-enabled recipients instead of skipping them" do
+        worker.perform(user_ids, subject_line, content, type_of, email_id)
+
+        expect(CustomMailer).to have_received(:with).twice
+      end
+
+      it "does not consult the delivery flag at all" do
+        worker.perform(user_ids, subject_line, content, type_of, email_id)
+
+        expect(FeatureFlag).not_to have_received(:enabled_for_user?)
+      end
+    end
+
     context "when Customer.io is not configured" do
       before { allow(ForemInstance).to receive(:customerio_enabled?).and_return(false) }
 


### PR DESCRIPTION
## Problem

#23774 made `CustomMailer` and `Emails::BatchCustomSendWorker` skip any recipient with `:customerio_email_delivery` enabled, so Forem does not double-send a broadcast that Customer.io is also sending. That reasoning holds only once a Customer.io campaign actually targets the cohort.

Until one does, those recipients are not spared a duplicate — they get **nothing**. `CustomMailer#custom_email` returns before `mail()`, which yields a `NullMail`, so no broadcast, newsletter or onboarding drip goes out and no `ahoy_messages` row records the omission. The failure is silent and asymmetric: a double-send generates complaints, a gap generates nothing.

This is live on production now — `:customerio_email_delivery` is at `percentage_of_actors = 10`, which measures at 9.87% of real user ids.

## Change

Add `:customerio_broadcast_passthrough`, declared as `Deliverable::CUSTOMERIO_BROADCAST_PASSTHROUGH_FLAG` and read through a new `ForemInstance.customerio_broadcast_passthrough?`. When on, it stands down both skips:

- `CustomMailer#customerio_managed_recipient?` — the per-recipient backstop that also covers `Emails::DripEmailWorker`
- `Emails::BatchCustomSendWorker#customerio_managed_user_ids` — the batch-level filter

Broadcasts then reach `mail()`, and `Deliverable#set_delivery_options` routes flagged recipients to `DeliveryMethods::CustomerIo`. With no `transactional_message_id`, that sends `body` and `from` directly — a body passthrough, the same path `[TEST]` sends already take today.

Click tracking needs no extra work: `AhoyEmail::Processor#track_links` rewrites links in the rendered HTML body during the mailer's `after_action`, and `build_body` reads that body at `deliver!` time. `Emails::AhoyLinkDecorator` exists only because the *templated* path discards the body and re-renders from `message_data`; passthrough keeps the body, so there is nothing to re-apply.

## Lifecycle

The flag defaults off, so merging and deploying changes no behavior.

| Phase | `customerio_email_delivery` | `customerio_broadcast_passthrough` | Cohort behavior |
|---|---|---|---|
| Today | 10% of actors | off | dropped (the gap) |
| Rollout | 10% of actors | **on** | sent via Customer.io passthrough |
| CIO campaign live | 10% of actors | off | dropped, CIO owns it |
| Full cutover | globally on | — | dropped everywhere, CIO owns it |

Explicitly temporary. At full cutover `ForemInstance.customerio_email_cutover?` already halts every Forem-side broadcast, so this flag and the two guards it gates should be deleted together. Both the constant and the predicate say so in comments.

## Testing

- `ForemInstance.customerio_broadcast_passthrough?` — flag on, never-enabled, and `CUSTOMERIO_APP_KEY` absent
- `CustomMailer` — sends through Customer.io rather than dropping; records an ahoy message; sends a body passthrough rather than a transactional template (asserts `transactional_message_id` is nil and the rendered content is in `body`)
- `Emails::BatchCustomSendWorker` — sends to flag-enabled recipients instead of skipping; does not consult the delivery flag at all

Reverting the two source lines fails all five new examples. 70 examples pass across the three files; no new RuboCop offenses against the `main` baseline.

https://claude.ai/code/session_01EGudt3atxAuushV7vjMwZG

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forem/codesmith/forem/pr/23825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791567652&installation_model_id=424141&pr_number=23825&repository=forem%2Fforem&return_to=https%3A%2F%2Fgithub.com%2Fforem%2Fforem%2Fpull%2F23825&signature=05ba30512715da5e979e6788103014f6495d0309dc13a023ac3b79a59e908a93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->